### PR TITLE
SRSAuto.SERVER_SRS_HOST variable missing

### DIFF
--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -6,6 +6,7 @@
 
 -- User options --
 local SRSAuto = {}
+SRSAuto.SERVER_SRS_HOST = "127.0.0.1"
 SRSAuto.SERVER_SEND_AUTO_CONNECT = true -- set to false to disable auto connect or just remove this file
 
 -- DO NOT EDIT BELOW HERE --


### PR DESCRIPTION
The variable was missing. If intentional it doesn't correlate with comment and readme.txt