### PR TITLE
Change audio output devices to use "FriendlyName"

### DIFF
--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -379,7 +379,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                
                 Speakers.Items.Add(new AudioDeviceListItem()
                 {
-                    Text = device.DeviceFriendlyName,
+                    Text = device.FriendlyName,
                     Value = device
                 });
 


### PR DESCRIPTION
Currently, my output devices show up like this:

![image](https://user-images.githubusercontent.com/787828/36046338-753d8366-0dd0-11e8-8581-981966a03e34.png)

With "High Definition Audio Device" showing up 3 times. By changing `device.DeviceFriendlyName` to `device.FriendlyName`, it looks like this:

![image](https://user-images.githubusercontent.com/787828/36046384-a0dc8d64-0dd0-11e8-8276-e4ca60c6773d.png)

Which allows the disambiguation of the device being selected.