### PR TITLE
Implemented minimise to tray & minimised startup

### DIFF
--- a/DCS-SR-Client/Properties/Resources.Designer.cs
+++ b/DCS-SR-Client/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -66,6 +66,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Properties {
         internal static System.IO.UnmanagedMemoryStream ARC_164_Rx_End_16_1600 {
             get {
                 return ResourceManager.GetStream("ARC_164_Rx_End_16_1600", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
+        /// </summary>
+        internal static System.Drawing.Icon audio_headset {
+            get {
+                object obj = ResourceManager.GetObject("audio_headset", resourceCulture);
+                return ((System.Drawing.Icon)(obj));
             }
         }
         

--- a/DCS-SR-Client/Properties/Resources.resx
+++ b/DCS-SR-Client/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARC_164_Rx_End_16_1600" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\ARC-164_Rx_End_16_1600.wav;System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="audio_headset" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\audio-headset.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="KY_58_RX_PREAMBLE_SHORT_16_1600" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\KY-58 RX PREAMBLE SHORT 16 1600.wav;System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/DCS-SR-Client/Settings/SettingsStore.cs
+++ b/DCS-SR-Client/Settings/SettingsStore.cs
@@ -35,6 +35,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         RadioEffectsClipping = 21,
 
+        MinimiseToTray = 22,
+        StartMinimised = 23,
+
         RadioRxEffects_Start = 40, // Recieving Radio Effects 
         RadioRxEffects_End = 41,
         RadioTxEffects_Start = 42, // Recieving Radio Effects 
@@ -233,6 +236,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             {SettingsKeys.RadioOverlayTaskbarHide.ToString(), "false"},
             {SettingsKeys.RefocusDCS.ToString(), "false"},
             {SettingsKeys.ExpandControls.ToString(), "false"},
+
+            {SettingsKeys.MinimiseToTray.ToString(), "true"},
+            {SettingsKeys.StartMinimised.ToString(), "false"},
 
             {SettingsKeys.RadioRxEffects_Start.ToString(), "true"},
             {SettingsKeys.RadioRxEffects_End.ToString(), "true"},

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -498,6 +498,7 @@
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <WrapPanel />
 
@@ -956,6 +957,60 @@
                                       HorizontalContentAlignment="Center"
                                       VerticalContentAlignment="Center"
                                       Click="AudioSelectChannel_OnClick">
+                            <ToggleButton.Style>
+                                <Style TargetType="{x:Type ToggleButton}">
+                                    <Setter Property="Content" Value="ON" />
+                                    <Style.Triggers>
+                                        <Trigger Property="IsChecked" Value="True">
+                                            <Setter Property="Content" Value="ON" />
+                                        </Trigger>
+                                        <Trigger Property="IsChecked" Value="False">
+                                            <Setter Property="Content" Value="OFF" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ToggleButton.Style>
+                        </ToggleButton>
+
+                        <Label Grid.Row="23"
+                               Grid.Column="0"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="Minimise to tray" />
+
+                        <ToggleButton Name="MinimiseToTray"
+                                      Grid.Row="23"
+                                      Grid.Column="1"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center"
+                                      Click="MinimiseToTray_OnClick">
+                            <ToggleButton.Style>
+                                <Style TargetType="{x:Type ToggleButton}">
+                                    <Setter Property="Content" Value="ON" />
+                                    <Style.Triggers>
+                                        <Trigger Property="IsChecked" Value="True">
+                                            <Setter Property="Content" Value="ON" />
+                                        </Trigger>
+                                        <Trigger Property="IsChecked" Value="False">
+                                            <Setter Property="Content" Value="OFF" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ToggleButton.Style>
+                        </ToggleButton>
+
+                        <Label Grid.Row="24"
+                               Grid.Column="0"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="Start minimised" />
+
+                        <ToggleButton Name="StartMinimised"
+                                      Grid.Row="24"
+                                      Grid.Column="1"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center"
+                                      Click="StartMinimised_OnClick">
                             <ToggleButton.Style>
                                 <Style TargetType="{x:Type ToggleButton}">
                                     <Setter Property="Content" Value="ON" />

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -90,12 +90,24 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             this.Left = _settings.GetPositionSetting(SettingsKeys.ClientX).FloatValue;
             this.Top = _settings.GetPositionSetting(SettingsKeys.ClientY).FloatValue;
 
+            // Notification/tray bar icon is initialised as soon as possible so it is visible immediately if the "StartMinimised" setting is enabled
+            InitNotificationIcon();
 
             SetupLogging();
 
             Title = Title + " - " + UpdaterChecker.VERSION;
 
-            Logger.Info("Started DCS-SimpleRadio Client " + UpdaterChecker.VERSION);
+            if (_settings.GetClientSetting(SettingsKeys.StartMinimised).BoolValue)
+            {
+                Hide();
+                WindowState = WindowState.Minimized;
+
+                Logger.Info("Started DCS-SimpleRadio Client " + UpdaterChecker.VERSION + " minimized");
+            }
+            else
+            {
+                Logger.Info("Started DCS-SimpleRadio Client " + UpdaterChecker.VERSION);
+            }
 
             _guid = _settings.GetClientSetting(SettingsKeys.CliendIdShort).StringValue;
 
@@ -480,9 +492,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 _settings.GetClientSetting(SettingsKeys.ExpandControls).BoolValue;
             RadioTxStartToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioTxEffects_Start).BoolValue;
             RadioTxEndToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioTxEffects_End).BoolValue;
-            ;
+            
             RadioRxStartToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioRxEffects_Start).BoolValue;
             RadioRxEndToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioRxEffects_Start).BoolValue;
+
+            MinimiseToTray.IsChecked = _settings.GetClientSetting(SettingsKeys.MinimiseToTray).BoolValue;
+            StartMinimised.IsChecked = _settings.GetClientSetting(SettingsKeys.StartMinimised).BoolValue;
 
             RadioSoundEffects.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioEffects).BoolValue;
             RadioSoundEffectsClipping.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioEffectsClipping).BoolValue;
@@ -517,6 +532,34 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             // Step 5. Activate the configuration
             LogManager.Configuration = config;
+        }
+
+        private void InitNotificationIcon()
+        {
+            System.Windows.Forms.MenuItem notifyIconContextMenuShow = new System.Windows.Forms.MenuItem
+            {
+                Index = 0,
+                Text = "Show"
+            };
+            notifyIconContextMenuShow.Click += new EventHandler(NotifyIcon_Show);
+
+            System.Windows.Forms.MenuItem notifyIconContextMenuQuit = new System.Windows.Forms.MenuItem
+            {
+                Index = 1,
+                Text = "Quit"
+            };
+            notifyIconContextMenuQuit.Click += new EventHandler(NotifyIcon_Quit);
+
+            System.Windows.Forms.ContextMenu notifyIconContextMenu = new System.Windows.Forms.ContextMenu();
+            notifyIconContextMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] { notifyIconContextMenuShow, notifyIconContextMenuQuit });
+
+            System.Windows.Forms.NotifyIcon notifyIcon = new System.Windows.Forms.NotifyIcon
+            {
+                Icon = Properties.Resources.audio_headset,
+                Visible = true
+            };
+            notifyIcon.ContextMenu = notifyIconContextMenu;
+            notifyIcon.DoubleClick += new EventHandler(NotifyIcon_Show);
         }
 
         private void Connect()
@@ -715,6 +758,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _dcsAutoConnectListener = null;
         }
 
+        protected override void OnStateChanged(EventArgs e)
+        {
+            if (WindowState == WindowState.Minimized && _settings.GetClientSetting(SettingsKeys.MinimiseToTray).BoolValue)
+            {
+                Hide();
+            }
+
+            base.OnStateChanged(e);
+        }
+
         private void PreviewAudio(object sender, RoutedEventArgs e)
         {
             if (_audioPreview == null)
@@ -746,6 +799,17 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 _audioPreview.StopEncoding();
                 _audioPreview = null;
             }
+        }
+
+        private void NotifyIcon_Show(object sender, EventArgs args)
+        {
+            Show();
+            WindowState = WindowState.Normal;
+        }
+
+        private void NotifyIcon_Quit(object sender, EventArgs args)
+        {
+            Close();
         }
 
         private void SpeakerBoost_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
@@ -996,6 +1060,20 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 (bool)RadioSoundEffectsClipping.IsChecked;
             _settings.Save();
 
+        }
+
+        private void MinimiseToTray_OnClick(object sender, RoutedEventArgs e)
+        {
+            _settings.GetClientSetting(SettingsKeys.MinimiseToTray).BoolValue =
+                (bool)MinimiseToTray.IsChecked;
+            _settings.Save();
+        }
+
+        private void StartMinimised_OnClick(object sender, RoutedEventArgs e)
+        {
+            _settings.GetClientSetting(SettingsKeys.StartMinimised).BoolValue =
+                (bool)StartMinimised.IsChecked;
+            _settings.Save();
         }
     }
 }


### PR DESCRIPTION
NotifyIcon currently uses an embedded version of the "audio-headset" icon, including a simple double-click/context-menu integration

"Minimise to tray" setting is enabled by default, "Start minimised" disabled

Closes #189 