### PR TITLE
Allow SRS to be used without a mic

### DIFF
--- a/DCS-SR-Client/Network/DCSAutoConnectListener.cs
+++ b/DCS-SR-Client/Network/DCSAutoConnectListener.cs
@@ -45,15 +45,23 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 {
                     while (!_stop)
                     {
-                        var groupEp = new IPEndPoint(IPAddress.Any, 5069);
-                        var bytes = _dcsUdpListener.Receive(ref groupEp);
-
                         try
                         {
+                            var groupEp = new IPEndPoint(IPAddress.Any, 5069);
+                            var bytes = _dcsUdpListener.Receive(ref groupEp);
+
                             var message = Encoding.UTF8.GetString(
                                 bytes, 0, bytes.Length);
 
                             HandleMessage(message);
+                        }
+                        catch (SocketException e)
+                        {
+                            // SocketException is raised when closing app/disconnecting, ignore so we don't log "irrelevant" exceptions
+                            if (!_stop)
+                            {
+                                Logger.Error(e, "SocketException Handling DCS AutoConnect Message");
+                            }
                         }
                         catch (Exception e)
                         {

--- a/DCS-SR-Client/Network/RadioDCSSyncServer.cs
+++ b/DCS-SR-Client/Network/RadioDCSSyncServer.cs
@@ -93,12 +93,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 {
                     while (!_stop)
                     {
-                        var groupEp = new IPEndPoint(IPAddress.Any,
-                            _settings.GetNetworkSetting(SettingsKeys.CommandListenerUDP));
-                        var bytes = _udpCommandListener.Receive(ref groupEp);
-
                         try
                         {
+                            var groupEp = new IPEndPoint(IPAddress.Any,
+                            _settings.GetNetworkSetting(SettingsKeys.CommandListenerUDP));
+                            var bytes = _udpCommandListener.Receive(ref groupEp);
+
                             //Logger.Info("Recevied Message from UDP COMMAND INTERFACE: "+ Encoding.UTF8.GetString(
                             //          bytes, 0, bytes.Length));
                             var message =
@@ -128,6 +128,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             else
                             {
                                 Logger.Error("Unknown UDP Command!");
+                            }
+                        }
+                        catch (SocketException e)
+                        {
+                            // SocketException is raised when closing app/disconnecting, ignore so we don't log "irrelevant" exceptions
+                            if (!_stop)
+                            {
+                                Logger.Error(e, "SocketException Handling DCS  Message");
                             }
                         }
                         catch (Exception e)
@@ -170,12 +178,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 {
                     while (!_stop)
                     {
-                        var groupEp = new IPEndPoint(IPAddress.Any,
-                            _settings.GetNetworkSetting(SettingsKeys.DCSIncomingUDP));
-                        var bytes = _dcsUdpListener.Receive(ref groupEp);
-
                         try
                         {
+                            var groupEp = new IPEndPoint(IPAddress.Any,
+                            _settings.GetNetworkSetting(SettingsKeys.DCSIncomingUDP));
+                            var bytes = _dcsUdpListener.Receive(ref groupEp);
+
                             var message =
                                 JsonConvert.DeserializeObject<DCSPlayerRadioInfo>(Encoding.UTF8.GetString(
                                     bytes, 0, bytes.Length));
@@ -195,6 +203,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             {
                                 LastSent = Environment.TickCount;
                                 _clientRadioUpdate();
+                            }
+                        }
+                        catch (SocketException e)
+                        {
+                            // SocketException is raised when closing app/disconnecting, ignore so we don't log "irrelevant" exceptions
+                            if (!_stop)
+                            {
+                                Logger.Error(e, "SocketException Handling DCS AutoConnect Message");
                             }
                         }
                         catch (Exception e)
@@ -286,12 +302,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     //    var count = 0;
                     while (!_stop)
                     {
-                        var groupEp = new IPEndPoint(IPAddress.Any,
-                            _settings.GetNetworkSetting(SettingsKeys.DCSIncomingGameGUIUDP));
-                        var bytes = _dcsGameGuiudpListener.Receive(ref groupEp);
-
                         try
                         {
+                            var groupEp = new IPEndPoint(IPAddress.Any,
+                            _settings.GetNetworkSetting(SettingsKeys.DCSIncomingGameGUIUDP));
+                            var bytes = _dcsGameGuiudpListener.Receive(ref groupEp);
+
                             var playerInfo =
                                 JsonConvert.DeserializeObject<DCSPlayerSideInfo>(Encoding.UTF8.GetString(
                                     bytes, 0, bytes.Length));
@@ -304,6 +320,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                 _clientStateSingleton.DcsPlayerSideInfo = playerInfo;
                                 _clientSideUpdate();
                                 //     count = 0;
+                            }
+                        }
+                        catch (SocketException e)
+                        {
+                            // SocketException is raised when closing app/disconnecting, ignore so we don't log "irrelevant" exceptions
+                            if (!_stop)
+                            {
+                                Logger.Error(e, "SocketException Handling DCS GameGUI Message");
                             }
                         }
                         catch (Exception e)
@@ -342,12 +366,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     //    var count = 0;
                     while (!_stop)
                     {
-                        var groupEp = new IPEndPoint(IPAddress.Any,
-                            _settings.GetNetworkSetting(SettingsKeys.DCSLOSIncomingUDP));
-                        var bytes = _dcsLOSListener.Receive(ref groupEp);
-
                         try
                         {
+                            var groupEp = new IPEndPoint(IPAddress.Any,
+                            _settings.GetNetworkSetting(SettingsKeys.DCSLOSIncomingUDP));
+                            var bytes = _dcsLOSListener.Receive(ref groupEp);
+
                             /*   Logger.Debug(Encoding.UTF8.GetString(
                                     bytes, 0, bytes.Length));*/
                             var playerInfo =
@@ -364,6 +388,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                                     //  Logger.Debug(client.ToString());
                                 }
+                            }
+                        }
+                        catch (SocketException e)
+                        {
+                            // SocketException is raised when closing app/disconnecting, ignore so we don't log "irrelevant" exceptions
+                            if (!_stop)
+                            {
+                                Logger.Error(e, "SocketException Handling DCS Los Result Message");
                             }
                         }
                         catch (Exception e)

--- a/DCS-SR-Client/Network/TCPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/TCPVoiceHandler.cs
@@ -544,13 +544,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         public bool Send(byte[] bytes, int len)
         {
-            //if either PTT is true && socket connected etc
-            if (_ready &&
-                _listener != null
+            //if either PTT is true, a microphone is available && socket connected etc
+            if (_ready
+                && _listener != null
                 && _listener.Connected
-                &&
-                (_ptt || _clientStateSingleton.DcsPlayerRadioInfo.ptt)
-                && _clientStateSingleton.DcsPlayerRadioInfo.IsCurrent() && (bytes != null))
+                && (_ptt || _clientStateSingleton.DcsPlayerRadioInfo.ptt)
+                && _clientStateSingleton.DcsPlayerRadioInfo.IsCurrent()
+                && _clientStateSingleton.MicrophoneAvailable
+                && (bytes != null))
                 //can only send if DCS is connected
             {
                 try

--- a/DCS-SR-Client/Singletons/ClientStateSingleton.cs
+++ b/DCS-SR-Client/Singletons/ClientStateSingleton.cs
@@ -24,6 +24,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         //store radio channels here?
         public PresetChannelsViewModel[] FixedChannels { get; }
 
+        // Indicates whether a valid microphone is available - deactivating audio input controls and transmissions otherwise
+        public bool MicrophoneAvailable { get; set; }
 
         private ClientStateSingleton()
         {
@@ -36,6 +38,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 FixedChannels[i] = new PresetChannelsViewModel(new FilePresetChannelsStore(), i + 1);
             }
+
+            MicrophoneAvailable = true;
         }
 
         public static ClientStateSingleton Instance

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -51,7 +51,8 @@
                             VerticalAlignment="Top"
                             Click="PreviewAudio"
                             Content="Preview Audio"
-                            Style="{DynamicResource SquareButtonStyle}" />
+                            Style="{DynamicResource SquareButtonStyle}"
+                            ToolTipService.ShowOnDisabled="True" />
 
 
                     <Label x:Name="SpeakerLabel"

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -75,6 +75,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private readonly DelegateCommand _connectCommand;
 
         private readonly Settings.SettingsStore _settings = Settings.SettingsStore.Instance;
+        private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
 
         public MainWindow()
         {
@@ -354,6 +355,52 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 }
             }
 
+            // No microphone is available - users can still connect/listen, but audio input controls are disabled and sending is prevented
+            if (WaveIn.DeviceCount == 0 || Mic.SelectedIndex < 0)
+            {
+                Logger.Info("Audio Input - No audio input devices available, disabling mic preview");
+
+                _clientStateSingleton.MicrophoneAvailable = false;
+
+                var noMicAvailableToolTip = new System.Windows.Controls.ToolTip();
+                var noMicAvailableToolTipContent = new System.Windows.Controls.StackPanel();
+
+                noMicAvailableToolTipContent.Children.Add(new System.Windows.Controls.TextBlock
+                {
+                    Text = "No microphone available",
+                    FontWeight = FontWeights.Bold
+                });
+                noMicAvailableToolTipContent.Children.Add(new System.Windows.Controls.TextBlock
+                {
+                    Text = "No valid microphone is available - others will not be able to hear you."
+                });
+                noMicAvailableToolTipContent.Children.Add(new System.Windows.Controls.TextBlock
+                {
+                    Text = "You can still use SRS to listen to radio calls, but will not be able to transmit anything yourself."
+                });
+
+                noMicAvailableToolTip.Content = noMicAvailableToolTipContent;
+
+                Preview.IsEnabled = false;
+
+                Preview.ToolTip = noMicAvailableToolTip;
+                StartStop.ToolTip = noMicAvailableToolTip;
+                Mic.ToolTip = noMicAvailableToolTip;
+                Mic_VU.ToolTip = noMicAvailableToolTip;
+            }
+            else
+            {
+                Logger.Info("Audio Input - " + WaveIn.DeviceCount + " audio input devices available, configuring as usual");
+
+                _clientStateSingleton.MicrophoneAvailable = true;
+
+                Preview.IsEnabled = true;
+
+                Preview.ToolTip = null;
+                StartStop.ToolTip = null;
+                Mic.ToolTip = null;
+                Mic_VU.ToolTip = null;
+            }
         }
 
         private void InitAudioOutput()
@@ -436,12 +483,20 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             if (_audioPreview != null)
             {
-                Mic_VU.Value = _audioPreview.MicMax;
+                // Only update mic volume output if an audio input device is available - sometimes the value can still change, leaving the user with the impression their mic is working after all
+                if (_clientStateSingleton.MicrophoneAvailable)
+                {
+                    Mic_VU.Value = _audioPreview.MicMax;
+                }
                 Speaker_VU.Value = _audioPreview.SpeakerMax;
             }
             else if (_audioManager != null)
             {
-                Mic_VU.Value = _audioManager.MicMax;
+                // Only update mic volume output if an audio input device is available - sometimes the value can still change, leaving the user with the impression their mic is working after all
+                if (_clientStateSingleton.MicrophoneAvailable)
+                {
+                    Mic_VU.Value = _audioManager.MicMax;
+                }
                 Speaker_VU.Value = _audioManager.SpeakerMax;
             }
             else
@@ -610,7 +665,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
           
             //save app settings
-            _settings.SetClientSetting(SettingsKeys.AudioInputDeviceId, ((WaveInCapabilities)((AudioDeviceListItem)Mic.SelectedItem).Value).ProductName);
+            // Only save selected microphone if one is actually available, resulting in a crash otherwise
+            if (_clientStateSingleton.MicrophoneAvailable)
+            {
+                _settings.SetClientSetting(SettingsKeys.AudioInputDeviceId, ((WaveInCapabilities)((AudioDeviceListItem)Mic.SelectedItem).Value).ProductName);
+            }
 
             _settings.SetClientSetting(SettingsKeys.AudioOutputDeviceId, output.ID);
 
@@ -706,6 +765,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         {
             if (_audioPreview == null)
             {
+                if (!_clientStateSingleton.MicrophoneAvailable)
+                {
+                    Logger.Info("Unable to preview audio, no valid audio input device available or selected");
+                    return;
+                }
+
                 //get device
                 try
                 {


### PR DESCRIPTION
SRS can now be used without crashes when no valid microphone is available.
Some audio input controls as well as the audio preview get disabled, transmissions are also "blocked" so the radio overlays don't show the client as transmitting to prevent confusion.
ToolTips placed over relevant controls in the SRS main window inform the user about no mic being available, but them still being able to listen to calls.

Closes #228 