### PR TITLE
Changed Environment.TickCount to DateTime.Ticks to avoid Win10 FastBoot issues

### DIFF
--- a/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
+++ b/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
@@ -76,8 +76,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
                 }
             }
 
-            long now = Environment.TickCount;
-            if ((now - LastUpdate) > 400) //400 ms since last update
+            long now = DateTime.Now.Ticks;
+            if ((now - LastUpdate) > 4000000) //400 ms since last update
             {
                 // System.Diagnostics.Debug.WriteLine(audio.ClientGuid+"ADDED");
                 //append ms of silence - this functions as our jitter buffer??

--- a/DCS-SR-Client/Network/ClientSync.cs
+++ b/DCS-SR-Client/Network/ClientSync.cs
@@ -175,7 +175,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                             var updatedSrClient = serverMessage.Client;
                                             if (srClient != null)
                                             {
-                                                srClient.LastUpdate = Environment.TickCount;
+                                                srClient.LastUpdate = DateTime.Now.Ticks;
                                                 srClient.Name = updatedSrClient.Name;
                                                 srClient.Coalition = updatedSrClient.Coalition;
                                                 srClient.Position = updatedSrClient.Position;
@@ -188,7 +188,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         else
                                         {
                                             var connectedClient = serverMessage.Client;
-                                            connectedClient.LastUpdate = Environment.TickCount;
+                                            connectedClient.LastUpdate = DateTime.Now.Ticks;
 
                                             //init with LOS true so you can hear them incase of bad DCS install where
                                             //LOS isnt working
@@ -231,7 +231,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         {
                                             foreach (var client in serverMessage.Clients)
                                             {
-                                                client.LastUpdate = Environment.TickCount;
+                                                client.LastUpdate = DateTime.Now.Ticks;
                                                 //init with LOS true so you can hear them incase of bad DCS install where
                                                 //LOS isnt working
                                                 client.LineOfSightLoss = 0.0f;

--- a/DCS-SR-Client/Network/Models/RadioSendingState.cs
+++ b/DCS-SR-Client/Network/Models/RadioSendingState.cs
@@ -5,7 +5,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
     public class RadioSendingState
     {
         [JsonIgnore]
-        public double LastSentAt { get; set; }
+        public long LastSentAt { get; set; }
 
         public bool IsSending { get; set; }
 

--- a/DCS-SR-Client/Network/RadioDCSSyncServer.cs
+++ b/DCS-SR-Client/Network/RadioDCSSyncServer.cs
@@ -207,7 +207,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             if (update || IsRadioInfoStale(message))
                             {
                                 Logger.Debug("Sending Radio Info To Server - Stale");
-                                _clientStateSingleton.LastSent = Environment.TickCount;
+                                _clientStateSingleton.LastSent = DateTime.Now.Ticks;
                                 _clientRadioUpdate();
                             }
                         }
@@ -717,20 +717,20 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             //            }
 
             //update
-            playerRadioInfo.LastUpdate = Environment.TickCount;
+            playerRadioInfo.LastUpdate = DateTime.Now.Ticks;
 
             return changed;
         }
 
         private bool IsRadioInfoStale(DCSPlayerRadioInfo radioUpdate)
         {
-            //send update if our metadata is nearly stale
-            if (Environment.TickCount - _clientStateSingleton.LastSent < 5000)
+            //send update if our metadata is nearly stale (1 tick = 100ns, 50000000 ticks = 5s stale timer)
+            if (DateTime.Now.Ticks - _clientStateSingleton.LastSent < 50000000)
             {
-                Logger.Debug($"Not Stale - Tick: {Environment.TickCount} Last sent: {_clientStateSingleton.LastSent} ");
+                Logger.Debug($"Not Stale - Tick: {DateTime.Now.Ticks} Last sent: {_clientStateSingleton.LastSent} ");
                 return false;
             }
-            Logger.Debug($"Stale Radio - Tick: {Environment.TickCount} Last sent: {_clientStateSingleton.LastSent} ");
+            Logger.Debug($"Stale Radio - Tick: {DateTime.Now.Ticks} Last sent: {_clientStateSingleton.LastSent} ");
             return true;
         }
 

--- a/DCS-SR-Client/Network/TCPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/TCPVoiceHandler.cs
@@ -434,7 +434,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         RadioReceivingState[audio.ReceivedRadio] = new RadioReceivingState
                                         {
                                             IsSecondary = receivingState.IsSecondary,
-                                            LastReceviedAt = Environment.TickCount,
+                                            LastReceviedAt = DateTime.Now.Ticks,
                                             PlayedEndOfTransmission = false,
                                             ReceivedOn = receivingState.ReceivedOn
                                         };
@@ -594,7 +594,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             RadioSendingState = new RadioSendingState
                             {
                                 IsSending = true,
-                                LastSentAt = Environment.TickCount,
+                                LastSentAt = DateTime.Now.Ticks,
                                 SendingOn = currentSelected
                             };
                             return true;

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private bool _stop = true;
 
         //used to debounce toggle
-        private double _toggleShowHide;
+        private long _toggleShowHide;
 
         private readonly DispatcherTimer _updateTimer;
         private MMDeviceCollection outputDeviceList;
@@ -896,10 +896,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void ToggleOverlay(bool uiButton)
         {
-            //debounce show hide
-            if ((Environment.TickCount - _toggleShowHide > 600) || uiButton)
+            //debounce show hide (1 tick = 100ns, 6000000 ticks = 600ms debounce)
+            if ((DateTime.Now.Ticks - _toggleShowHide > 6000000) || uiButton)
             {
-                _toggleShowHide = Environment.TickCount;
+                _toggleShowHide = DateTime.Now.Ticks;
                 if ((_radioOverlayWindow == null) || !_radioOverlayWindow.IsVisible ||
                     (_radioOverlayWindow.WindowState == WindowState.Minimized))
                 {

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
@@ -124,7 +124,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
             FocusDCS();
         }
 
-        private int _lastFocus;
+        private long _lastFocus;
 
         private void FocusDCS()
         {
@@ -143,9 +143,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
                     if (foreGround == localByName[0].MainWindowHandle || overlayWindow != foreGround ||
                         this.IsMouseOver)
                     {
-                        _lastFocus = Environment.TickCount;
+                        _lastFocus = DateTime.Now.Ticks;
                     }
-                    else if (Environment.TickCount > _lastFocus + 2000l && overlayWindow == foreGround)
+                    else if (DateTime.Now.Ticks > _lastFocus + 20000000 && overlayWindow == foreGround)
                     {
                         WindowHelper.BringProcessToFront(localByName[0]);
                     }
@@ -262,7 +262,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
         private void RadioOverlayWindow_OnLocationChanged(object sender, EventArgs e)
         {
             //reset last focus so we dont switch back to dcs while dragging
-            _lastFocus = Environment.TickCount;
+            _lastFocus = DateTime.Now.Ticks;
         }
     }
 }

--- a/DCS-SR-Common/DCSState/DCSPlayerRadioInfo.cs
+++ b/DCS-SR-Common/DCSState/DCSPlayerRadioInfo.cs
@@ -92,7 +92,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 
         public bool IsCurrent()
         {
-            return LastUpdate > Environment.TickCount - 10000;
+            return LastUpdate > DateTime.Now.Ticks - 100000000;
         }
 
         public RadioInformation CanHearTransmission(double frequency, RadioInformation.Modulation modulation,
@@ -120,7 +120,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                             receivingState = new RadioReceivingState
                             {
                                 IsSecondary = false,
-                                LastReceviedAt = Environment.TickCount,
+                                LastReceviedAt = DateTime.Now.Ticks,
                                 ReceivedOn = i
                             };
 
@@ -144,7 +144,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                         receivingState = new RadioReceivingState
                         {
                             IsSecondary = false,
-                            LastReceviedAt = Environment.TickCount,
+                            LastReceviedAt = DateTime.Now.Ticks,
                             ReceivedOn = i
                         };
 
@@ -156,7 +156,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                         receivingState = new RadioReceivingState
                         {
                             IsSecondary = true,
-                            LastReceviedAt = Environment.TickCount,
+                            LastReceviedAt = DateTime.Now.Ticks,
                             ReceivedOn = i
                         };
 

--- a/DCS-SR-Common/DCSState/RadioReceivingState.cs
+++ b/DCS-SR-Common/DCSState/RadioReceivingState.cs
@@ -7,13 +7,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
     public class RadioReceivingState
     {
         [JsonIgnore]
-        public double LastReceviedAt { get; set; }
+        public long LastReceviedAt { get; set; }
 
         public bool IsSecondary { get; set; }
         public int ReceivedOn { get; set; }
 
         public bool PlayedEndOfTransmission { get; set; }
 
-        public bool IsReceiving => (Environment.TickCount - LastReceviedAt) < 500;
+        public bool IsReceiving => (DateTime.Now.Ticks - LastReceviedAt) < 5000000;
     }
 }

--- a/DCS-SR-Common/Network/SRClient.cs
+++ b/DCS-SR-Common/Network/SRClient.cs
@@ -66,7 +66,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
         public bool isCurrent()
         {
             return true;
-//             if(LastUpdate > Environment.TickCount - 10000)//last in game 10 seconds ago
+//             if(LastUpdate > DateTime.Now.Ticks - 100000000)//last in game 10 seconds ago
 //             {
 //                Console.WriteLine("NOT CURRENT!");
 //                 return true;

--- a/DCS-SimpleRadio Server/Network/ServerSync.cs
+++ b/DCS-SimpleRadio Server/Network/ServerSync.cs
@@ -367,7 +367,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                 if (client != null)
                 {
                     //copy the data we need
-                    client.LastUpdate = Environment.TickCount;
+                    client.LastUpdate = DateTime.Now.Ticks;
                     client.Name = message.Client.Name;
                     client.Coalition = message.Client.Coalition;
                     client.Position = message.Client.Position;
@@ -421,9 +421,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                 if (client != null)
                 {
                     //update to local ticks
-                    message.Client.RadioInfo.LastUpdate = Environment.TickCount;
+                    message.Client.RadioInfo.LastUpdate = DateTime.Now.Ticks;
 
-                    client.LastUpdate = Environment.TickCount;
+                    client.LastUpdate = DateTime.Now.Ticks;
                     client.Name = message.Client.Name;
                     client.Coalition = message.Client.Coalition;
                     client.RadioInfo = message.Client.RadioInfo;


### PR DESCRIPTION
`Environment.TickCount` represents the systems ticks since uptime, returned as a signed `Int32`, thus rolling over every 24.9 days.

Windows 10 has a "FastBoot" feature enabled by default, saving the kernel's state before shutdown to increase the boot speed - also restoring the `TickCount` after reboot, leading to an Integer overflow after a certain uptime without a full restart.

`DateTime.Ticks` is time dependent, representing the ticks (1 tick equals 100 nanoseconds) since `0001-01-01T00:00:00Z` and is thus not affected by this Win10 "oddity". Just remember to properly "convert" all comparison units now - 1ms equals 10000 ticks.

This should resolve the issue reported about FC3/GCI (basically all non-fully simulated) radios not syncing properly.