### PR TITLE
Minimizing a radio overlay window with hidden task bar icon now toggles it

### DIFF
--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
@@ -136,7 +136,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
 
         private void Button_Minimise(object sender, RoutedEventArgs e)
         {
-            WindowState = WindowState.Minimized;
+            // Minimising a window without a taskbar icon leads to the window's menu bar still showing up in the bottom of screen
+            // Since controls are unusable, but a very small portion of the always-on-top window still showing, we're closing it instead, similar to toggling the overlay
+            if (_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue)
+            {
+                Close();
+            }
+            else
+            {
+                WindowState = WindowState.Minimized;
+            }
         }
 
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -524,10 +524,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             AutoConnectPromptToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.AutoConnectPrompt).BoolValue;
             RadioOverlayTaskbarItem.IsChecked =
                 _settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
-            RefocusDCS.IsChecked = RadioOverlayTaskbarItem.IsChecked =
-                _settings.GetClientSetting(SettingsKeys.RefocusDCS).BoolValue;
-            ExpandInputDevices.IsChecked = RadioOverlayTaskbarItem.IsChecked =
-                _settings.GetClientSetting(SettingsKeys.ExpandControls).BoolValue;
+            RefocusDCS.IsChecked = _settings.GetClientSetting(SettingsKeys.RefocusDCS).BoolValue;
+            ExpandInputDevices.IsChecked = _settings.GetClientSetting(SettingsKeys.ExpandControls).BoolValue;
             RadioTxStartToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioTxEffects_Start).BoolValue;
             RadioTxEndToggle.IsChecked = _settings.GetClientSetting(SettingsKeys.RadioTxEffects_End).BoolValue;
             
@@ -853,7 +851,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
 
                     _radioOverlayWindow.ShowInTaskbar =
-                        _settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
+                        !_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
                     _radioOverlayWindow.Show();
                 }
                 else
@@ -877,7 +875,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
                 _awacsRadioOverlay = new AwacsRadioOverlayWindow.RadioOverlayWindow();
                 _awacsRadioOverlay.ShowInTaskbar =
-                    _settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
+                    !_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
                 _awacsRadioOverlay.Show();
             }
             else
@@ -968,6 +966,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue =
                 (bool) RadioOverlayTaskbarItem.IsChecked;
             _settings.Save();
+
+            if (_radioOverlayWindow != null)
+            {
+                _radioOverlayWindow.ShowInTaskbar = !_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
+            }
+            else if (_awacsRadioOverlay != null)
+            {
+                _awacsRadioOverlay.ShowInTaskbar = !_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue;
+            }
         }
 
 

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
@@ -173,7 +173,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
 
         private void Button_Minimise(object sender, RoutedEventArgs e)
         {
-            WindowState = WindowState.Minimized;
+            // Minimising a window without a taskbar icon leads to the window's menu bar still showing up in the bottom of screen
+            // Since controls are unusable, but a very small portion of the always-on-top window still showing, we're closing it instead, similar to toggling the overlay
+            if (_settings.GetClientSetting(SettingsKeys.RadioOverlayTaskbarHide).BoolValue)
+            {
+                Close();
+            }
+            else
+            {
+                WindowState = WindowState.Minimized;
+            }
         }
 
 


### PR DESCRIPTION
Prevents issue of top part of window still showing up in bottom corner of screen (with unclickable buttons)
Fixed "Hide Overlay Taskbar Item" having inverted effect and not being indicated in Settings tab properly

Fixes #239 