### PR TITLE
Close AWACS overlay on main window exit

### DIFF
--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -743,6 +743,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _radioOverlayWindow?.Close();
             _radioOverlayWindow = null;
 
+            _awacsRadioOverlay?.Close();
+            _awacsRadioOverlay = null;
+
             _dcsAutoConnectListener.Stop();
             _dcsAutoConnectListener = null;
         }


### PR DESCRIPTION
Radio overlay was already closed, but the AWACS overlay left open, preventing proper shutdown when closing the main SRS window

Double-clicking the notify icon in this state lead to a crash