### PR TITLE
Simultaneous transmissions via AWACS overlay

### DIFF
--- a/DCS-SR-Client/Audio/Models/ClientAudio.cs
+++ b/DCS-SR-Client/Audio/Models/ClientAudio.cs
@@ -17,6 +17,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
         public RadioReceivingState RadioReceivingState { get; set; }
         public double RecevingPower { get; set; }
         public float LineOfSightLoss { get; set; }
-        public uint PacketNumber { get; set; }
+        public ulong PacketNumber { get; set; }
     }
 }

--- a/DCS-SR-Client/Audio/Models/JitterBufferAudio.cs
+++ b/DCS-SR-Client/Audio/Models/JitterBufferAudio.cs
@@ -4,6 +4,6 @@
     {
         public byte[] Audio { get; set; }
 
-        public uint PacketNumber { get; set; }
+        public ulong PacketNumber { get; set; }
     }
 }

--- a/DCS-SR-Client/Network/TCPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/TCPVoiceHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -94,7 +95,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                     var radioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
 
-                    _audioManager.PlaySoundEffectEndReceive(i, radioInfo.radios[i].volume);
+                    if (!radioState.IsSimultaneous)
+                    {
+                        _audioManager.PlaySoundEffectEndReceive(i, radioInfo.radios[i].volume);
+                    }
                 }
             }
         }
@@ -180,10 +184,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                         GuidBytes = _guidAsciiBytes,
                         AudioPart1Bytes = new byte[] {0, 1, 2, 3, 4, 5},
                         AudioPart1Length = (ushort) 6,
-                        Frequency = 100,
+                        Frequencies = new double[] { 100 },
                         UnitId = 1,
-                        Encryption = 0,
-                        Modulation = 4,
+                        Encryptions = new byte[] { 0 },
+                        Modulations = new byte[] { 4 },
                         PacketNumber = 1
                     }.EncodePacket();
 
@@ -327,7 +331,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                         var time = GetTickCount64(); //should add at the receive instead?
 
-                        if ((encodedOpusAudio != null) && (encodedOpusAudio.Length > 36))
+                        if ((encodedOpusAudio != null)
+                            && (encodedOpusAudio.Length >= (UDPVoicePacket.PacketHeaderLength + UDPVoicePacket.FixedPacketLength + UDPVoicePacket.FrequencySegmentLength)))
                         {
                             //  process
                             // check if we should play audio
@@ -338,42 +343,65 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             {
                                 //Decode bytes
                                 var udpVoicePacket = UDPVoicePacket.DecodeVoicePacket(encodedOpusAudio);
+                                var frequencyCount = udpVoicePacket.Frequencies.Length;
 
-                                // check the radio
-                                RadioReceivingState receivingState = null;
-                                var receivingRadio =
-                                    _clientStateSingleton.DcsPlayerRadioInfo.CanHearTransmission(
-                                        udpVoicePacket.Frequency,
-                                        (RadioInformation.Modulation) udpVoicePacket.Modulation,
-                                        udpVoicePacket.UnitId, out receivingState);
+                                List<RadioReceivingPriority> radioReceivingPriorities = new List<RadioReceivingPriority>(frequencyCount);
 
-                                //Check that we're not transmitting on this radio
-
-                                double receivingPowerLossPercent = 0;
-                                float lineOfSightLoss = 0;
-
-                                if ((receivingRadio != null) && (receivingState != null)
-                                    &&
-                                    ((receivingRadio.modulation == RadioInformation.Modulation.INTERCOM)
-                                     // INTERCOM Modulation is 2 so if its two dont bother checking LOS and Range
-                                     ||
-                                     (
-                                         HasLineOfSight(udpVoicePacket, out lineOfSightLoss)
-                                         &&
-                                         InRange(udpVoicePacket, out receivingPowerLossPercent)
-                                         &&
-                                         !ShouldBlockRxAsTransmitting(receivingState.ReceivedOn)
-                                     )
-                                    )
-                                )
+                                // Parse frequencies into receiving radio priority for selection below
+                                for (var i = 0; i < frequencyCount; i++)
                                 {
-                                    //  RadioReceivingState[receivingState.ReceivedOn] = receivingState;
+                                    RadioReceivingState state = null;
+                                    bool decryptable;
+                                    var radio = _clientStateSingleton.DcsPlayerRadioInfo.CanHearTransmission(
+                                        udpVoicePacket.Frequencies[i],
+                                        (RadioInformation.Modulation) udpVoicePacket.Modulations[i],
+                                        udpVoicePacket.Encryptions[i],
+                                        udpVoicePacket.UnitId, out state, out decryptable);
 
+                                    float losLoss = 0.0f;
+                                    double receivPowerLossPercent = 0.0;
+                                    bool canReceive = false;
+
+                                    if (radio != null && state != null)
+                                    {
+                                        if (
+                                            radio.modulation == RadioInformation.Modulation.INTERCOM
+                                            || (
+                                                HasLineOfSight(udpVoicePacket, out losLoss)
+                                                && InRange(udpVoicePacket.Guid, udpVoicePacket.Frequencies[i], out receivPowerLossPercent)
+                                                && !ShouldBlockRxAsTransmitting(state.ReceivedOn)
+                                            )
+                                        )
+                                        {
+                                            canReceive = true;
+                                        }
+
+                                        decryptable = (udpVoicePacket.Encryptions[i] == 0) || (udpVoicePacket.Encryptions[i] == radio.encKey && radio.enc);
+                                    }
+
+                                    radioReceivingPriorities.Add(new RadioReceivingPriority()
+                                    {
+                                        CanReceive = canReceive,
+                                        Decryptable = decryptable,
+                                        Encryption = udpVoicePacket.Encryptions[i],
+                                        Frequency = udpVoicePacket.Frequencies[i],
+                                        LineOfSightLoss = losLoss,
+                                        Modulation = udpVoicePacket.Modulations[i],
+                                        ReceivingPowerLossPercent = receivPowerLossPercent,
+                                        ReceivingRadio = radio,
+                                        ReceivingState = state
+                                    });
+                                }
+
+                                // Sort receiving radios to play audio on correct one
+                                radioReceivingPriorities.Sort(SortRadioReceivingPriorities);
+
+                                if (radioReceivingPriorities.Count > 0)
+                                {
                                     //DECODE audio
                                     int len1;
                                     var decoded = _decoder.Decode(udpVoicePacket.AudioPart1Bytes,
                                         udpVoicePacket.AudioPart1Bytes.Length, out len1);
-
 
                                     if (len1 > 0)
                                     {
@@ -384,62 +412,69 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                                         //ALL GOOD!
                                         //create marker for bytes
-                                        var audio = new ClientAudio
+                                        for (int i = 0; i < radioReceivingPriorities.Count; i++)
                                         {
-                                            ClientGuid = udpVoicePacket.Guid,
-                                            PcmAudioShort = ConversionHelpers.ByteArrayToShortArray(tmp),
-                                            //Convert to Shorts!
-                                            ReceiveTime = GetTickCount64(),
-                                            Frequency = udpVoicePacket.Frequency,
-                                            Modulation = udpVoicePacket.Modulation,
-                                            Volume = receivingRadio.volume,
-                                            ReceivedRadio = receivingState.ReceivedOn,
-                                            UnitId = udpVoicePacket.UnitId,
-                                            Encryption = udpVoicePacket.Encryption,
-                                            Decryptable =
-                                                (udpVoicePacket.Encryption == receivingRadio.encKey) &&
-                                                receivingRadio.enc,
-                                            // mark if we can decrypt it
-                                            RadioReceivingState = receivingState,
-                                            RecevingPower =
-                                                receivingPowerLossPercent, //loss of 1.0 or greater is total loss
-                                            LineOfSightLoss = lineOfSightLoss, // Loss of 1.0 or greater is total loss
-                                            PacketNumber = udpVoicePacket.PacketNumber
-                                        };
+                                            var destinationRadio = radioReceivingPriorities[i];
+                                            var isSimultaneousTransmission = radioReceivingPriorities.Count > 1 && i > 0;
 
-
-                                        //handle effects
-                                        var radioState = RadioReceivingState[audio.ReceivedRadio];
-
-                                        if ((radioState == null) || radioState.PlayedEndOfTransmission ||
-                                            !radioState.IsReceiving)
-                                        {
-                                            var decrytable = audio.Decryptable || (audio.Encryption == 0);
-
-                                            //mark that we have decrpyted encrypted audio for sound effects
-                                            if (decrytable && (audio.Encryption > 0))
+                                            var audio = new ClientAudio
                                             {
-                                                _audioManager.PlaySoundEffectStartReceive(audio.ReceivedRadio,
-                                                    true,
-                                                    audio.Volume);
+                                                ClientGuid = udpVoicePacket.Guid,
+                                                PcmAudioShort = ConversionHelpers.ByteArrayToShortArray(tmp),
+                                                //Convert to Shorts!
+                                                ReceiveTime = GetTickCount64(),
+                                                Frequency = destinationRadio.Frequency,
+                                                Modulation = destinationRadio.Modulation,
+                                                Volume = destinationRadio.ReceivingRadio.volume,
+                                                ReceivedRadio = destinationRadio.ReceivingState.ReceivedOn,
+                                                UnitId = udpVoicePacket.UnitId,
+                                                Encryption = destinationRadio.Encryption,
+                                                Decryptable = destinationRadio.Decryptable,
+                                                // mark if we can decrypt it
+                                                RadioReceivingState = destinationRadio.ReceivingState,
+                                                RecevingPower = destinationRadio.ReceivingPowerLossPercent, //loss of 1.0 or greater is total loss
+                                                LineOfSightLoss = destinationRadio.LineOfSightLoss, // Loss of 1.0 or greater is total loss
+                                                PacketNumber = udpVoicePacket.PacketNumber
+                                            };
+
+                                            //handle effects
+                                            var radioState = RadioReceivingState[audio.ReceivedRadio];
+
+                                            if (!isSimultaneousTransmission && (radioState == null || radioState.PlayedEndOfTransmission ||
+                                                !radioState.IsReceiving))
+                                            {
+                                                var decrytable = audio.Decryptable || (audio.Encryption == 0);
+
+                                                //mark that we have decrpyted encrypted audio for sound effects
+                                                if (decrytable && (audio.Encryption > 0))
+                                                {
+                                                    _audioManager.PlaySoundEffectStartReceive(audio.ReceivedRadio,
+                                                        true,
+                                                        audio.Volume);
+                                                }
+                                                else
+                                                {
+                                                    _audioManager.PlaySoundEffectStartReceive(audio.ReceivedRadio,
+                                                        false,
+                                                        audio.Volume);
+                                                }
                                             }
-                                            else
+
+                                            RadioReceivingState[audio.ReceivedRadio] = new RadioReceivingState
                                             {
-                                                _audioManager.PlaySoundEffectStartReceive(audio.ReceivedRadio,
-                                                    false,
-                                                    audio.Volume);
+                                                IsSecondary = destinationRadio.ReceivingState.IsSecondary,
+                                                IsSimultaneous = isSimultaneousTransmission,
+                                                LastReceviedAt = DateTime.Now.Ticks,
+                                                PlayedEndOfTransmission = false,
+                                                ReceivedOn = destinationRadio.ReceivingState.ReceivedOn
+                                            };
+
+                                            // Only play actual audio once
+                                            if (i == 0)
+                                            {
+                                                _audioManager.AddClientAudio(audio);
                                             }
                                         }
-
-                                        RadioReceivingState[audio.ReceivedRadio] = new RadioReceivingState
-                                        {
-                                            IsSecondary = receivingState.IsSecondary,
-                                            LastReceviedAt = DateTime.Now.Ticks,
-                                            PlayedEndOfTransmission = false,
-                                            ReceivedOn = receivingState.ReceivedOn
-                                        };
-
-                                        _audioManager.AddClientAudio(audio);
                                     }
                                     else
                                     {
@@ -509,7 +544,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             return false;
         }
 
-        private bool InRange(UDPVoicePacket udpVoicePacket, out double signalStrength)
+        private bool InRange(string transmissingClientGuid, double frequency, out double signalStrength)
         {
             signalStrength = 0;
             if (!ClientSync.ServerSettings[(int) ServerSettingType.DISTANCE_ENABLED])
@@ -518,7 +553,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             }
 
             SRClient transmittingClient;
-            if (_clientsList.TryGetValue(udpVoicePacket.Guid, out transmittingClient))
+            if (_clientsList.TryGetValue(transmissingClientGuid, out transmittingClient))
             {
                 var myPosition = _clientStateSingleton.DcsPlayerRadioInfo.pos;
 
@@ -532,7 +567,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                 var dist = RadioCalculator.CalculateDistance(myPosition, clientPos);
 
-                var max = RadioCalculator.FriisMaximumTransmissionRange(udpVoicePacket.Frequency);
+                var max = RadioCalculator.FriisMaximumTransmissionRange(frequency);
                 // % loss of signal
                 // 0 is no loss 1.0 is full loss
                 signalStrength = (dist / max);
@@ -540,6 +575,50 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 return max > dist;
             }
             return false;
+        }
+
+        private int SortRadioReceivingPriorities(RadioReceivingPriority x, RadioReceivingPriority y)
+        {
+            int xScore = 0;
+            int yScore = 0;
+
+            if (x.ReceivingRadio == null || x.ReceivingState == null)
+            {
+                return 1;
+            }
+            if (y.ReceivingRadio == null | y.ReceivingState == null)
+            {
+                return -1;
+            }
+
+            if (x.CanReceive && x.Decryptable)
+            {
+                xScore += 16;
+            }
+            if (y.CanReceive && y.Decryptable)
+            {
+                yScore += 16;
+            }
+
+            if (_clientStateSingleton.DcsPlayerRadioInfo.selected == x.ReceivingState.ReceivedOn)
+            {
+                xScore += 8;
+            }
+            if (_clientStateSingleton.DcsPlayerRadioInfo.selected == y.ReceivingState.ReceivedOn)
+            {
+                yScore += 8;
+            }
+
+            if (x.ReceivingRadio.volume > 0)
+            {
+                xScore += 4;
+            }
+            if (y.ReceivingRadio.volume > 0)
+            {
+                yScore += 4;
+            }
+
+            return yScore - xScore;
         }
 
         public bool Send(byte[] bytes, int len)
@@ -556,49 +635,105 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             {
                 try
                 {
+                    // List of radios the transmission is sent to (can me multiple if simultaneous transmission is enabled)
+                    List<RadioInformation> transmittingRadios = new List<RadioInformation>();
+
+                    // Always add currently selected radio (if valid)
                     var currentSelected = _clientStateSingleton.DcsPlayerRadioInfo.selected;
-                    //removes race condition by assigning here with the current selected changing
-                    if ((currentSelected >= 0)
-                        && (currentSelected < _clientStateSingleton.DcsPlayerRadioInfo.radios.Length))
+                    RadioInformation currentlySelectedRadio = null;
+                    if (currentSelected >= 0 
+                        && currentSelected < _clientStateSingleton.DcsPlayerRadioInfo.radios.Length)
                     {
-                        var radio = _clientStateSingleton.DcsPlayerRadioInfo.radios[currentSelected];
-
-                        if (((radio != null) && (radio.freq > 100) &&
-                             (radio.modulation != RadioInformation.Modulation.DISABLED))
-                            || (radio.modulation == RadioInformation.Modulation.INTERCOM))
+                        currentlySelectedRadio = _clientStateSingleton.DcsPlayerRadioInfo.radios[currentSelected];
+                        
+                        if (currentlySelectedRadio != null && currentlySelectedRadio.modulation != RadioInformation.Modulation.DISABLED
+                            && (currentlySelectedRadio.freq > 100 || currentlySelectedRadio.modulation == RadioInformation.Modulation.INTERCOM))
                         {
-                            //generate packet
-                            var udpVoicePacket = new UDPVoicePacket
-                            {
-                                GuidBytes = _guidAsciiBytes,
-                                AudioPart1Bytes = bytes,
-                                AudioPart1Length = (ushort) bytes.Length,
-                                Frequency = radio.freq,
-                                UnitId = _clientStateSingleton.DcsPlayerRadioInfo.unitId,
-                                Encryption = radio.enc ? radio.encKey : (byte) 0,
-                                Modulation = (byte) radio.modulation,
-                                PacketNumber = _packetNumber++
-                            }.EncodePacket();
+                            transmittingRadios.Add(currentlySelectedRadio);
+                        }
+                    }
 
-                            //send audio
-                            _listener.Client.Send(udpVoicePacket);
-
-                            //not sending or really quickly switched sending
-                            if (!RadioSendingState.IsSending || (RadioSendingState.SendingOn != currentSelected))
+                    // Add all radios toggled for simultaneous transmission if the global flag has been set
+                    if (_clientStateSingleton.DcsPlayerRadioInfo.simultaneousTransmission)
+                    {
+                        foreach (var radio in _clientStateSingleton.DcsPlayerRadioInfo.radios)
+                        {
+                            if (radio != null && radio.simul && radio.modulation != RadioInformation.Modulation.DISABLED
+                                && (radio.freq > 100 || radio.modulation == RadioInformation.Modulation.INTERCOM)
+                                && !transmittingRadios.Contains(radio)) // Make sure we don't add the selected radio twice
                             {
-                                _audioManager.PlaySoundEffectStartTransmit(currentSelected,
-                                    radio.enc && (radio.encKey > 0), radio.volume);
+                                transmittingRadios.Add(radio);
+                            }
+                        }
+                    }
+
+                    if (transmittingRadios.Count > 0)
+                    {
+                        List<double> frequencies = new List<double>(transmittingRadios.Count);
+                        List<byte> encryptions = new List<byte>(transmittingRadios.Count);
+                        List<byte> modulations = new List<byte>(transmittingRadios.Count);
+
+                        for (int i = 0; i < transmittingRadios.Count; i++)
+                        {
+                            var radio = transmittingRadios[i];
+
+                            // Further deduplicate transmitted frequencies if they have the same freq./modulation/encryption (caused by differently named radios)
+                            bool alreadyIncluded = false;
+                            for (int j = 0; j < frequencies.Count; j++)
+                            {
+                                if (frequencies[j] == radio.freq
+                                    && modulations[j] == (byte)radio.modulation
+                                    && encryptions[j] == (radio.enc ? radio.encKey : (byte)0))
+                                {
+                                    alreadyIncluded = true;
+                                    break;
+                                }
                             }
 
-                            //set radio overlay state
-                            RadioSendingState = new RadioSendingState
+                            if (alreadyIncluded)
                             {
-                                IsSending = true,
-                                LastSentAt = DateTime.Now.Ticks,
-                                SendingOn = currentSelected
-                            };
-                            return true;
+                                continue;
+                            }
+
+                            frequencies.Add(radio.freq);
+                            encryptions.Add(radio.enc ? radio.encKey : (byte)0);
+                            modulations.Add((byte)radio.modulation);
                         }
+
+                        //generate packet
+                        var udpVoicePacket = new UDPVoicePacket
+                        {
+                            GuidBytes = _guidAsciiBytes,
+                            AudioPart1Bytes = bytes,
+                            AudioPart1Length = (ushort)bytes.Length,
+                            Frequencies = frequencies.ToArray(),
+                            UnitId = _clientStateSingleton.DcsPlayerRadioInfo.unitId,
+                            Encryptions = encryptions.ToArray(),
+                            Modulations = modulations.ToArray(),
+                            PacketNumber = _packetNumber++
+                        };
+
+                        var encodedUdpVoicePacket = udpVoicePacket.EncodePacket();
+
+                        //send audio
+                        _listener.Client.Send(encodedUdpVoicePacket);
+
+                        //not sending or really quickly switched sending
+                        if (currentlySelectedRadio != null &&
+                            (!RadioSendingState.IsSending || RadioSendingState.SendingOn != currentSelected))
+                        {
+                            _audioManager.PlaySoundEffectStartTransmit(currentSelected,
+                                currentlySelectedRadio.enc && (currentlySelectedRadio.encKey > 0), currentlySelectedRadio.volume);
+                        }
+
+                        //set radio overlay state
+                        RadioSendingState = new RadioSendingState
+                        {
+                            IsSending = true,
+                            LastSentAt = DateTime.Now.Ticks,
+                            SendingOn = currentSelected
+                        };
+                        return true;
                     }
                 }
                 catch (Exception e)
@@ -649,10 +784,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                 GuidBytes = _guidAsciiBytes,
                                 AudioPart1Bytes = message,
                                 AudioPart1Length = (ushort) message.Length,
-                                Frequency = 100,
+                                Frequencies = new double[] { 100 },
                                 UnitId = 1,
-                                Encryption = 0,
-                                Modulation = 4,
+                                Encryptions = new byte[] { 0 },
+                                Modulations = new byte[] { 4 },
                                 PacketNumber = 1
                             }.EncodePacket();
 

--- a/DCS-SR-Client/Singletons/ClientStateSingleton.cs
+++ b/DCS-SR-Client/Singletons/ClientStateSingleton.cs
@@ -29,6 +29,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         
         public long LastSent { get; set; }
 
+        public bool IsConnected { get; set; }
+
         private ClientStateSingleton()
         {
             DcsPlayerRadioInfo = new DCSPlayerRadioInfo();
@@ -42,6 +44,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             }
 
             MicrophoneAvailable = true;
+
+            IsConnected = false;
         }
 
         public static ClientStateSingleton Instance

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsIntercomControlGroup.xaml
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsIntercomControlGroup.xaml
@@ -12,7 +12,7 @@
     <StackPanel Orientation="Horizontal">
 
         <TextBlock x:Name="RadioLabel"
-                   Width="110"
+                   Width="75"
                    Margin="2"
                    HorizontalAlignment="Center"
                    VerticalAlignment="Center"
@@ -20,7 +20,7 @@
                    Foreground="#E7E7E7"
                    Padding="0"
                    Style="{x:Null}"
-                   Text="Telephone / Sat Comms"
+                   Text="INTERCOM"
                    TextAlignment="Center" />
 
         <Ellipse x:Name="RadioActive"

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsIntercomControlGroup.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsIntercomControlGroup.xaml.cs
@@ -65,7 +65,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
         {
             var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
 
-            if ((dcsPlayerRadioInfo == null) || !dcsPlayerRadioInfo.IsCurrent())
+            if (!_clientStateSingleton.IsConnected || (dcsPlayerRadioInfo == null) || !dcsPlayerRadioInfo.IsCurrent())
             {
                 RadioActive.Fill = new SolidColorBrush(Colors.Red);
 

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml
@@ -143,10 +143,11 @@
         <Slider x:Name="windowOpacitySlider"
                 Grid.Row="3"
                 Grid.Column="2"
-                Grid.ColumnSpan="3"
+                Grid.ColumnSpan="2"
                 Width="280"
-                Margin="60,0,0,0"
+                Margin="0,0,20,0"
                 VerticalAlignment="Center"
+                HorizontalAlignment="Left"
                 Maximum="1.0"
                 Minimum="0.05"
                 Style="{x:Null}"
@@ -158,10 +159,16 @@
                                     Grid.Row="4"
                                     Grid.Column="0"
                                     Grid.ColumnSpan="3"
-                                    Margin="30,0,0,0"
+                                    Margin="10,0,0,0"
                                     HorizontalAlignment="Left"
                                     RadioId="0" />
 
-
+        <Button x:Name="ToggleGlobalSimultaneousTransmissionButton"
+                Grid.Row="4"
+                Grid.Column="4"
+                Click="ToggleGlobalSimultaneousTransmissionButton_Click"
+                Content="Simul. Transmission OFF"
+                Margin="0,5,25,5"
+                Style="{x:Null}" />
     </Grid>
 </Window>

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
@@ -101,15 +101,32 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
             intercom.RepaintRadioStatus();
 
             var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
-            if ((dcsPlayerRadioInfo != null) && dcsPlayerRadioInfo.IsCurrent())
+            if (dcsPlayerRadioInfo != null)
             {
-                var avalilableRadios = 0;
-
-                for (var i = 0; i < dcsPlayerRadioInfo.radios.Length; i++)
+                if (_clientStateSingleton.IsConnected && dcsPlayerRadioInfo.IsCurrent())
                 {
-                    if (dcsPlayerRadioInfo.radios[i].modulation != RadioInformation.Modulation.DISABLED)
+                    ToggleGlobalSimultaneousTransmissionButton.IsEnabled = true;
+
+                    var avalilableRadios = 0;
+
+                    for (var i = 0; i < dcsPlayerRadioInfo.radios.Length; i++)
                     {
-                        avalilableRadios++;
+                        if (dcsPlayerRadioInfo.radios[i].modulation != RadioInformation.Modulation.DISABLED)
+                        {
+                            avalilableRadios++;
+                        }
+                    }
+                }
+                else
+                {
+                    ToggleGlobalSimultaneousTransmissionButton.IsEnabled = false;
+                    ToggleGlobalSimultaneousTransmissionButton.Content = "Simul. Transmission OFF";
+
+                    dcsPlayerRadioInfo.simultaneousTransmission = false;
+
+                    foreach (var radio in dcsPlayerRadioInfo.radios)
+                    {
+                        radio.simul = false;
                     }
                 }
             }
@@ -233,5 +250,34 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
         }
 
         #endregion
+
+        private void ToggleGlobalSimultaneousTransmissionButton_Click(object sender, RoutedEventArgs e)
+        {
+            var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
+            if (dcsPlayerRadioInfo != null)
+            {
+                dcsPlayerRadioInfo.simultaneousTransmission = !dcsPlayerRadioInfo.simultaneousTransmission;
+
+                if (!dcsPlayerRadioInfo.simultaneousTransmission)
+                {
+                    foreach (var radio in dcsPlayerRadioInfo.radios)
+                    {
+                        radio.simul = false;
+                    }
+                }
+
+                ToggleGlobalSimultaneousTransmissionButton.Content = _clientStateSingleton.DcsPlayerRadioInfo.simultaneousTransmission ? "Simul. Transmission ON" : "Simul. Transmission OFF";
+
+                foreach (var radio in radioControlGroup)
+                {
+                    if (!dcsPlayerRadioInfo.simultaneousTransmission)
+                    {
+                        radio.ToggleSimultaneousTransmissionButton.Content = "Sim. OFF";
+                    }
+
+                    radio.RepaintRadioStatus();
+                }
+            }
+        }
     }
 }

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroup.xaml
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroup.xaml
@@ -197,16 +197,21 @@
                         Style="{StaticResource DarkStyle-Button}"
                         ToolTip="-0.01MHz" />
                 <Slider x:Name="RadioVolume"
-                        Width="115"
+                        Width="95"
                         Height="20"
-                        Margin="15,2,0,0"
+                        Margin="3,2,0,0"
                         IsEnabled="False"
                         Maximum="100"
                         Style="{x:Null}"
                         Thumb.DragCompleted="RadioVolume_DragCompleted"
                         Thumb.DragStarted="RadioVolume_DragStarted" />
 
-
+                <Button Name="ToggleSimultaneousTransmissionButton"
+                        Click="ToggleSimultaneousTransmissionButton_Click"
+                        Content="Sim. OFF"
+                        Width="50"
+                        Margin="3,0,0,2"
+                        Style="{x:Null}" />
             </WrapPanel>
         </TabItem>
         <TabItem>

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -572,18 +572,24 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                         Mic.IsEnabled = false;
                         Speakers.IsEnabled = false;
                         MicOutput.IsEnabled = false;
+
+                        _clientStateSingleton.IsConnected = true;
                     }
                     else
                     {
                         //invalid ID
                         MessageBox.Show("Invalid IP or Host Name!", "Host Name Error", MessageBoxButton.OK,
                             MessageBoxImage.Error);
+
+                        _clientStateSingleton.IsConnected = false;
                     }
                 }
                 catch (Exception ex) when (ex is SocketException || ex is ArgumentException)
                 {
                     MessageBox.Show("Invalid IP or Host Name!", "Host Name Error", MessageBoxButton.OK,
                         MessageBoxImage.Error);
+
+                    _clientStateSingleton.IsConnected = false;
                 }
             }
         }
@@ -624,6 +630,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             Mic.IsEnabled = true;
             Speakers.IsEnabled = true;
             MicOutput.IsEnabled = true;
+            _clientStateSingleton.IsConnected = false;
             try
             {
                 _audioManager.StopEncoding();
@@ -742,6 +749,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             _radioOverlayWindow?.Close();
             _radioOverlayWindow = null;
+
+            _awacsRadioOverlay?.Close();
+            _awacsRadioOverlay = null;
 
             _dcsAutoConnectListener.Stop();
             _dcsAutoConnectListener = null;

--- a/DCS-SR-Common/DCS-SR-Common.csproj
+++ b/DCS-SR-Common/DCS-SR-Common.csproj
@@ -97,6 +97,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DCSState\RadioReceivingPriority.cs" />
     <Compile Include="DCSState\RadioReceivingState.cs" />
     <Compile Include="Helpers\CircularBuffer.cs" />
     <Compile Include="Helpers\ConversionHelpers.cs" />

--- a/DCS-SR-Common/DCSState/RadioInformation.cs
+++ b/DCS-SR-Common/DCSState/RadioInformation.cs
@@ -54,6 +54,8 @@
 
         public int channel = -1;
 
+        public bool simul = false;
+
         /**
          * Used to determine if we should send an update to the server or not
          * We only need to do that if something that would stop us Receiving happens which
@@ -75,8 +77,15 @@
             {
                 return false;
             }
-
             if (modulation != compare.modulation)
+            {
+                return false;
+            }
+            if (enc != compare.enc)
+            {
+                return false;
+            }
+            if (encKey != compare.encKey)
             {
                 return false;
             }

--- a/DCS-SR-Common/DCSState/RadioReceivingPriority.cs
+++ b/DCS-SR-Common/DCSState/RadioReceivingPriority.cs
@@ -1,0 +1,16 @@
+﻿namespace Ciribob.DCS.SimpleRadio.Standalone.Common
+{
+    public class RadioReceivingPriority
+    {
+        public double Frequency;
+        public byte Encryption;
+        public short Modulation;
+        public float LineOfSightLoss;
+        public double ReceivingPowerLossPercent;
+        public bool CanReceive;
+        public bool Decryptable;
+
+        public RadioReceivingState ReceivingState;
+        public RadioInformation ReceivingRadio;
+    }
+}

--- a/DCS-SR-Common/DCSState/RadioReceivingState.cs
+++ b/DCS-SR-Common/DCSState/RadioReceivingState.cs
@@ -10,6 +10,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
         public long LastReceviedAt { get; set; }
 
         public bool IsSecondary { get; set; }
+        public bool IsSimultaneous { get; set; }
         public int ReceivedOn { get; set; }
 
         public bool PlayedEndOfTransmission { get; set; }

--- a/DCS-SR-CommonTests/DCS-SR-CommonTests.csproj
+++ b/DCS-SR-CommonTests/DCS-SR-CommonTests.csproj
@@ -71,6 +71,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Helpers\ConversionHelpersTests.cs" />
+    <Compile Include="Network\UDPVoicePacketTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DCS-SR-CommonTests/Network/UDPVoicePacketTests.cs
+++ b/DCS-SR-CommonTests/Network/UDPVoicePacketTests.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ciribob.DCS.SimpleRadio.Standalone.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Tests
+{
+    [TestClass()]
+    public class UDPVoicePacketTests
+    {
+        [TestMethod()]
+        public void EncodeInitialVoicePacket()
+        {
+            var udpVoicePacket = new UDPVoicePacket
+            {
+                GuidBytes = Encoding.ASCII.GetBytes("ufYS_WlLVkmFPjqCgxz6GA"),
+                AudioPart1Bytes = new byte[] { 0, 1, 2, 3, 4, 5 },
+                AudioPart1Length = (ushort)6,
+                Frequencies = new double[] { 100 },
+                UnitId = 1,
+                Encryptions = new byte[] { 0 },
+                Modulations = new byte[] { 4 },
+                PacketNumber = 1
+            };
+
+            var encodedUdpVoicePacket = udpVoicePacket.EncodePacket();
+
+            Assert.AreEqual(60, udpVoicePacket.PacketLength);
+            Assert.AreEqual(60, encodedUdpVoicePacket.Length);
+
+            var expectedEncodedUdpVoicePacket = new byte[60] {
+                60, 0, 6, 0, 10, 0, 0, 1, 2, 3,
+                4, 5, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 89, 64, 4, 0, 1, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 117, 102,
+                89, 83, 95, 87, 108, 76, 86, 107, 109, 70,
+                80, 106, 113, 67, 103, 120, 122, 54, 71, 65 };
+
+            CollectionAssert.AreEqual(expectedEncodedUdpVoicePacket, encodedUdpVoicePacket);
+        }
+
+        [TestMethod()]
+        public void DecodeInitialVoicePacket()
+        {
+            var encodedUdpVoicePacket = new byte[60] {
+                60, 0, 6, 0, 10, 0, 0, 1, 2, 3,
+                4, 5, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 89, 64, 4, 0, 1, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 117, 102,
+                89, 83, 95, 87, 108, 76, 86, 107, 109, 70,
+                80, 106, 113, 67, 103, 120, 122, 54, 71, 65 };
+
+            var udpVoicePacket = UDPVoicePacket.DecodeVoicePacket(encodedUdpVoicePacket);
+
+            Assert.AreEqual("ufYS_WlLVkmFPjqCgxz6GA", udpVoicePacket.Guid);
+            CollectionAssert.AreEqual(new byte[] { 0, 1, 2, 3, 4, 5 }, udpVoicePacket.AudioPart1Bytes);
+            Assert.AreEqual(6, udpVoicePacket.AudioPart1Length);
+            CollectionAssert.AreEqual(new double[] { 100 }, udpVoicePacket.Frequencies);
+            Assert.AreEqual((uint)1, udpVoicePacket.UnitId);
+            CollectionAssert.AreEqual(new byte[] { 0 }, udpVoicePacket.Encryptions);
+            CollectionAssert.AreEqual(new byte[] { 4 }, udpVoicePacket.Modulations);
+            Assert.AreEqual((ulong)1, udpVoicePacket.PacketNumber);
+            Assert.AreEqual((ushort)60, udpVoicePacket.PacketLength);
+        }
+
+        [TestMethod()]
+        public void EncodeMultipleFrequencyVoicePacket()
+        {
+            var udpVoicePacket = new UDPVoicePacket
+            {
+                GuidBytes = Encoding.ASCII.GetBytes("ufYS_WlLVkmFPjqCgxz6GA"),
+                AudioPart1Bytes = new byte[] { 0, 1, 2, 3, 4, 5 },
+                AudioPart1Length = (ushort)6,
+                Frequencies = new double[] { 251000000, 30000000, 251000000 },
+                UnitId = 1,
+                Encryptions = new byte[] { 0, 0, 1 },
+                Modulations = new byte[] { 0, 1, 0 },
+                PacketNumber = 1
+            };
+
+            var encodedUdpVoicePacket = udpVoicePacket.EncodePacket();
+
+            Assert.AreEqual(80, encodedUdpVoicePacket.Length);
+
+            var expectedEncodedUdpVoicePacket = new byte[80] {
+                80, 0, 6, 0, 30, 0, 0, 1, 2, 3,
+                4, 5, 0, 0, 0, 0, 0, 0, 0, 128,
+                233, 235, 173, 65, 0, 0, 0, 0, 0, 0,
+                56, 156, 124, 65, 1, 0, 0, 0, 0, 128,
+                233, 235, 173, 65, 0, 1, 1, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 117, 102,
+                89, 83, 95, 87, 108, 76, 86, 107, 109, 70,
+                80, 106, 113, 67, 103, 120, 122, 54, 71, 65 };
+
+            CollectionAssert.AreEqual(expectedEncodedUdpVoicePacket, encodedUdpVoicePacket);
+        }
+
+        [TestMethod()]
+        public void DecodeMultipleFrequencyVoicePacket()
+        {
+            var encodedUdpVoicePacket = new byte[80] {
+                80, 0, 6, 0, 30, 0, 0, 1, 2, 3,
+                4, 5, 0, 0, 0, 0, 0, 0, 0, 128,
+                233, 235, 173, 65, 0, 0, 0, 0, 0, 0,
+                56, 156, 124, 65, 1, 0, 0, 0, 0, 128,
+                233, 235, 173, 65, 0, 1, 1, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 117, 102,
+                89, 83, 95, 87, 108, 76, 86, 107, 109, 70,
+                80, 106, 113, 67, 103, 120, 122, 54, 71, 65 };
+
+            var udpVoicePacket = UDPVoicePacket.DecodeVoicePacket(encodedUdpVoicePacket);
+
+            Assert.AreEqual("ufYS_WlLVkmFPjqCgxz6GA", udpVoicePacket.Guid);
+            CollectionAssert.AreEqual(new byte[] { 0, 1, 2, 3, 4, 5 }, udpVoicePacket.AudioPart1Bytes);
+            Assert.AreEqual(6, udpVoicePacket.AudioPart1Length);
+            CollectionAssert.AreEqual(new double[] { 251000000, 30000000, 251000000 }, udpVoicePacket.Frequencies);
+            Assert.AreEqual((uint)1, udpVoicePacket.UnitId);
+            CollectionAssert.AreEqual(new byte[] { 0, 0, 1 }, udpVoicePacket.Encryptions);
+            CollectionAssert.AreEqual(new byte[] { 0, 1, 0 }, udpVoicePacket.Modulations);
+            Assert.AreEqual((ulong)1, udpVoicePacket.PacketNumber);
+            Assert.AreEqual((ushort)80, udpVoicePacket.PacketLength);
+        }
+    }
+}

--- a/DCS-SimpleRadio Server/Network/VOIPPacketHandler.cs
+++ b/DCS-SimpleRadio Server/Network/VOIPPacketHandler.cs
@@ -90,11 +90,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                     {
                         HashSet<string> matchingClients = new HashSet<string>();
 
-                        if (decodedPacket.Modulation != 4)
-                            //magical ignore message 4 - just used for ping
+                        for (int i = 0; i < decodedPacket.Frequencies.Length; i++)
                         {
+                            // Magical ignore message 4 - just used for ping
+                            if (decodedPacket.Modulations[0] == 4) {
+                                continue;
+                            }
+
                             var coalitionSecurity =
-                                _serverSettings.ServerSetting[(int) ServerSettingType.COALITION_AUDIO_SECURITY];
+                                _serverSettings.ServerSetting[(int)ServerSettingType.COALITION_AUDIO_SECURITY];
 
                             foreach (KeyValuePair<string, SRClient> _client in _clientsList)
                             {
@@ -109,23 +113,27 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                                         if (radioInfo != null)
                                         {
                                             RadioReceivingState radioReceivingState = null;
-                                            var receivingRadio = radioInfo.CanHearTransmission(decodedPacket.Frequency,
-                                                (RadioInformation.Modulation) decodedPacket.Modulation,
-                                                decodedPacket.UnitId, out radioReceivingState);
+                                            bool decryptable;
+                                            var receivingRadio = radioInfo.CanHearTransmission(decodedPacket.Frequencies[i],
+                                                (RadioInformation.Modulation)decodedPacket.Modulations[i],
+                                                decodedPacket.Encryptions[i],
+                                                decodedPacket.UnitId, out radioReceivingState, out decryptable);
 
                                             //only send if we can hear!
-                                            if (receivingRadio != null)
+                                            if (receivingRadio != null && !matchingClients.Contains(_client.Value.ClientChannelId))
+                                            {
                                                 matchingClients.Add(_client.Value.ClientChannelId);
+                                            }
                                         }
                                     }
                                 }
                             }
+                        }
 
-                            //send to other connected clients
-                            if (matchingClients.Count > 0)
-                            {
-                                group.WriteAndFlushAsync(message, new AllMatchingChannels(matchingClients));
-                            }
+                        //send to other connected clients
+                        if (matchingClients.Count > 0)
+                        {
+                            group.WriteAndFlushAsync(message, new AllMatchingChannels(matchingClients));
                         }
                     }
                 }


### PR DESCRIPTION
Includes larger rewrite of data serialisation/handling to fit multiple frequencies (including modulations + encryptions) being transmitted
Added simple unit tests verifying UDPVoicePacket encoding/decoding
Fixed issue with radio overlays showing frequencies if the user disconnects too faster after connecting

Maximum of three additional channels can be chosen for transmission (controlled via hard-coded limit in `AwacsRadioControlGroup.xaml.cs`)

Tested and verified working with 3 people, would probably still be useful to test further via a beta release or likewise. Can do another refactoring/cleanup of certain parts if requested.