### PR TITLE
Modified UpdateChecker to allow for beta release handling

### DIFF
--- a/DCS-SR-Client/Settings/SettingsStore.cs
+++ b/DCS-SR-Client/Settings/SettingsStore.cs
@@ -84,7 +84,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         AlwaysAllowHotasControls = 76,
         AllowDCSPTT = 77,
 
-        LastSeenName = 78
+        LastSeenName = 78,
+
+        CheckForBetaUpdates = 79
     }
 
     public enum InputBinding
@@ -305,7 +307,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             {SettingsKeys.AlwaysAllowHotasControls.ToString(),"false" },
             {SettingsKeys.AllowDCSPTT.ToString(),"true" },
 
-            {SettingsKeys.LastSeenName.ToString(), ""}
+            {SettingsKeys.LastSeenName.ToString(), ""},
+
+            {SettingsKeys.CheckForBetaUpdates.ToString(), "false"}
 
         };
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -543,7 +543,7 @@
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
-
+                            <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
@@ -1038,107 +1038,133 @@
                             </ToggleButton.Style>
                         </ToggleButton>
 
-
                         <Label Grid.Row="16"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
-                               Content="Radio 1 Audio Channel" />
-                        <local:RadioChannelConfigUi x:Name="Radio1Config"
-                                                    Grid.Row="16"
-                                                    Grid.Column="1"
-                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio1Channel}" />
+                               Content="Check for beta updates" />
+
+                        <ToggleButton Name="CheckForBetaUpdates"
+                                      Grid.Row="16"
+                                      Grid.Column="1"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center"
+                                      Click="CheckForBetaUpdates_OnClick">
+                            <ToggleButton.Style>
+                                <Style TargetType="{x:Type ToggleButton}">
+                                    <Setter Property="Content" Value="ON" />
+                                    <Style.Triggers>
+                                        <Trigger Property="IsChecked" Value="True">
+                                            <Setter Property="Content" Value="ON" />
+                                        </Trigger>
+                                        <Trigger Property="IsChecked" Value="False">
+                                            <Setter Property="Content" Value="OFF" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ToggleButton.Style>
+                        </ToggleButton>
 
                         <Label Grid.Row="17"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
-                               Content="Radio 2 Audio Channel" />
-                        <local:RadioChannelConfigUi x:Name="Radio2Config"
+                               Content="Radio 1 Audio Channel" />
+                        <local:RadioChannelConfigUi x:Name="Radio1Config"
                                                     Grid.Row="17"
                                                     Grid.Column="1"
-                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio2Channel}" />
+                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio1Channel}" />
 
                         <Label Grid.Row="18"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
-                               Content="Radio 3 Audio Channel" />
-                        <local:RadioChannelConfigUi x:Name="Radio3Config"
+                               Content="Radio 2 Audio Channel" />
+                        <local:RadioChannelConfigUi x:Name="Radio2Config"
                                                     Grid.Row="18"
                                                     Grid.Column="1"
-                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio3Channel}" />
+                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio2Channel}" />
+
                         <Label Grid.Row="19"
+                               Grid.Column="0"
+                               HorizontalContentAlignment="Center"
+                               VerticalContentAlignment="Center"
+                               Content="Radio 3 Audio Channel" />
+                        <local:RadioChannelConfigUi x:Name="Radio3Config"
+                                                    Grid.Row="19"
+                                                    Grid.Column="1"
+                                                    SettingConfig="{x:Static settings:SettingsKeys.Radio3Channel}" />
+                        <Label Grid.Row="20"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 4 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio4Config"
-                                                    Grid.Row="19"
+                                                    Grid.Row="20"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio4Channel}" />
-                        <Label Grid.Row="20"
+                        <Label Grid.Row="21"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 5 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio5Config"
-                                                    Grid.Row="20"
+                                                    Grid.Row="21"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio5Channel}" />
-                        <Label Grid.Row="21"
+                        <Label Grid.Row="22"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 6 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio6Config"
-                                                    Grid.Row="21"
+                                                    Grid.Row="22"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio6Channel}" />
-                        <Label Grid.Row="22"
+                        <Label Grid.Row="23"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 7 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio7Config"
-                                                    Grid.Row="22"
+                                                    Grid.Row="23"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio7Channel}" />
-                        <Label Grid.Row="23"
+                        <Label Grid.Row="24"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 8 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio8Config"
-                                                    Grid.Row="23"
+                                                    Grid.Row="24"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio8Channel}" />
-                        <Label Grid.Row="24"
+                        <Label Grid.Row="25"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 9 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio9Config"
-                                                    Grid.Row="24"
+                                                    Grid.Row="25"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio9Channel}" />
-                        <Label Grid.Row="25"
+                        <Label Grid.Row="26"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Radio 10 Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="Radio10Config"
-                                                    Grid.Row="25"
+                                                    Grid.Row="26"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.Radio10Channel}" />
 
-                        <Label Grid.Row="26"
+                        <Label Grid.Row="27"
                                Grid.Column="0"
                                HorizontalContentAlignment="Center"
                                VerticalContentAlignment="Center"
                                Content="Intercom Audio Channel" />
                         <local:RadioChannelConfigUi x:Name="IntercomConfig"
-                                                    Grid.Row="26"
+                                                    Grid.Row="27"
                                                     Grid.Column="1"
                                                     SettingConfig="{x:Static settings:SettingsKeys.IntercomChannel}" />
                     </Grid>

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -161,8 +161,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 SpeakerBoostLabel.Content = VolumeConversionHelper.ConvertLinearDiffToDB(_audioManager.SpeakerBoost);
             }
 
-            UpdaterChecker.CheckForUpdate();
-
+            UpdaterChecker.CheckForUpdate(_settings.GetClientSetting(SettingsKeys.CheckForBetaUpdates).BoolValue);
 
             InitFlowDocument();
 
@@ -581,6 +580,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             AlwaysAllowHotas.IsChecked = _settings.GetClientSetting(SettingsKeys.AlwaysAllowHotasControls).BoolValue;
             AllowDCSPTT.IsChecked = _settings.GetClientSetting(SettingsKeys.AllowDCSPTT).BoolValue;
+
+            CheckForBetaUpdates.IsChecked = _settings.GetClientSetting(SettingsKeys.CheckForBetaUpdates).BoolValue;
         }
 
         private void Connect()
@@ -1187,6 +1188,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 (bool)AlwaysAllowHotas.IsChecked;
             _settings.Save();
 
+        }
+
+        private void CheckForBetaUpdates_OnClick(object sender, RoutedEventArgs e)
+        {
+            _settings.GetClientSetting(SettingsKeys.CheckForBetaUpdates).BoolValue =
+                (bool)CheckForBetaUpdates.IsChecked;
+            _settings.Save();
         }
 
         private void ConnectExternalAWACSMode_OnClick(object sender, RoutedEventArgs e)

--- a/DCS-SR-Common/DCS-SR-Common.csproj
+++ b/DCS-SR-Common/DCS-SR-Common.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.props" Condition="Exists('..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -62,6 +63,9 @@
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="Octokit, Version=0.30.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.0.30.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -134,8 +138,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.props'))" />
+    <Error Condition="!Exists('..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.targets'))" />
   </Target>
   <Import Project="..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets" Condition="Exists('..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" />
+  <Import Project="..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.targets" Condition="Exists('..\packages\SourceLink.Create.GitHub.2.8.0\build\SourceLink.Create.GitHub.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DCS-SR-Common/Network/UpdaterChecker.cs
+++ b/DCS-SR-Common/Network/UpdaterChecker.cs
@@ -5,78 +5,101 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Windows;
 using NLog;
+using Octokit;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 {
     //Quick and dirty update checker based on GitHub Published Versions
     public class UpdaterChecker
     {
+        public static readonly string GITHUB_USERNAME = "ciribob";
+        public static readonly string GITHUB_REPOSITORY = "DCS-SimpleRadioStandalone";
+        // Required for all requests against the GitHub API, as per https://developer.github.com/v3/#user-agent-required
+        public static readonly string GITHUB_USER_AGENT = $"{GITHUB_USERNAME}_{GITHUB_REPOSITORY}";
+
         public static readonly string MINIMUM_PROTOCOL_VERSION = "1.5.0.0";
 
         public static readonly string VERSION = "1.5.2.0";
 
-        public static async void CheckForUpdate()
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+        public static async void CheckForUpdate(bool checkForBetaUpdates)
         {
-            var logger = LogManager.GetCurrentClassLogger();
-            var currentVersion = Version.Parse(VERSION);
+            Version currentVersion = Version.Parse(VERSION);
+
             try
             {
-                var request = WebRequest.Create("https://github.com/ciribob/DCS-SimpleRadioStandalone/releases/latest");
-                var response = (HttpWebResponse) await Task.Factory
-                    .FromAsync(request.BeginGetResponse,
-                        request.EndGetResponse,
-                        null);
+                var githubClient = new GitHubClient(new ProductHeaderValue(GITHUB_USER_AGENT, VERSION));
 
-                if (response.StatusCode == HttpStatusCode.OK)
+                var releases = await githubClient.Repository.Release.GetAll(GITHUB_USERNAME, GITHUB_REPOSITORY);
+
+                Version latestStableVersion = new Version();
+                Release latestStableRelease = null;
+                Version latestBetaVersion = new Version();
+                Release latestBetaRelease = null;
+
+                // Retrieve last stable and beta branch release as tagged on GitHub
+                foreach (Release release in releases)
                 {
-                    var path = response.ResponseUri.AbsolutePath;
+                    Version releaseVersion;
 
-                    if (path.Contains("tag/"))
+                    if (Version.TryParse(release.TagName.Replace("v", ""), out releaseVersion))
                     {
-                        var githubVersion = path.Split('/').Last().ToLower().Replace("v", "");
-                        Version ghVersion = null;
-
-                        if (Version.TryParse(githubVersion, out ghVersion))
+                        if (release.Prerelease && releaseVersion > latestBetaVersion)
                         {
-                            //comparse parts
-                            if (ghVersion.CompareTo(currentVersion) > 0)
-                            {
-                                logger.Warn("Update Available on GitHub: " + githubVersion);
-                                var result =
-                                    MessageBox.Show("New Version Available!\n\nDo you want to Update?",
-                                        "Update Available", MessageBoxButton.YesNo, MessageBoxImage.Information);
-
-                                // Process message box results
-                                switch (result)
-                                {
-                                    case MessageBoxResult.Yes:
-                                        //launch browser
-                                        Process.Start(response.ResponseUri.ToString());
-                                        break;
-                                    case MessageBoxResult.No:
-
-                                        break;
-                                }
-                            }
-                            else if (ghVersion.CompareTo(currentVersion) == 0)
-                            {
-                                logger.Warn("Running Latest Version: " + githubVersion);
-                            }
-                            else
-                            {
-                                logger.Warn("Running TESTING Version!! : " + VERSION);
-                            }
+                            latestBetaRelease = release;
+                            latestBetaVersion = releaseVersion;
                         }
-                        else
+                        else if (!release.Prerelease && releaseVersion > latestStableVersion)
                         {
-                            logger.Warn("Failed to Parse version: " + githubVersion);
+                            latestStableRelease = release;
+                            latestStableVersion = releaseVersion;
                         }
                     }
+                    else
+                    {
+                        _logger.Warn($"Failed to parse GitHub release version {release.TagName}");
+                    }
+                }
+
+                // Compare latest versions with currently running version depending on user branch choice
+                if (checkForBetaUpdates && latestBetaVersion > currentVersion)
+                {
+                    ShowUpdateAvailableDialog("beta", latestBetaVersion, latestBetaRelease.HtmlUrl);
+                }
+                else if (latestStableVersion > currentVersion)
+                {
+                    ShowUpdateAvailableDialog("stable", latestStableVersion, latestStableRelease.HtmlUrl);
+                }
+                else if (checkForBetaUpdates && latestBetaVersion == currentVersion)
+                {
+                    _logger.Warn($"Running latest beta version: {currentVersion}");
+                }
+                else if (latestStableVersion == currentVersion)
+                {
+                    _logger.Warn($"Running latest stable version: {currentVersion}");
+                }
+                else
+                {
+                    _logger.Warn($"Running development version: {currentVersion}");
                 }
             }
             catch (Exception ex)
             {
-                //Ignore for now
+                _logger.Error(ex, "Failed to check for updated version");
+            }
+        }
+
+        public static void ShowUpdateAvailableDialog(string branch, Version version, string url)
+        {
+            _logger.Warn($"New {branch} version available on GitHub: {version}");
+
+            var result = MessageBox.Show($"New {branch} version {version} available!\n\nDo you want to update?",
+                "Update available", MessageBoxButton.YesNo, MessageBoxImage.Information);
+
+            if (result == MessageBoxResult.Yes)
+            {
+                Process.Start(url);
             }
         }
     }

--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -21,7 +21,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         EXTERNAL_AWACS_MODE = 10,
         EXTERNAL_AWACS_MODE_BLUE_PASSWORD = 11,
         EXTERNAL_AWACS_MODE_RED_PASSWORD = 12,
-        CLIENT_EXPORT_FILE_PATH = 13
+        CLIENT_EXPORT_FILE_PATH = 13,
+        CHECK_FOR_BETA_UPDATES = 14
     }
 
     public class DefaultServerSettings
@@ -42,6 +43,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.SERVER_PORT.ToString(), "5002" },
             { ServerSettingsKeys.SPECTATORS_AUDIO_DISABLED.ToString(), "false" },
             { ServerSettingsKeys.CLIENT_EXPORT_FILE_PATH.ToString(), "clients-list.json" },
+            { ServerSettingsKeys.CHECK_FOR_BETA_UPDATES.ToString(), "false" }
         };
     }
 }

--- a/DCS-SR-Common/packages.config
+++ b/DCS-SR-Common/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="Costura.Fody" version="1.6.2" targetFramework="net46" developmentDependency="true" />
   <package id="Extended.Wpf.Toolkit" version="3.2.0" targetFramework="net46" />
   <package id="Fody" version="2.1.2" targetFramework="net46" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net46" />
   <package id="NLog" version="4.4.12" targetFramework="net46" />
+  <package id="Octokit" version="0.30.0" targetFramework="net46" />
+  <package id="SourceLink.Create.GitHub" version="2.8.0" targetFramework="net46" />
 </packages>

--- a/DCS-SimpleRadio Server/App.config
+++ b/DCS-SimpleRadio Server/App.config
@@ -11,9 +11,12 @@
         <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"
-                          culture="neutral" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DCS-SimpleRadio Server/Bootstrapper.cs
+++ b/DCS-SimpleRadio Server/Bootstrapper.cs
@@ -94,7 +94,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server
 
             DisplayRootViewFor<MainViewModel>(settings);
 
-            UpdaterChecker.CheckForUpdate();
+            UpdaterChecker.CheckForUpdate(Settings.ServerSettingsStore.Instance.GetServerSetting(Common.Setting.ServerSettingsKeys.CHECK_FOR_BETA_UPDATES).BoolValue);
         }
 
         protected override void BuildUp(object instance)

--- a/DCS-SimpleRadio Server/Settings/ServerSettingsStore.cs
+++ b/DCS-SimpleRadio Server/Settings/ServerSettingsStore.cs
@@ -68,6 +68,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
             SetSetting("Server Settings", key.ToString(), value.ToString(CultureInfo.InvariantCulture));
         }
 
+        public void SetServerSetting(ServerSettingsKeys key, bool value)
+        {
+            SetSetting("Server Settings", key.ToString(), value.ToString(CultureInfo.InvariantCulture));
+        }
+
         public Setting GetExternalAWACSModeSetting(ServerSettingsKeys key)
         {
             return GetSetting("External AWACS Mode Settings", key.ToString());

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -5,7 +5,7 @@
              xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Server.UI"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              Width="330"
-             Height="375"
+             Height="410"
              mc:Ignorable="d">
     <Grid Margin="0,0,-6,0">
         <Button x:Name="ServerStartStop"
@@ -136,38 +136,51 @@
                Margin="18,278,0,-3"
                HorizontalAlignment="Left"
                VerticalAlignment="Top"
+               Content="Check for beta updates" />
+
+        <Button x:Name="CheckForBetaUpdatesToggle"
+                Width="75"
+                Margin="206,283,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Content="{Binding CheckForBetaUpdates}" />
+        
+        <Label Width="165"
+               Margin="18,309,0,-3"
+               HorizontalAlignment="Left"
+               VerticalAlignment="Top"
                Content="External AWACS Mode (EAM)" />
 
         <Button x:Name="ExternalAWACSModeToggle"
                 Width="75"
-                Margin="206,283,0,0"
+                Margin="206,314,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
                 Content="{Binding ExternalAWACSMode}" />
 
         <Label Width="143"
-               Margin="18,309,0,-3"
+               Margin="18,340,0,-3"
                HorizontalAlignment="Left"
                VerticalAlignment="Top"
                Content="EAM blue coal. password" />
 
         <TextBox x:Name="ExternalAWACSModeBluePassword"
                 Width="75"
-                Margin="206,314,0,0"
+                Margin="206,345,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
                 IsEnabled="{Binding IsExternalAWACSModeEnabled}"
                 Text="{Binding Path=ExternalAWACSModeBluePassword, UpdateSourceTrigger=PropertyChanged}"/>
 
         <Label Width="143"
-               Margin="18,340,0,-3"
+               Margin="18,371,0,-3"
                HorizontalAlignment="Left"
                VerticalAlignment="Top"
                Content="EAM red coal. password" />
 
         <TextBox x:Name="ExternalAWACSModeRedPassword"
                 Width="75"
-                Margin="206,345,0,0"
+                Margin="206,376,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
                 IsEnabled="{Binding IsExternalAWACSModeEnabled}"

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -75,6 +75,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
         public string RadioExpansion
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.RADIO_EXPANSION).BoolValue ? "ON" : "OFF";
 
+        public string CheckForBetaUpdates
+            => ServerSettingsStore.Instance.GetServerSetting(ServerSettingsKeys.CHECK_FOR_BETA_UPDATES).BoolValue ? "ON" : "OFF";
+
         public string ExternalAWACSMode
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.EXTERNAL_AWACS_MODE).BoolValue ? "ON" : "OFF";
 
@@ -228,6 +231,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
             var newSetting = RadioExpansion != "ON";
             ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.RADIO_EXPANSION, newSetting);
             NotifyOfPropertyChange(() => RadioExpansion);
+
+            _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+        }
+
+        public void CheckForBetaUpdatesToggle()
+        {
+            var newSetting = CheckForBetaUpdates != "ON";
+            ServerSettingsStore.Instance.SetServerSetting(ServerSettingsKeys.CHECK_FOR_BETA_UPDATES, newSetting);
+            NotifyOfPropertyChange(() => CheckForBetaUpdates);
 
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }


### PR DESCRIPTION
Now uses GitHub library client to parse stable/beta releases using the `prerelease` flag
Added setting to server and client to check for beta updates

This updater allows for separate checks for `stable` and `beta` (= prerelease) versions using the GitHub releases. Beta updates can be toggled via the server/client setting UI, changes will take effect on the next restart.