### PR TITLE
Fixes #279, changes Connect/VOIP icons when server is offline

### DIFF
--- a/DCS-SR-Client/Network/ClientSync.cs
+++ b/DCS-SR-Client/Network/ClientSync.cs
@@ -152,7 +152,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(ex, "error connecting to server");
+                    Logger.Error(ex, "Could not connect to server");
+                    connectionError = true;
                 }
             }
 
@@ -205,6 +206,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             }
             catch (Exception ex)
             {
+                 Logger.Debug(ex, "Never ignore exceptions");
             }
         }
 


### PR DESCRIPTION
This should do the trick: just triggers the `connectionError` switch when actually there are connections errors". Without it the Thread delegated exists with an unhandled Exception

(please be patient: I'm no C# expert :) )