### PR TITLE
Fixed edited favourite values not being saved properly

### DIFF
--- a/DCS-SR-Client/Network/ClientSync.cs
+++ b/DCS-SR-Client/Network/ClientSync.cs
@@ -206,7 +206,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             }
             catch (Exception ex)
             {
-                 Logger.Debug(ex, "Never ignore exceptions");
+                 Logger.Error(ex, "Failed to update UI after connection callback (result {result}, connectionError {connectionError})", result, connectionError);
             }
         }
 

--- a/DCS-SR-Client/Settings/Favourites/ServerAddress.cs
+++ b/DCS-SR-Client/Settings/Favourites/ServerAddress.cs
@@ -5,22 +5,66 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 {
     public class ServerAddress : INotifyPropertyChanged
     {
-        private bool _isDefault;
-
         public ServerAddress(string name, string address, string eamCoalitionPassword, bool isDefault)
         {
-            Name = name;
-            Address = address;
-            EAMCoalitionPassword = eamCoalitionPassword;
-            IsDefault = isDefault;
+            // Set private values directly so we don't trigger useless re-saving of favourites list when being loaded for the first time
+            _name = name;
+            _address = address;
+            _eamCoalitionPassword = eamCoalitionPassword;
+            IsDefault = isDefault; // Explicitly use property setter here since IsDefault change includes additional logic
         }
 
-        public string Name { get; set; }
+        private string _name;
+        public string Name {
+            get
+            {
+                return _name;
+            }
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
-        public string Address { get; set; }
+        private string _address;
+        public string Address
+        {
+            get
+            {
+                return _address;
+            }
+            set
+            {
+                if (_address != value)
+                {
+                    _address = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
-        public string EAMCoalitionPassword { get; set; }
+        private string _eamCoalitionPassword;
+        public string EAMCoalitionPassword
+        {
+            get
+            {
+                return _eamCoalitionPassword;
+            }
+            set
+            {
+                if (_eamCoalitionPassword != value)
+                {
+                    _eamCoalitionPassword = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
+        private bool _isDefault;
         public bool IsDefault
         {
             get { return _isDefault; }

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Preferences;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
@@ -18,6 +19,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.Favourites
         public FavouriteServersViewModel(IFavouriteServerStore favouriteServerStore)
         {
             _favouriteServerStore = favouriteServerStore;
+
+            _addresses.CollectionChanged += OnServerAddressesCollectionChanged;
 
             foreach (var favourite in _favouriteServerStore.LoadFromStore())
             {
@@ -124,6 +127,34 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.Favourites
             }
 
             Save();
+        }
+
+        private void OnServerAddressesCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (ServerAddress address in e.NewItems)
+                {
+                    address.PropertyChanged += OnServerAddressPropertyChanged;
+                }
+            }
+
+            if (e.OldItems != null)
+            {
+                foreach (ServerAddress address in e.OldItems)
+                {
+                    address.PropertyChanged -= OnServerAddressPropertyChanged;
+                }
+            }
+        }
+
+        private void OnServerAddressPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            // Saving after changing default favourite is done by OnDefaultChanged
+            if (e.PropertyName != "IsDefault")
+            {
+                Save();
+            }
         }
     }
 }


### PR DESCRIPTION
Uses collection changed event to add/remove `PropertyChanged` events to ServerAddress objects, saving updated values after every update. Still preserves original `IsDefault` property change handling.

Fixes #281 