### PR TITLE
fix voip packet handler to always release memory

### DIFF
--- a/DCS-SimpleRadio Server/Network/VOIPPacketHandler.cs
+++ b/DCS-SimpleRadio Server/Network/VOIPPacketHandler.cs
@@ -87,6 +87,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
 
                     if ((srClient.Coalition == 0) && spectatorAudioDisabled)
                     {
+                        byteBuffer.Release();
                         return;
                     }
                     else
@@ -141,7 +142,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                         {
                             group.WriteAndFlushAsync(message, new AllMatchingChannels(matchingClients));
                         }
+                        else
+                        {
+                            byteBuffer.Release();
+                        }
                     }
+                }
+                else
+                {
+
+                    byteBuffer.Release();
                 }
             }
         }


### PR DESCRIPTION
Hi,

this PR is about something first noticed by @Lugghawk. When using ATIS clients that broadcast to SRS non-stop, the memory usage of the SRS server constantly increases. I've kept both running over last night and ended up with a 1GB memory usage. IIRC, for GAW, it were about 9GB after roughly 3 days.

To be fair, this is probably something that will not be noticed with "normal" SRS usage (no clients that broadcast non-stop).

Comparing memory snapshots (show difference between two snapshots with a time difference of several minutes), we can see that the heap/buffer of Dotnetty is constantly increasing.

![capture](https://user-images.githubusercontent.com/409021/48084434-fcd83680-e1f7-11e8-81db-89abb99e551b.PNG)

My investigations into the issue showed that the buffer allocated for an UDP package is only released when `WriteAndFlushAsync` is called. For all other cases, like when there is no matching client for a voice packet, the buffer is not released.

That is, I've added to all other (non-`WriteAndFlushAsync`) cases a `byteBuffer.Release();`. It might be not the prettiest solution to have three `byteBuffer.Release();`, but I tried to avoid refactoring the whole logic/flow here.


