### PR TITLE
Exception thrown if clients-list.json is in use

### DIFF
--- a/DCS-SimpleRadio Server/Network/ServerState.cs
+++ b/DCS-SimpleRadio Server/Network/ServerState.cs
@@ -109,7 +109,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                     if (ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.CLIENT_EXPORT_ENABLED).BoolValue)
                     {
                         var json = JsonConvert.SerializeObject(_connectedClients.Values) + "\n";
-                        File.WriteAllText(exportFilePath, json);
+                        try
+                        {
+                            File.WriteAllText(exportFilePath, json);
+                        }
+                        catch (IOException e)
+                        {
+                            Logger.Error(e);
+                        }
                     }
                     Thread.Sleep(5000);
                 }


### PR DESCRIPTION
An exception gets thrown if clients-list.json is in use, this would lead to the list no longer getting updated since the Task would stop.