### PR TITLE
Create install-build\Scripts\DCS-SRS\bin\ if necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,7 +249,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
-<<<<<<< HEAD
 
 # JetBrains Rider
 .idea/

--- a/Installer/Installer.csproj
+++ b/Installer/Installer.csproj
@@ -255,6 +255,7 @@ xcopy /Y /e "$(SolutionDir)DCS-SR-Client\AudioEffects" "$(SolutionDir)install-bu
 copy /Y "$(SolutionDir)Installer\bin\x64\Release\Installer.exe" "$(SolutionDir)install-build\Installer.exe"
 copy /Y "$(SolutionDir)AutoUpdater\bin\Release\SRS-AutoUpdater.exe" "$(SolutionDir)install-build\SRS-AutoUpdater.exe" 
 xcopy /Y /e "$(SolutionDir)Scripts" "$(SolutionDir)install-build\Scripts"
+if not exist "$(SolutionDir)install-build\Scripts\bin" mkdir "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\"
 copy /Y "$(SolutionDir)x64\Release\srs.dll" "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\srs.dll"
 </PostBuildEvent>
   </PropertyGroup>

--- a/Installer/Installer.csproj
+++ b/Installer/Installer.csproj
@@ -244,16 +244,16 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if not exist "$(SolutionDir)\install-build\Scripts" mkdir "$(SolutionDir)\install-build\Scripts"
-if not exist "$(SolutionDir)\install-build\AudioEffects" mkdir "$(SolutionDir)\install-build\AudioEffects"
-copy /Y "$(SolutionDir)\DCS-SimpleRadio Server\bin\x64\Release\SR-Server.exe" "$(SolutionDir)\install-build\SR-Server.exe"
-copy /Y "$(SolutionDir)\DCS-SR-Client\bin\x64\Release\SR-ClientRadio.exe" "$(SolutionDir)\install-build\SR-ClientRadio.exe"
-copy /Y "$(SolutionDir)\DCS-SR-Client\bin\x64\Release\opus.dll" "$(SolutionDir)\install-build\opus.dll"
-copy /Y "$(SolutionDir)\DCS-SR-Client\bin\x64\Release\speexdsp.dll" "$(SolutionDir)\install-build\speexdsp.dll"
-copy /Y "$(SolutionDir)\DCS-SR-Client\bin\x64\Release\awacs-radios.json" "$(SolutionDir)\install-build\awacs-radios.json"
-xcopy /Y /e "$(SolutionDir)\DCS-SR-Client\AudioEffects" "$(SolutionDir)install-build\AudioEffects"
-copy /Y "$(SolutionDir)\Installer\bin\x64\Release\Installer.exe" "$(SolutionDir)\install-build\Installer.exe"
-copy /Y "$(SolutionDir)\AutoUpdater\bin\Release\SRS-AutoUpdater.exe" "$(SolutionDir)\install-build\SRS-AutoUpdater.exe" 
+    <PostBuildEvent>if not exist "$(SolutionDir)install-build\Scripts" mkdir "$(SolutionDir)install-build\Scripts"
+if not exist "$(SolutionDir)install-build\AudioEffects" mkdir "$(SolutionDir)install-build\AudioEffects"
+copy /Y "$(SolutionDir)DCS-SimpleRadio Server\bin\x64\Release\SR-Server.exe" "$(SolutionDir)install-build\SR-Server.exe"
+copy /Y "$(SolutionDir)DCS-SR-Client\bin\x64\Release\SR-ClientRadio.exe" "$(SolutionDir)install-build\SR-ClientRadio.exe"
+copy /Y "$(SolutionDir)DCS-SR-Client\bin\x64\Release\opus.dll" "$(SolutionDir)install-build\opus.dll"
+copy /Y "$(SolutionDir)DCS-SR-Client\bin\x64\Release\speexdsp.dll" "$(SolutionDir)install-build\speexdsp.dll"
+copy /Y "$(SolutionDir)DCS-SR-Client\bin\x64\Release\awacs-radios.json" "$(SolutionDir)install-build\awacs-radios.json"
+xcopy /Y /e "$(SolutionDir)DCS-SR-Client\AudioEffects" "$(SolutionDir)install-build\AudioEffects"
+copy /Y "$(SolutionDir)Installer\bin\x64\Release\Installer.exe" "$(SolutionDir)install-build\Installer.exe"
+copy /Y "$(SolutionDir)AutoUpdater\bin\Release\SRS-AutoUpdater.exe" "$(SolutionDir)install-build\SRS-AutoUpdater.exe" 
 xcopy /Y /e "$(SolutionDir)Scripts" "$(SolutionDir)install-build\Scripts"
 copy /Y "$(SolutionDir)x64\Release\srs.dll" "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\srs.dll"
 </PostBuildEvent>

--- a/Installer/Installer.csproj
+++ b/Installer/Installer.csproj
@@ -255,7 +255,7 @@ xcopy /Y /e "$(SolutionDir)DCS-SR-Client\AudioEffects" "$(SolutionDir)install-bu
 copy /Y "$(SolutionDir)Installer\bin\x64\Release\Installer.exe" "$(SolutionDir)install-build\Installer.exe"
 copy /Y "$(SolutionDir)AutoUpdater\bin\Release\SRS-AutoUpdater.exe" "$(SolutionDir)install-build\SRS-AutoUpdater.exe" 
 xcopy /Y /e "$(SolutionDir)Scripts" "$(SolutionDir)install-build\Scripts"
-if not exist "$(SolutionDir)install-build\Scripts\bin" mkdir "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\"
+if not exist "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\" mkdir "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\"
 copy /Y "$(SolutionDir)x64\Release\srs.dll" "$(SolutionDir)install-build\Scripts\DCS-SRS\bin\srs.dll"
 </PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
The directory `install-build\Scripts\DCS-SRS\bin\` does not get created automatically,
resulting in a post build event failure, as the `srs.dll` cannot be copied.

This PR fixes that by creating the folder, if not present already.

Also introduces:
- formatting fixes for the post build events
- merge conflict relic removal in the .gitignore from 072551e