### PR TITLE
2. Switch NLog configuration to config file

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -17,6 +17,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -31,7 +32,6 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -368,6 +368,9 @@
     <None Include="awacs-radios.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/DCS-SR-Client/NLog.config
+++ b/DCS-SR-Client/NLog.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  If you are an SRS Developer modifying this file in the VS project for committing then you must update the hard-coded
+  logging configuration in App.xaml.cs as well to keep the changes in sync.
+-->
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <targets>
+    <target name="asyncFileTarget" xsi:type="AsyncWrapper" queueLimit="5000" overflowAction="Discard" >
+      <target name="fileTarget"
+              xsi:type="File"
+              fileName="clientlog.txt"
+              archiveFileName="clientlog.old.txt"
+              archiveAboveSize="104857600"
+              maxArchiveFiles="1"
+              layout="${longdate} | ${logger} | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
+      />
+    </target>
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="asyncFileTarget" />
+  </rules>
+</nlog>

--- a/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
+++ b/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
@@ -271,6 +271,9 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="app.manifest" />
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/DCS-SimpleRadio Server/NLog.config
+++ b/DCS-SimpleRadio Server/NLog.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  If you are an SRS Developer modifying this file in the VS project for committing then you must update the hard-coded
+  logging configuration in App.xaml.cs as well to keep the changes in sync.
+-->
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <targets>
+    <target name="asyncFileTarget" xsi:type="AsyncWrapper" queueLimit="5000" overflowAction="Discard" >
+      <target name="fileTarget"
+              xsi:type="File"
+              fileName="serverlog.txt"
+              archiveFileName="serverlog.old.txt"
+              archiveAboveSize="104857600"
+              maxArchiveFiles="1"
+              layout="${longdate} | ${logger} | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
+      />
+    </target>
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="asyncFileTarget" />
+  </rules>
+</nlog>


### PR DESCRIPTION
Switch NLog configuration to config file

Switch the configuration of NLog to a config file from the current
in-code configuration.

This makes it much easier to tailor logging to the requirements of the
developer or user.

I have chosen to use a separate "NLog.config" file by default from the
various options available to us (See
https://github.com/nlog/nlog/wiki/Configuration-file#configuration-file-locations
for the full list) as I think it is the simplest and easiest to
understand by most people.

This commit includes a config file and hard-coded defaults that almost,
but not quite, replicates the old hard-coded config. Differences are:

1. We delegate log rotation to NLog itself.

This means that in its current configuration it will log up to 200MB
of data (100MB in the current log and 100MB in the old log)

This is unlike the existing setup which will log to an unlimited
filesize until the client is restarted and then only creates an "old"
file if the existing one is over 100MB on application startup. I don't
expect this to have any real-world impact and the file sizes, number of
old log files and other settings can now be changed as the user wishes.

2. There is no hard-coded "Debug" LogLevel set on app debug mode.

For VS users the copy settings will only copy the config file if it is
newer than the one in the build directory which means developers can
modify their logging settings as they please (e.g. set the log level to
debug mode once and it will persist until the project logging file is
updated which should not happen often).

Of course, since this is all in a config file, we can change all of this
as we please.

Note that the existing hard-coded config for the SRS client was
incorrectly calling the fileTarget directly instead of the async
wrapper. This was fixed as part of this commit, the SRS server was
correctly calling the async wrapper.

### Testing

Tested by running Client and server with and without config files and making sure they still created the log files.