### PR TITLE
1. ConnectedClientsSingleton refactor

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -43,7 +43,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         private readonly ConcurrentDictionary<string, ClientAudioProvider> _clientsBufferedAudio =
             new ConcurrentDictionary<string, ClientAudioProvider>();
 
-        private readonly ConcurrentDictionary<string, SRClient> _clientsList;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
         private MixingSampleProvider _clientAudioMixer;
 
         private OpusDecoder _decoder;
@@ -75,10 +75,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         private Preprocessor _speex;
         private bool windowsN = false;
 
-        public AudioManager(ConcurrentDictionary<string, SRClient> clientsList, bool windowsN)
+        public AudioManager(bool windowsN)
         {
             this.windowsN = windowsN;
-            _clientsList = clientsList;
 
             _cachedAudioEffects =
                 new CachedAudioEffect[Enum.GetNames(typeof(CachedAudioEffect.AudioEffectTypes)).Length];
@@ -241,7 +240,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                     _waveIn.WaveFormat = new WaveFormat(INPUT_SAMPLE_RATE, 16, 1);
 
                     _udpVoiceHandler =
-                        new UdpVoiceHandler(_clientsList, guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
+                        new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
                     var voiceSenderThread = new Thread(_udpVoiceHandler.Listen);
 
                     voiceSenderThread.Start();
@@ -264,7 +263,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             {
                 //no mic....
                 _udpVoiceHandler =
-                    new UdpVoiceHandler(_clientsList, guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
+                    new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
                 MessageHub.Instance.Subscribe<SRClient>(RemoveClientBuffer);
                 var voiceSenderThread = new Thread(_udpVoiceHandler.Listen);
                 voiceSenderThread.Start();

--- a/DCS-SR-Client/Network/DCS/DCSLineOfSightHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSLineOfSightHandler.cs
@@ -21,16 +21,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
     public class DCSLineOfSightHandler
     {
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
-        private readonly ConcurrentDictionary<string, SRClient> _clients;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
         private readonly string _guid;
         private readonly GlobalSettingsStore _globalSettings = GlobalSettingsStore.Instance;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private volatile bool _stop = false;
         private UdpClient _dcsLOSListener;
 
-        public DCSLineOfSightHandler(ConcurrentDictionary<string, SRClient> clients, string guid)
+        public DCSLineOfSightHandler(string guid)
         {
-            _clients = clients;
             _guid = guid;
         }
 

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
@@ -23,11 +23,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
     public class DCSRadioSyncHandler
     {
         private readonly DCSRadioSyncManager.SendRadioUpdate _radioUpdate;
-        private readonly ConcurrentDictionary<string, SRClient> _clients;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
+
 
         private UdpClient _dcsUdpListener;
         private UdpClient _dcsRadioUpdateSender;
@@ -43,11 +44,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
         private long _identStart = 0;
         private bool _ident;
 
-        public DCSRadioSyncHandler(DCSRadioSyncManager.SendRadioUpdate radioUpdate,
-            ConcurrentDictionary<string, SRClient> clients, NewAircraft _newAircraft)
+        public DCSRadioSyncHandler(DCSRadioSyncManager.SendRadioUpdate radioUpdate, NewAircraft _newAircraft)
         {
             _radioUpdate = radioUpdate;
-            _clients = clients;
             _newAircraftCallback = _newAircraft;
         }
 
@@ -158,16 +157,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                 _dcsRadioUpdateSender.ExclusiveAddressUse = false;
             }
 
-            int clientCountIngame = 0;
-
-            foreach (KeyValuePair<string, SRClient> kvp in _clients)
-            {
-                if (kvp.Value.IsIngame())
-                {
-                    clientCountIngame++;
-                }
-            }
-
             try
             {
                 var connectedClientsSingleton = ConnectedClientsSingleton.Instance;
@@ -196,8 +185,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                     RadioInfo = _clientStateSingleton.DcsPlayerRadioInfo,
                     RadioSendingState = UdpVoiceHandler.RadioSendingState,
                     RadioReceivingState = UdpVoiceHandler.RadioReceivingState,
-                    ClientCountConnected = _clients.Count,
-                    ClientCountIngame = clientCountIngame,
+                    ClientCountConnected = _clients.Total,
+                    ClientCountIngame = _clients.InGame,
                     TunedClients = tunedClients,
                 };
 

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
@@ -33,19 +33,18 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
 
         private volatile bool _stopExternalAWACSMode;
 
-        private readonly ConcurrentDictionary<string, SRClient> _clients;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
 
         public bool IsListening { get; private set; }
 
         public DCSRadioSyncManager(SendRadioUpdate clientRadioUpdate, ClientSideUpdate clientSideUpdate,
-            ConcurrentDictionary<string, SRClient> clients, string guid, DCSRadioSyncHandler.NewAircraft _newAircraftCallback)
+           string guid, DCSRadioSyncHandler.NewAircraft _newAircraftCallback)
         {
-            this._clients = clients;
             IsListening = false;
-            _lineOfSightHandler = new DCSLineOfSightHandler(clients,guid);
+            _lineOfSightHandler = new DCSLineOfSightHandler(guid);
             _udpCommandHandler = new UDPCommandHandler();
             _dcsGameGuiHandler = new DCSGameGuiHandler(clientSideUpdate);
-            _dcsRadioSyncHandler = new DCSRadioSyncHandler(clientRadioUpdate, _clients, _newAircraftCallback);
+            _dcsRadioSyncHandler = new DCSRadioSyncHandler(clientRadioUpdate, _newAircraftCallback);
         }
 
         public void Start()

--- a/DCS-SR-Client/Network/LotATC/LotATCSyncHandler.cs
+++ b/DCS-SR-Client/Network/LotATC/LotATCSyncHandler.cs
@@ -31,17 +31,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.LotATC
         private volatile bool _stop = false;
         private readonly ClientStateSingleton _clientStateSingleton;
         private readonly DCSRadioSyncManager.ClientSideUpdate _clientSideUpdate;
-        private readonly ConcurrentDictionary<string, SRClient> _clients;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
         private readonly string _guid;
         private long _lastSent = 0;
 
         private double _heightOffset;
 
-        public LotATCSyncHandler(DCSRadioSyncManager.ClientSideUpdate clientSideUpdate, ConcurrentDictionary<string, SRClient> clients,
-            string guid)
+        public LotATCSyncHandler(DCSRadioSyncManager.ClientSideUpdate clientSideUpdate, string guid)
         {
             _clientSideUpdate = clientSideUpdate;
-            _clients = clients;
             _guid = guid;
             _clientStateSingleton = ClientStateSingleton.Instance;
 

--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -33,7 +33,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private volatile bool _stop = false;
 
         public static string ServerVersion = "Unknown";
-        private readonly ConcurrentDictionary<string, SRClient> _clients;
         private readonly string _guid;
         private ConnectCallback _callback;
         private ExternalAWACSModeConnectCallback _externalAWACSModeCallback;
@@ -44,6 +43,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
+
 
         private DCSRadioSyncManager _radioDCSSync = null;
         private LotATCSyncHandler _lotATCSync;
@@ -52,9 +53,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private VAICOMSyncHandler _vaicomSync;
 
 
-        public SRSClientSyncHandler(ConcurrentDictionary<string, SRClient> clients, string guid, UpdateUICallback uiCallback, DCSRadioSyncHandler.NewAircraft _newAircraft)
+        public SRSClientSyncHandler(string guid, UpdateUICallback uiCallback, DCSRadioSyncHandler.NewAircraft _newAircraft)
         {
-            _clients = clients;
             _guid = guid;
             _updateUICallback = uiCallback;
             this._newAircraft = _newAircraft;
@@ -142,8 +142,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
             bool connectionError = false;
 
-            _radioDCSSync = new DCSRadioSyncManager(ClientRadioUpdated, ClientCoalitionUpdate, _clients, _guid,_newAircraft);
-            _lotATCSync = new LotATCSyncHandler(ClientCoalitionUpdate,_clients, _guid);
+            _radioDCSSync = new DCSRadioSyncManager(ClientRadioUpdated, ClientCoalitionUpdate, _guid,_newAircraft);
+            _lotATCSync = new LotATCSyncHandler(ClientCoalitionUpdate, _guid);
             _vaicomSync = new VAICOMSyncHandler();
 
             using (_tcpClient = new TcpClient())

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -33,7 +33,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         private readonly IPAddress _address;
         private readonly AudioManager _audioManager;
-        private readonly ConcurrentDictionary<string, SRClient> _clientsList;
+        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
 
 
         private readonly BlockingCollection<byte[]> _encodedAudio = new BlockingCollection<byte[]>();
@@ -73,14 +73,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private long _udpLastReceived = 0;
         private DispatcherTimer _updateTimer;
 
-        public UdpVoiceHandler(ConcurrentDictionary<string, SRClient> clientsList, string guid, IPAddress address,
-            int port, OpusDecoder decoder, AudioManager audioManager, InputDeviceManager inputManager,
-            AudioManager.VOIPConnectCallback voipConnectCallback)
+        public UdpVoiceHandler(string guid, IPAddress address, int port, OpusDecoder decoder, AudioManager audioManager,
+            InputDeviceManager inputManager, AudioManager.VOIPConnectCallback voipConnectCallback)
         {
             // _decoder = decoder;
             _audioManager = audioManager;
-
-            _clientsList = clientsList;
             _guidAsciiBytes = Encoding.ASCII.GetBytes(guid);
 
             _guid = guid;
@@ -295,9 +292,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         private SRClient IsClientMetaDataValid(string clientGuid)
         {
-            if (_clientsList.ContainsKey(clientGuid))
+            if (_clients.ContainsKey(clientGuid))
             {
-                var client = _clientsList[_guid];
+                var client = _clients[_guid];
 
                 if ((client != null) && client.isCurrent())
                 {
@@ -542,7 +539,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             }
 
             SRClient transmittingClient;
-            if (_clientsList.TryGetValue(udpVoicePacket.Guid, out transmittingClient))
+            if (_clients.TryGetValue(udpVoicePacket.Guid, out transmittingClient))
             {
                 var myLatLng= _clientStateSingleton.PlayerCoaltionLocationMetadata.LngLngPosition;
                 var clientLatLng = transmittingClient.LatLngPosition;
@@ -569,7 +566,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             }
 
             SRClient transmittingClient;
-            if (_clientsList.TryGetValue(transmissingClientGuid, out transmittingClient))
+            if (_clients.TryGetValue(transmissingClientGuid, out transmittingClient))
             {
                 double dist = 0;
                

--- a/DCS-SR-Client/Singletons/ConnectedClientsSingleton.cs
+++ b/DCS-SR-Client/Singletons/ConnectedClientsSingleton.cs
@@ -2,10 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Remoting.Messaging;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
@@ -13,7 +9,7 @@ using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
 {
-    public class ConnectedClientsSingleton
+    public sealed class ConnectedClientsSingleton
     {
         private readonly ConcurrentDictionary<string, SRClient> _clients = new ConcurrentDictionary<string, SRClient>();
         private static volatile ConnectedClientsSingleton _instance;
@@ -21,12 +17,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         private readonly string guid = GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.CliendIdShort).StringValue;
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
 
-        public ConcurrentDictionary<string, SRClient> Clients {
-            get
-            {
-                return _clients;
-            }
-        }
+        private ConnectedClientsSingleton() { }
 
         public static ConnectedClientsSingleton Instance
         {
@@ -45,9 +36,68 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             }
         }
 
-        private ConnectedClientsSingleton()
+        public SRClient this[string key]
         {
+            get
+            {
+                return _clients[key];
+            }
+            set
+            {
+                _clients[key] = value;
+            }
+        }
 
+        public ICollection<SRClient> Values
+        {
+            get
+            {
+                return _clients.Values;
+            }
+        }
+
+        public int Total
+        {
+            get
+            {
+                return _clients.Count();
+            }
+        }
+
+        public int InGame
+        {
+            get
+            {
+                int clientCountIngame = 0;
+                foreach (SRClient client in _clients.Values)
+                {
+                    if (client.IsIngame())
+                    {
+                        clientCountIngame++;
+                    }
+                }
+                return clientCountIngame;
+            }
+        }
+
+        public bool TryRemove(string key, out SRClient value)
+        {
+            return _clients.TryRemove(key, out value);
+        }
+
+        public void Clear()
+        {
+            _clients.Clear();
+        }
+
+        public bool TryGetValue(string key, out SRClient value)
+        {
+            return _clients.TryGetValue(key, out value);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _clients.ContainsKey(key);
         }
 
         public int ClientsOnFreq(double freq, RadioInformation.Modulation modulation)

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -239,8 +239,18 @@
                                 Orientation="Horizontal">
                         <Label HorizontalAlignment="Center" Content="Connected Clients:" />
                         <Label x:Name="ClientCount"
-                               HorizontalAlignment="Center"
-                               Content="0" />
+                               HorizontalAlignment="Center">
+                            <Label.Content>
+                                <TextBlock> <!-- https://stackoverflow.com/questions/4399178/stringformat-and-multibinding-with-label -->
+                                    <TextBlock.Text>
+                                        <MultiBinding StringFormat=" {0} ({1} ingame)">
+                                            <Binding Path="Clients.Total" />
+                                            <Binding Path="Clients.InGame" />
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                            </Label.Content>
+                        </Label>
                         <Label Content="Current Position:"></Label>
                         <Label >
                             <TextBlock Name="CurrentPosition" Text="0,0 - Alt:0" MouseLeftButtonUp="CurrentPosition_OnClick" />

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -79,11 +79,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private readonly GlobalSettingsStore _globalSettings = GlobalSettingsStore.Instance;
         private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
-        private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
+        
+        /// <remarks>Used in the XAML for DataBinding the connected client count</remarks>
+        public ConnectedClientsSingleton Clients { get; } = ConnectedClientsSingleton.Instance;
 
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
         private bool windowsN;
-        
+
         public MainWindow()
         {
             GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
@@ -171,7 +173,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _dcsAutoConnectListener = new DCSAutoConnectHandler(AutoConnect);
 
             _updateTimer = new DispatcherTimer {Interval = TimeSpan.FromMilliseconds(100)};
-            _updateTimer.Tick += UpdateClientCount_VUMeters;
+            _updateTimer.Tick += UpdatePlayerLocationAndVUMeters;
             _updateTimer.Start();
 
             _redrawUITimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
@@ -741,10 +743,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             }
         }
 
-        private void UpdateClientCount_VUMeters(object sender, EventArgs e)
+        private void UpdatePlayerLocationAndVUMeters(object sender, EventArgs e)
         {
-            ClientCount.Content = $"{_clients.Total} ({_clients.InGame} ingame)";
-
             if (_audioPreview != null)
             {
                 // Only update mic volume output if an audio input device is available - sometimes the value can still change, leaving the user with the impression their mic is working after all


### PR DESCRIPTION
Refactor `ConnectedClientsSingleton` to fully encapsulate the operations on connected clients.

Building on this refactor we then switch the display of clients connected to using Bindings looking at the newly refactored auhtoritative singleton which emits notifications when the data changes in a manner that is not coupled to any receiver.

See the Commit messages for full details.