### PR TITLE
3. Replace if statements with guard clauses

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -108,7 +108,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         {
             _stop = false;
 
-
             try
             {
                 _micInputQueue.Clear();
@@ -224,7 +223,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                     Environment.Exit(1);
                 }
             }
-
 
             if (_clientStateSingleton.MicrophoneAvailable)
             {
@@ -347,76 +345,83 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
 
         public void PlaySoundEffectStartReceive(int transmitOnRadio, bool encrypted, float volume)
         {
-            if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioRxEffects_Start))
+            if (!_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioRxEffects_Start))
             {
-                var _effectsBuffer = _effectsOutputBuffer[transmitOnRadio];
+                return;
+            }
 
-                if (encrypted && (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioEncryptionEffects)))
-                {
-                    _effectsBuffer.VolumeSampleProvider.Volume = volume;
-                    _effectsBuffer.AddAudioSamples(
-                        _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.KY_58_RX].AudioEffectBytes,
-                        transmitOnRadio);
-                }
-                else
-                {
-                    _effectsBuffer.VolumeSampleProvider.Volume = volume;
-                    _effectsBuffer.AddAudioSamples(
-                        _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_TX].AudioEffectBytes,
-                        transmitOnRadio);
-                }
+            var _effectsBuffer = _effectsOutputBuffer[transmitOnRadio];
+
+            if (encrypted && (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioEncryptionEffects)))
+            {
+                _effectsBuffer.VolumeSampleProvider.Volume = volume;
+                _effectsBuffer.AddAudioSamples(
+                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.KY_58_RX].AudioEffectBytes,
+                    transmitOnRadio);
+            }
+            else
+            {
+                _effectsBuffer.VolumeSampleProvider.Volume = volume;
+                _effectsBuffer.AddAudioSamples(
+                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_TX].AudioEffectBytes,
+                    transmitOnRadio);
             }
         }
 
         public void PlaySoundEffectStartTransmit(int transmitOnRadio, bool encrypted, float volume)
         {
-            if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioTxEffects_Start))
+            if (!_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioTxEffects_Start))
             {
-                var _effectBuffer = _effectsOutputBuffer[transmitOnRadio];
+                return;
+            }
 
+            var _effectBuffer = _effectsOutputBuffer[transmitOnRadio];
 
-                if (encrypted && (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioEncryptionEffects)))
-                {
-                    _effectBuffer.VolumeSampleProvider.Volume = volume;
-                    _effectBuffer.AddAudioSamples(
-                        _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.KY_58_TX].AudioEffectBytes,
-                        transmitOnRadio);
-                }
-                else
-                {
-                    _effectBuffer.VolumeSampleProvider.Volume = volume;
-                    _effectBuffer.AddAudioSamples(
-                        _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_TX].AudioEffectBytes,
-                        transmitOnRadio);
-                }
+            if (encrypted && (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioEncryptionEffects)))
+            {
+                _effectBuffer.VolumeSampleProvider.Volume = volume;
+                _effectBuffer.AddAudioSamples(
+                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.KY_58_TX].AudioEffectBytes,
+                    transmitOnRadio);
+            }
+            else
+            {
+                _effectBuffer.VolumeSampleProvider.Volume = volume;
+                _effectBuffer.AddAudioSamples(
+                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_TX].AudioEffectBytes,
+                    transmitOnRadio);
             }
         }
 
 
         public void PlaySoundEffectEndReceive(int transmitOnRadio, float volume)
         {
-            if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioRxEffects_End))
+            if (!_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioRxEffects_End))
             {
-                var _effectsBuffer = _effectsOutputBuffer[transmitOnRadio];
-
-                _effectsBuffer.VolumeSampleProvider.Volume = volume;
-                _effectsBuffer.AddAudioSamples(
-                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_RX].AudioEffectBytes,
-                    transmitOnRadio);
+                return;
             }
+
+            var _effectsBuffer = _effectsOutputBuffer[transmitOnRadio];
+
+            _effectsBuffer.VolumeSampleProvider.Volume = volume;
+            _effectsBuffer.AddAudioSamples(
+                _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_RX].AudioEffectBytes,
+                transmitOnRadio);
         }
 
         public void PlaySoundEffectEndTransmit(int transmitOnRadio, float volume)
         {
-            if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioTxEffects_End))
+            if (!_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioTxEffects_End))
             {
-                var _effectBuffer = _effectsOutputBuffer[transmitOnRadio];
-
-                _effectBuffer.VolumeSampleProvider.Volume = volume;
-                _effectBuffer.AddAudioSamples(
-                    _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_RX].AudioEffectBytes,
-                    transmitOnRadio);
+                return;
             }
+
+            var _effectBuffer = _effectsOutputBuffer[transmitOnRadio];
+
+            _effectBuffer.VolumeSampleProvider.Volume = volume;
+            _effectBuffer.AddAudioSamples(
+                _cachedAudioEffects[(int) CachedAudioEffect.AudioEffectTypes.RADIO_RX].AudioEffectBytes,
+                transmitOnRadio);
         }
 
         private int _errorCount = 0;
@@ -428,7 +433,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             // _stopwatch.Restart();
 
             short[] pcmShort = null;
-
 
             if ((e.BytesRecorded/2 == SEGMENT_FRAMES) && (_micInputQueue.Count == 0))
             {
@@ -487,7 +491,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                         //determine peak
                         if (pcmShort[i] > max)
                         {
-
                             max = pcmShort[i];
                         }
                     }
@@ -542,7 +545,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
 
         public void StopEncoding()
         {
-
             _waveIn?.StopRecording();
             _waveIn?.Dispose();
             _waveIn = null;
@@ -614,16 +616,18 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             ClientAudioProvider clientAudio = null;
             _clientsBufferedAudio.TryRemove(srClient.ClientGuid, out clientAudio);
 
-            if (clientAudio != null)
+            if (clientAudio == null)
             {
-                try
-                {
-                    _clientAudioMixer.RemoveMixerInput(clientAudio.SampleProvider);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, "Error removing client input");
-                }
+                return;
+            }
+
+            try
+            {
+                _clientAudioMixer.RemoveMixerInput(clientAudio.SampleProvider);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error removing client input");
             }
         }
     }

--- a/DCS-SR-Client/Audio/Providers/CachedLoopingAudioProvider.cs
+++ b/DCS-SR-Client/Audio/Providers/CachedLoopingAudioProvider.cs
@@ -38,26 +38,28 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Providers
         {
             int read = source.Read(buffer, offset, count);
 
-            if (Settings.GlobalSettingsStore.Instance.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.NATOTone))
+            if (!GlobalSettingsStore.Instance.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.NATOTone))
             {
-                var effectBytes = GetEffect(read / 2);
+                return read;
+            }
 
-                //mix together
-                for (int i = 0; i < read / 2; i++)
-                {
-                    short audio = ConversionHelpers.ToShort(buffer[(offset + i) * 2], buffer[((i + offset) * 2) + 1]);
+            var effectBytes = GetEffect(read / 2);
 
-                    audio = (short)(audio + _audioEffectShort[i]);
+            //mix together
+            for (int i = 0; i < read / 2; i++)
+            {
+                short audio = ConversionHelpers.ToShort(buffer[(offset + i) * 2], buffer[((i + offset) * 2) + 1]);
 
-                    //buffer[i + offset] = effectBytes[i]+buffer[i + offset];
+                audio = (short)(audio + _audioEffectShort[i]);
 
-                    byte byte1;
-                    byte byte2;
-                    ConversionHelpers.FromShort(audio, out byte1, out byte2);
+                //buffer[i + offset] = effectBytes[i]+buffer[i + offset];
 
-                    buffer[(offset + i) * 2] = byte1;
-                    buffer[((i + offset) * 2) + 1] = byte2;
-                }
+                byte byte1;
+                byte byte2;
+                ConversionHelpers.FromShort(audio, out byte1, out byte2);
+
+                buffer[(offset + i) * 2] = byte1;
+                buffer[((i + offset) * 2) + 1] = byte2;
             }
 
             return read;

--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -92,86 +92,84 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             foreach (var deviceInstance in deviceInstances)
             {
                 //Workaround for Bad Devices that pretend to be joysticks
-                if (!IsBlackListed(deviceInstance.ProductGuid))
-                {
-                    Logger.Info("Found Device ID:" + deviceInstance.ProductGuid +
-                                " " +
-                                deviceInstance.ProductName.Trim().Replace("\0", "") + " Usage: " +
-                                deviceInstance.UsagePage + " Type: " +
-                                deviceInstance.Type);
-                    if (_inputDevices.ContainsKey(deviceInstance.InstanceGuid))
-                    {
-                        Logger.Info("Already have device:" + deviceInstance.ProductGuid +
-                                    " " +
-                                    deviceInstance.ProductName.Trim().Replace("\0", ""));
-                    }
-                    else
-                    {
-
-                        if (deviceInstance.Type == DeviceType.Keyboard)
-                        {
-
-                            Logger.Info("Adding Device ID:" + deviceInstance.ProductGuid +
-                                        " " +
-                                        deviceInstance.ProductName.Trim().Replace("\0", ""));
-                            var device = new Keyboard(_directInput);
-
-                            device.SetCooperativeLevel(WindowHelper.Handle,
-                                CooperativeLevel.Background | CooperativeLevel.NonExclusive);
-                            device.Acquire();
-
-                            _inputDevices.Add(deviceInstance.InstanceGuid, device);
-                        }
-                        else if (deviceInstance.Type == DeviceType.Mouse)
-                        {
-                            Logger.Info("Adding Device ID:" + deviceInstance.ProductGuid + " " +
-                                        deviceInstance.ProductName.Trim().Replace("\0", ""));
-                            var device = new Mouse(_directInput);
-
-                            device.SetCooperativeLevel(WindowHelper.Handle,
-                                CooperativeLevel.Background | CooperativeLevel.NonExclusive);
-                            device.Acquire();
-
-                            _inputDevices.Add(deviceInstance.InstanceGuid, device);
-                        }
-                        else if (((deviceInstance.Type >= DeviceType.Joystick) &&
-                                  (deviceInstance.Type <= DeviceType.FirstPerson)) ||
-                                 IsWhiteListed(deviceInstance.ProductGuid))
-                        {
-                            var device = new Joystick(_directInput, deviceInstance.InstanceGuid);
-
-                            Logger.Info("Adding ID:" + deviceInstance.ProductGuid + " " +
-                                        deviceInstance.ProductName.Trim().Replace("\0", ""));
-
-                            device.SetCooperativeLevel(WindowHelper.Handle,
-                                CooperativeLevel.Background | CooperativeLevel.NonExclusive);
-                            device.Acquire();
-
-                            _inputDevices.Add(deviceInstance.InstanceGuid, device);
-                        }
-                        else if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.ExpandControls))
-                        {
-                            Logger.Info("Adding (Expanded Devices) ID:" + deviceInstance.ProductGuid + " " +
-                                        deviceInstance.ProductName.Trim().Replace("\0", ""));
-
-                            var device = new Joystick(_directInput, deviceInstance.InstanceGuid);
-
-                            device.SetCooperativeLevel(WindowHelper.Handle,
-                                CooperativeLevel.Background | CooperativeLevel.NonExclusive);
-                            device.Acquire();
-
-                            _inputDevices.Add(deviceInstance.InstanceGuid, device);
-
-                            Logger.Info("Added (Expanded Device) ID:" + deviceInstance.ProductGuid + " " +
-                                        deviceInstance.ProductName.Trim().Replace("\0", ""));
-                        }
-                    }
-                }
-                else
+                if (IsBlackListed(deviceInstance.ProductGuid))
                 {
                     Logger.Info("Found but ignoring blacklist device  " + deviceInstance.ProductGuid + " Instance: " +
-                                deviceInstance.InstanceGuid + " " +
-                                deviceInstance.ProductName.Trim().Replace("\0", "") + " Type: " + deviceInstance.Type);
+                        deviceInstance.InstanceGuid + " " +
+                        deviceInstance.ProductName.Trim().Replace("\0", "") + " Type: " + deviceInstance.Type);
+                    continue;
+                }
+
+                Logger.Info("Found Device ID:" + deviceInstance.ProductGuid +
+                            " " +
+                            deviceInstance.ProductName.Trim().Replace("\0", "") + " Usage: " +
+                            deviceInstance.UsagePage + " Type: " +
+                            deviceInstance.Type);
+                if (_inputDevices.ContainsKey(deviceInstance.InstanceGuid))
+                {
+                    Logger.Info("Already have device:" + deviceInstance.ProductGuid +
+                                " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
+                    continue;
+                }
+
+
+                if (deviceInstance.Type == DeviceType.Keyboard)
+                {
+
+                    Logger.Info("Adding Device ID:" + deviceInstance.ProductGuid +
+                                " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
+                    var device = new Keyboard(_directInput);
+
+                    device.SetCooperativeLevel(WindowHelper.Handle,
+                        CooperativeLevel.Background | CooperativeLevel.NonExclusive);
+                    device.Acquire();
+
+                    _inputDevices.Add(deviceInstance.InstanceGuid, device);
+                }
+                else if (deviceInstance.Type == DeviceType.Mouse)
+                {
+                    Logger.Info("Adding Device ID:" + deviceInstance.ProductGuid + " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
+                    var device = new Mouse(_directInput);
+
+                    device.SetCooperativeLevel(WindowHelper.Handle,
+                        CooperativeLevel.Background | CooperativeLevel.NonExclusive);
+                    device.Acquire();
+
+                    _inputDevices.Add(deviceInstance.InstanceGuid, device);
+                }
+                else if (((deviceInstance.Type >= DeviceType.Joystick) &&
+                            (deviceInstance.Type <= DeviceType.FirstPerson)) ||
+                            IsWhiteListed(deviceInstance.ProductGuid))
+                {
+                    var device = new Joystick(_directInput, deviceInstance.InstanceGuid);
+
+                    Logger.Info("Adding ID:" + deviceInstance.ProductGuid + " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
+
+                    device.SetCooperativeLevel(WindowHelper.Handle,
+                        CooperativeLevel.Background | CooperativeLevel.NonExclusive);
+                    device.Acquire();
+
+                    _inputDevices.Add(deviceInstance.InstanceGuid, device);
+                }
+                else if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.ExpandControls))
+                {
+                    Logger.Info("Adding (Expanded Devices) ID:" + deviceInstance.ProductGuid + " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
+
+                    var device = new Joystick(_directInput, deviceInstance.InstanceGuid);
+
+                    device.SetCooperativeLevel(WindowHelper.Handle,
+                        CooperativeLevel.Background | CooperativeLevel.NonExclusive);
+                    device.Acquire();
+
+                    _inputDevices.Add(deviceInstance.InstanceGuid, device);
+
+                    Logger.Info("Added (Expanded Device) ID:" + deviceInstance.ProductGuid + " " +
+                                deviceInstance.ProductName.Trim().Replace("\0", ""));
                 }
             }
         }
@@ -194,31 +192,33 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         private void LoadGuidFromPath(string path, HashSet<Guid> _hashSet)
         {
-            if (File.Exists(path))
-            {
-                string[] lines = File.ReadAllLines(path);
-                if (lines?.Length > 0)
-                {
-                    foreach (var line in lines)
-                    {
-                        var trimmed = line.Trim();
-                        if (trimmed.Length > 0)
-                        {
-                            try
-                            {
-                                _hashSet.Add(new Guid(trimmed));
-                                Logger.Info("Added " + trimmed);
-                            }
-                            catch (Exception ex)
-                            {
-                            }
-                        }
-                    }
-                }
-            }
-            else
+            if (!File.Exists(path))
             {
                 Logger.Info("File doesnt exist: " + path);
+                return;
+            }
+
+            string[] lines = File.ReadAllLines(path);
+            if (lines?.Length <= 0)
+            {
+                return;
+
+            }
+
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length > 0)
+                {
+                    try
+                    {
+                        _hashSet.Add(new Guid(trimmed));
+                        Logger.Info("Added " + trimmed);
+                    }
+                    catch (Exception ex)
+                    {
+                    }
+                }
             }
         }
 
@@ -259,60 +259,62 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                 for (var i = 0; i < deviceList.Count; i++)
                 {
-                    if (deviceList[i] != null && !deviceList[i].IsDisposed)
+                    if (deviceList[i] == null || deviceList[i].IsDisposed)
                     {
-                        try
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (deviceList[i] is Joystick)
                         {
-                            if (deviceList[i] is Joystick)
+                            deviceList[i].Poll();
+
+                            var state = (deviceList[i] as Joystick).GetCurrentState();
+
+                            for (var j = 0; j < state.Buttons.Length; j++)
                             {
-                                deviceList[i].Poll();
-
-                                var state = (deviceList[i] as Joystick).GetCurrentState();
-
-                                for (var j = 0; j < state.Buttons.Length; j++)
-                                {
-                                    initial[i, j] = state.Buttons[j] ? 1 : 0;
-                                }
-                                var pov = state.PointOfViewControllers;
-
-                                for (var j = 0; j < pov.Length; j++)
-                                {
-                                    initial[i, j + 128] = pov[j];
-                                }
+                                initial[i, j] = state.Buttons[j] ? 1 : 0;
                             }
-                            else if (deviceList[i] is Keyboard)
+                            var pov = state.PointOfViewControllers;
+
+                            for (var j = 0; j < pov.Length; j++)
                             {
-                                var keyboard = deviceList[i] as Keyboard;
-                                keyboard.Poll();
-                                var state = keyboard.GetCurrentState();
-
-                                for (var j = 0; j < 128; j++)
-                                {
-                                    initial[i, j] = state.IsPressed(state.AllKeys[j]) ? 1 : 0;
-                                }
-                            }
-                            else if (deviceList[i] is Mouse)
-                            {
-                                var mouse = deviceList[i] as Mouse;
-                                mouse.Poll();
-
-                                var state = mouse.GetCurrentState();
-
-                                for (var j = 0; j < state.Buttons.Length; j++)
-                                {
-                                    initial[i, j] = state.Buttons[j] ? 1 : 0;
-                                }
+                                initial[i, j + 128] = pov[j];
                             }
                         }
-                        catch (Exception e)
+                        else if (deviceList[i] is Keyboard)
                         {
-                            Logger.Error(e, $"Failed to get current state of input device {deviceList[i].Information.ProductName.Trim().Replace("\0", "")} " +
-                                $"(ID: {deviceList[i].Information.ProductGuid}) while assigning button, ignoring until next restart/rediscovery");
+                            var keyboard = deviceList[i] as Keyboard;
+                            keyboard.Poll();
+                            var state = keyboard.GetCurrentState();
 
-                            deviceList[i].Unacquire();
-                            deviceList[i].Dispose();
-                            deviceList[i] = null;
+                            for (var j = 0; j < 128; j++)
+                            {
+                                initial[i, j] = state.IsPressed(state.AllKeys[j]) ? 1 : 0;
+                            }
                         }
+                        else if (deviceList[i] is Mouse)
+                        {
+                            var mouse = deviceList[i] as Mouse;
+                            mouse.Poll();
+
+                            var state = mouse.GetCurrentState();
+
+                            for (var j = 0; j < state.Buttons.Length; j++)
+                            {
+                                initial[i, j] = state.Buttons[j] ? 1 : 0;
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, $"Failed to get current state of input device {deviceList[i].Information.ProductName.Trim().Replace("\0", "")} " +
+                            $"(ID: {deviceList[i].Information.ProductGuid}) while assigning button, ignoring until next restart/rediscovery");
+
+                        deviceList[i].Unacquire();
+                        deviceList[i].Dispose();
+                        deviceList[i] = null;
                     }
                 }
 
@@ -328,75 +330,27 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                     for (var i = 0; i < _inputDevices.Count; i++)
                     {
-                        if (deviceList[i] != null && !deviceList[i].IsDisposed)
+                        if (deviceList[i] == null || deviceList[i].IsDisposed)
                         {
-                            try
+                            continue;
+                        }
+
+                        try
+                        {
+                            if (deviceList[i] is Joystick)
                             {
-                                if (deviceList[i] is Joystick)
+                                deviceList[i].Poll();
+
+                                var state = (deviceList[i] as Joystick).GetCurrentState();
+
+                                for (var j = 0; j < 128 + 4; j++)
                                 {
-                                    deviceList[i].Poll();
-
-                                    var state = (deviceList[i] as Joystick).GetCurrentState();
-
-                                    for (var j = 0; j < 128 + 4; j++)
+                                    if (j >= 128)
                                     {
-                                        if (j >= 128)
-                                        {
-                                            //handle POV
-                                            var pov = state.PointOfViewControllers;
+                                        //handle POV
+                                        var pov = state.PointOfViewControllers;
 
-                                            if (pov[j - 128] != initial[i, j])
-                                            {
-                                                found = true;
-
-                                                var inputDevice = new InputDevice
-                                                {
-                                                    DeviceName =
-                                                        deviceList[i].Information.ProductName.Trim().Replace("\0", ""),
-                                                    Button = j,
-                                                    InstanceGuid = deviceList[i].Information.InstanceGuid,
-                                                    ButtonValue = pov[j - 128]
-                                                };
-                                                Application.Current.Dispatcher.Invoke(
-                                                    () => { callback(inputDevice); });
-                                                return;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            var buttonState = state.Buttons[j] ? 1 : 0;
-
-                                            if (buttonState != initial[i, j])
-                                            {
-                                                found = true;
-
-                                                var inputDevice = new InputDevice
-                                                {
-                                                    DeviceName =
-                                                        deviceList[i].Information.ProductName.Trim().Replace("\0", ""),
-                                                    Button = j,
-                                                    InstanceGuid = deviceList[i].Information.InstanceGuid,
-                                                    ButtonValue = buttonState
-                                                };
-
-                                                Application.Current.Dispatcher.Invoke(
-                                                    () => { callback(inputDevice); });
-
-
-                                                return;
-                                            }
-                                        }
-                                    }
-                                }
-                                else if (deviceList[i] is Keyboard)
-                                {
-                                    var keyboard = deviceList[i] as Keyboard;
-                                    keyboard.Poll();
-                                    var state = keyboard.GetCurrentState();
-
-                                    for (var j = 0; j < 128; j++)
-                                    {
-                                        if (initial[i, j] != (state.IsPressed(state.AllKeys[j]) ? 1 : 0))
+                                        if (pov[j - 128] != initial[i, j])
                                         {
                                             found = true;
 
@@ -406,34 +360,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                                                     deviceList[i].Information.ProductName.Trim().Replace("\0", ""),
                                                 Button = j,
                                                 InstanceGuid = deviceList[i].Information.InstanceGuid,
-                                                ButtonValue = 1
+                                                ButtonValue = pov[j - 128]
                                             };
-
                                             Application.Current.Dispatcher.Invoke(
                                                 () => { callback(inputDevice); });
-
-
                                             return;
                                         }
-
-                                        //                                if (initial[i, j] == 1)
-                                        //                                {
-                                        //                                    Console.WriteLine("Pressed: "+j);
-                                        //                                    MessageBox.Show("Keyboard!");
-                                        //                                }
                                     }
-                                }
-                                else if (deviceList[i] is Mouse)
-                                {
-                                    deviceList[i].Poll();
-
-                                    var state = (deviceList[i] as Mouse).GetCurrentState();
-
-                                    //skip left mouse button - start at 1 with j 0 is left, 1 is right, 2 is middle
-                                    for (var j = 1; j < state.Buttons.Length; j++)
+                                    else
                                     {
                                         var buttonState = state.Buttons[j] ? 1 : 0;
-
 
                                         if (buttonState != initial[i, j])
                                         {
@@ -450,20 +386,87 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                                             Application.Current.Dispatcher.Invoke(
                                                 () => { callback(inputDevice); });
+
+
                                             return;
                                         }
                                     }
                                 }
                             }
-                            catch (Exception e)
+                            else if (deviceList[i] is Keyboard)
                             {
-                                Logger.Error(e, $"Failed to get current state of input device {deviceList[i].Information.ProductName.Trim().Replace("\0", "")} " +
-                                    $"(ID: {deviceList[i].Information.ProductGuid}) while discovering button press while assigning, ignoring until next restart/rediscovery");
+                                var keyboard = deviceList[i] as Keyboard;
+                                keyboard.Poll();
+                                var state = keyboard.GetCurrentState();
 
-                                deviceList[i].Unacquire();
-                                deviceList[i].Dispose();
-                                deviceList[i] = null;
+                                for (var j = 0; j < 128; j++)
+                                {
+                                    if (initial[i, j] != (state.IsPressed(state.AllKeys[j]) ? 1 : 0))
+                                    {
+                                        found = true;
+
+                                        var inputDevice = new InputDevice
+                                        {
+                                            DeviceName =
+                                                deviceList[i].Information.ProductName.Trim().Replace("\0", ""),
+                                            Button = j,
+                                            InstanceGuid = deviceList[i].Information.InstanceGuid,
+                                            ButtonValue = 1
+                                        };
+
+                                        Application.Current.Dispatcher.Invoke(
+                                            () => { callback(inputDevice); });
+
+
+                                        return;
+                                    }
+
+                                    //                                if (initial[i, j] == 1)
+                                    //                                {
+                                    //                                    Console.WriteLine("Pressed: "+j);
+                                    //                                    MessageBox.Show("Keyboard!");
+                                    //                                }
+                                }
                             }
+                            else if (deviceList[i] is Mouse)
+                            {
+                                deviceList[i].Poll();
+
+                                var state = (deviceList[i] as Mouse).GetCurrentState();
+
+                                //skip left mouse button - start at 1 with j 0 is left, 1 is right, 2 is middle
+                                for (var j = 1; j < state.Buttons.Length; j++)
+                                {
+                                    var buttonState = state.Buttons[j] ? 1 : 0;
+
+                                    if (buttonState != initial[i, j])
+                                    {
+                                        found = true;
+
+                                        var inputDevice = new InputDevice
+                                        {
+                                            DeviceName =
+                                                deviceList[i].Information.ProductName.Trim().Replace("\0", ""),
+                                            Button = j,
+                                            InstanceGuid = deviceList[i].Information.InstanceGuid,
+                                            ButtonValue = buttonState
+                                        };
+
+                                        Application.Current.Dispatcher.Invoke(
+                                            () => { callback(inputDevice); });
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error(e, $"Failed to get current state of input device {deviceList[i].Information.ProductName.Trim().Replace("\0", "")} " +
+                                $"(ID: {deviceList[i].Information.ProductGuid}) while discovering button press while assigning, ignoring until next restart/rediscovery");
+
+                            deviceList[i].Unacquire();
+                            deviceList[i].Dispose();
+                            deviceList[i] = null;
                         }
                     }
                 }
@@ -480,7 +483,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                 while (_detectPtt)
                 {
                     var bindStates = GenerateBindStateList();
-
 
                     for (var i = 0; i < bindStates.Count; i++)
                     {
@@ -509,34 +511,36 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                                 //check previous bindings
                                 var previousBind = bindStates[j];
 
-                                if (previousBind.IsActive)
+                                if (!previousBind.IsActive)
                                 {
-                                    if (previousBind.ModifierDevice == null && bindState.ModifierDevice != null)
+                                    continue;
+                                }
+
+                                if (previousBind.ModifierDevice == null && bindState.ModifierDevice != null)
+                                {
+                                    //set previous bind to off if previous bind Main == main or modifier of bindstate
+                                    if (previousBind.MainDevice.IsSameBind(bindState.MainDevice))
                                     {
-                                        //set previous bind to off if previous bind Main == main or modifier of bindstate
-                                        if (previousBind.MainDevice.IsSameBind(bindState.MainDevice))
-                                        {
-                                            previousBind.IsActive = false;
-                                            break;
-                                        }
-                                        if (previousBind.MainDevice.IsSameBind(bindState.ModifierDevice))
-                                        {
-                                            previousBind.IsActive = false;
-                                            break;
-                                        }
+                                        previousBind.IsActive = false;
+                                        break;
                                     }
-                                    else if (previousBind.ModifierDevice != null && bindState.ModifierDevice == null)
+                                    if (previousBind.MainDevice.IsSameBind(bindState.ModifierDevice))
                                     {
-                                        if (previousBind.MainDevice.IsSameBind(bindState.MainDevice))
-                                        {
-                                            bindState.IsActive = false;
-                                            break;
-                                        }
-                                        if (previousBind.ModifierDevice.IsSameBind(bindState.MainDevice))
-                                        {
-                                            bindState.IsActive = false;
-                                            break;
-                                        }
+                                        previousBind.IsActive = false;
+                                        break;
+                                    }
+                                }
+                                else if (previousBind.ModifierDevice != null && bindState.ModifierDevice == null)
+                                {
+                                    if (previousBind.MainDevice.IsSameBind(bindState.MainDevice))
+                                    {
+                                        bindState.IsActive = false;
+                                        break;
+                                    }
+                                    if (previousBind.ModifierDevice.IsSameBind(bindState.MainDevice))
+                                    {
+                                        bindState.IsActive = false;
+                                        break;
                                     }
                                 }
                             }
@@ -666,65 +670,67 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             foreach (var kpDevice in _inputDevices)
             {
                 var device = kpDevice.Value;
-                if (device != null &&
-                    !device.IsDisposed &&
-                    device.Information.InstanceGuid.Equals(inputDeviceBinding.InstanceGuid))
+                if (device == null ||
+                    device.IsDisposed ||
+                    !device.Information.InstanceGuid.Equals(inputDeviceBinding.InstanceGuid))
                 {
+                    continue;
+                }
 
-                    try
+                try
+                {
+                    if (device is Joystick)
                     {
-                        if (device is Joystick)
-                        {
-                            device.Poll();
-                            var state = (device as Joystick).GetCurrentState();
+                        device.Poll();
+                        var state = (device as Joystick).GetCurrentState();
 
-                            if (inputDeviceBinding.Button >= 128) //its a POV!
-                            {
-                                var pov = state.PointOfViewControllers;
-                                //-128 to get POV index
-                                return pov[inputDeviceBinding.Button - 128] == inputDeviceBinding.ButtonValue;
-                            }
-                            else
-                            {
-                                return state.Buttons[inputDeviceBinding.Button];
-                            }
-                        }
-                        else if (device is Keyboard)
+                        if (inputDeviceBinding.Button >= 128) //its a POV!
                         {
-                            var keyboard = device as Keyboard;
-                            keyboard.Poll();
-                            var state = keyboard.GetCurrentState();
-                            return
-                                state.IsPressed(state.AllKeys[inputDeviceBinding.Button]);
+                            var pov = state.PointOfViewControllers;
+                            //-128 to get POV index
+                            return pov[inputDeviceBinding.Button - 128] == inputDeviceBinding.ButtonValue;
                         }
-                        else if (device is Mouse)
+                        else
                         {
-                            device.Poll();
-                            var state = (device as Mouse).GetCurrentState();
-
-                            //just incase mouse changes number of buttons, like logitech can?
-                            if (inputDeviceBinding.Button < state.Buttons.Length)
-                            {
-                                return state.Buttons[inputDeviceBinding.Button];
-                            }
+                            return state.Buttons[inputDeviceBinding.Button];
                         }
                     }
-                    catch (Exception e)
+                    else if (device is Keyboard)
                     {
-                        Logger.Error(e, $"Failed to get current state of input device {device.Information.ProductName.Trim().Replace("\0", "")} " +
-                            $"(ID: {device.Information.ProductGuid}) while retrieving button state, ignoring until next restart/rediscovery");
+                        var keyboard = device as Keyboard;
+                        keyboard.Poll();
+                        var state = keyboard.GetCurrentState();
+                        return
+                            state.IsPressed(state.AllKeys[inputDeviceBinding.Button]);
+                    }
+                    else if (device is Mouse)
+                    {
+                        device.Poll();
+                        var state = (device as Mouse).GetCurrentState();
 
-                        MessageBox.Show(
-                            $"An error occurred while querying your {device.Information.ProductName.Trim().Replace("\0", "")} input device.\nThis could for example be caused by unplugging " +
-                            $"your joystick or disabling it in the Windows settings.\n\nAll controls bound to this input device will not work anymore until your restart SRS.",
-                            "Input device error",
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Error);
-
-                        device.Unacquire();
-                        device.Dispose();
+                        //just incase mouse changes number of buttons, like logitech can?
+                        if (inputDeviceBinding.Button < state.Buttons.Length)
+                        {
+                            return state.Buttons[inputDeviceBinding.Button];
+                        }
                     }
                 }
+                catch (Exception e)
+                {
+                    Logger.Error(e, $"Failed to get current state of input device {device.Information.ProductName.Trim().Replace("\0", "")} " +
+                        $"(ID: {device.Information.ProductGuid}) while retrieving button state, ignoring until next restart/rediscovery");
+
+                    MessageBox.Show(
+                        $"An error occurred while querying your {device.Information.ProductName.Trim().Replace("\0", "")} input device.\nThis could for example be caused by unplugging " +
+                        $"your joystick or disabling it in the Windows settings.\n\nAll controls bound to this input device will not work anymore until your restart SRS.",
+                        "Input device error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+
+                    device.Unacquire();
+                    device.Dispose();
+                }
+
             }
             return false;
         }
@@ -738,27 +744,29 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             //MIN + MAX bind numbers
             for (int i = (int)InputBinding.Intercom; i <= (int)InputBinding.RadioChannelDown; i++)
             {
-                if (currentInputProfile.ContainsKey((InputBinding)i))
+                if (!currentInputProfile.ContainsKey((InputBinding)i))
                 {
-                    var input = currentInputProfile[(InputBinding)i];
-                    //construct InputBindState
-
-                    var bindState = new InputBindState()
-                    {
-                        IsActive = false,
-                        MainDevice = input,
-                        MainDeviceState = false,
-                        ModifierDevice = null,
-                        ModifierState = false
-                    };
-
-                    if (currentInputProfile.ContainsKey((InputBinding)i + 100))
-                    {
-                        bindState.ModifierDevice = currentInputProfile[(InputBinding)i + 100];
-                    }
-
-                    bindStates.Add(bindState);
+                    continue;
                 }
+
+                var input = currentInputProfile[(InputBinding)i];
+                //construct InputBindState
+
+                var bindState = new InputBindState()
+                {
+                    IsActive = false,
+                    MainDevice = input,
+                    MainDeviceState = false,
+                    ModifierDevice = null,
+                    ModifierState = false
+                };
+
+                if (currentInputProfile.ContainsKey((InputBinding)i + 100))
+                {
+                    bindState.ModifierDevice = currentInputProfile[(InputBinding)i + 100];
+                }
+
+                bindStates.Add(bindState);
             }
 
             return bindStates;


### PR DESCRIPTION
Note: This commit covers the code in `Audio` and `Input`. I will wait upon judgement of this PR until I do the rest. Some people don't like refactoring commits where a relatively superficial benefit is realised across many files because it adds an indirection level to anyone using `git blame`. Since there are only a few committers on this project I don't think that will be an issue but will await a response.

These kinds of commits are also a bit messy to look at in a diff so recommendation is to just look at the modified files in VS and use the diff as a indicate on which methods to check over..

---------------------------------------------------------------------------

Replace usage of `if` statements at the beginning of methods that
determine whether the rest of the method is run on not with Guard
Clauses.

This reduces the amount of nesting in methods and improves
readibility since you don't need to skip to the bottom of a potentially
long method to determine if an `if` is a Guard Clause or if there is an
`else` down there somewhere.

Process for switching to a guard clause. Find a lop-sided `if` statement
where one of the branches doesn't exist or is vestigial (i.e. contains
no business logic). Then:

1. Invert the conditional
2. Add a new body that returns or continues (Depending on if we are in a
loop or not). Including Debug statements if they were in the old
vestigial branch
3. Remove the brackets around the old big branch
4. Unindent the old branch code