### PR TITLE
Remove NullReferenceException causing code

### DIFF
--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -321,15 +321,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                                     srClient.RadioInfo = updatedSrClient.RadioInfo;
                                                     srClient.RadioInfo.LastUpdate = DateTime.Now.Ticks;
                                                 }
-                                                else
-                                                {
-                                                    //radio update but null RadioInfo means no change
-                                                    if (serverMessage.MsgType ==
-                                                        NetworkMessage.MessageType.RADIO_UPDATE)
-                                                    {
-                                                        srClient.RadioInfo.LastUpdate = DateTime.Now.Ticks;
-                                                    }
-                                                }
 
 //                                                Logger.Info("Recevied Update Client: " + NetworkMessage.MessageType.UPDATE + " From: " +
 //                                                            srClient.Name + " Coalition: " +


### PR DESCRIPTION
Remove some code that will never succeed and is guaranteed to cause a
bunch of NullReferenceExceptions when connecting to a server.

They are caught in the Exception catch-all futher down but still show up
in the VS IDE output so stopping them happening in the first place
reduces noise a bit.