### PR TITLE
Add RadioInfo null check on update

### DIFF
--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -325,7 +325,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                                 {
                                                     //radio update but null RadioInfo means no change
                                                     if (serverMessage.MsgType ==
-                                                        NetworkMessage.MessageType.RADIO_UPDATE)
+                                                        NetworkMessage.MessageType.RADIO_UPDATE &&
+                                                        srClient.RadioInfo != null)
                                                     {
                                                         srClient.RadioInfo.LastUpdate = DateTime.Now.Ticks;
                                                     }


### PR DESCRIPTION
Add a null check on `srClient.RadioInfo` to remove NullReference exceptions when a
client first connects to a server.

This is the proper fix instead of #425 which was due to no not noticing the difference in `updatedSrClient` and `srClient`.