### PR TITLE
Switch connection status indicators to Bindings

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -103,7 +103,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         }
 
         public void StartEncoding(int mic, MMDevice speakers, string guid, InputDeviceManager inputManager,
-            IPAddress ipAddress, int port, MMDevice micOutput, VOIPConnectCallback voipConnectCallback)
+            IPAddress ipAddress, int port, MMDevice micOutput)
         {
             _stop = false;
 
@@ -240,7 +240,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                     _waveIn.WaveFormat = new WaveFormat(INPUT_SAMPLE_RATE, 16, 1);
 
                     _udpVoiceHandler =
-                        new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
+                        new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager);
                     var voiceSenderThread = new Thread(_udpVoiceHandler.Listen);
 
                     voiceSenderThread.Start();
@@ -263,7 +263,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             {
                 //no mic....
                 _udpVoiceHandler =
-                    new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager, voipConnectCallback);
+                    new UdpVoiceHandler(guid, ipAddress, port, _decoder, this, inputManager);
                 MessageHub.Instance.Subscribe<SRClient>(RemoveClientBuffer);
                 var voiceSenderThread = new Thread(_udpVoiceHandler.Listen);
                 voiceSenderThread.Start();

--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -280,6 +280,7 @@
     <Compile Include="Utils\DelegateCommand.cs" />
     <Compile Include="Utils\RadioHelper.cs" />
     <Compile Include="Utils\TransponderHelper.cs" />
+    <Compile Include="Utils\ValueConverters\ConnectionStatusImageConverter.cs" />
     <Compile Include="Utils\WPFElementHelper.cs" />
     <Page Include="UI\RadioOverlayWindow\TransponderPanel.xaml">
       <SubType>Designer</SubType>

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -74,7 +74,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private DispatcherTimer _updateTimer;
 
         public UdpVoiceHandler(string guid, IPAddress address, int port, OpusDecoder decoder, AudioManager audioManager,
-            InputDeviceManager inputManager, AudioManager.VOIPConnectCallback voipConnectCallback)
+            InputDeviceManager inputManager)
         {
             // _decoder = decoder;
             _audioManager = audioManager;
@@ -88,8 +88,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
             _inputManager = inputManager;
 
-            _voipConnectCallback = voipConnectCallback;
-
             _updateTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _updateTimer.Tick += UpdateVOIPStatus;
             _updateTimer.Start();
@@ -102,14 +100,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             //ping every 15 so after 35 seconds VoIP UDP issue
             if (diff.Seconds > 35)
             {
-                CallOnMainVOIPConnect(false);
+                _clientStateSingleton.IsVoipConnected = false;
             }
             else
             {
-                CallOnMainVOIPConnect(true);
+                _clientStateSingleton.IsVoipConnected = true;
             }
-
-
         }
 
         private void AudioEffectCheckTick()
@@ -249,7 +245,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             //stop UI Refreshing
             _updateTimer.Stop();
 
-            CallOnMainVOIPConnect(false);
+            _clientStateSingleton.IsVoipConnected = false;
         }
 
         public void StartTimer()
@@ -874,21 +870,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 }
             });
             thread.Start();
-        }
-
-        private void CallOnMainVOIPConnect(bool result, bool connectionError = false)
-        {
-            try
-            {
-                Application.Current.Dispatcher.Invoke(DispatcherPriority.Background,
-                    new ThreadStart(delegate
-                    {
-                        _voipConnectCallback(result, connectionError, $"{_address.ToString()}:{_port}");
-                    }));
-            }
-            catch (Exception ex)
-            {
-            }
         }
     }
 }

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -9,6 +9,7 @@
                       xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Client.UI"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:settings="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Client.Settings"
+                      xmlns:converters="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Client.Utils.ValueConverters"
                       Title="DCS-SRS Client"
                       Width="550"
                       Height="690"
@@ -260,27 +261,30 @@
                     <StackPanel Margin="0"
                                 HorizontalAlignment="Center"
                                 Orientation="Horizontal">
+                        <StackPanel.Resources>
+                            <converters:ConnectionStatusImageConverter x:Key="ConnectionStatusImageConverter"/>
+                        </StackPanel.Resources>
                         <Label HorizontalAlignment="Center" HorizontalContentAlignment="Center" Content="Server" />
                         <Image x:Name="ServerConnectionStatus"
-                               Source="/SR-ClientRadio;component/status-disconnected.png"
+                               Source="{Binding Path=ClientState.IsConnected, Converter={StaticResource ConnectionStatusImageConverter}}"
                                HorizontalAlignment="Center"
                                Height="26"
                                Margin="5,0,5,0" />
                         <Label HorizontalAlignment="Center" HorizontalContentAlignment="Center" Content="VOIP" />
                         <Image x:Name="VOIPConnectionStatus"
-                               Source="/SR-ClientRadio;component/status-disconnected.png"
+                               Source="{Binding Path=ClientState.IsVoipConnected, Converter={StaticResource ConnectionStatusImageConverter}}"
                                Height="26"
                                HorizontalAlignment="Center"
                                Margin="5,0,5,0" />
                         <Label HorizontalAlignment="Center" HorizontalContentAlignment="Center" Content="Game" />
                         <Image x:Name="GameConnectionStatus"
-                               Source="/SR-ClientRadio;component/status-disconnected.png"
+                               Source="{Binding Path=ClientState.IsGameConnected, Converter={StaticResource ConnectionStatusImageConverter}}"
                                Height="26"
                                HorizontalAlignment="Center" 
                                Margin="5,0,5,0" />
                         <Label HorizontalAlignment="Center" HorizontalContentAlignment="Center" Content="LotATC" />
                         <Image x:Name="LotATCConnectionStatus"
-                               Source="/SR-ClientRadio;component/status-disconnected.png"
+                               Source="{Binding Path=ClientState.IsLotATCConnected, Converter={StaticResource ConnectionStatusImageConverter}}"
                                Height="26"
                                HorizontalAlignment="Center" 
                                Margin="5,0,0,0" />

--- a/DCS-SR-Client/Utils/ValueConverters/ConnectionStatusImageConverter.cs
+++ b/DCS-SR-Client/Utils/ValueConverters/ConnectionStatusImageConverter.cs
@@ -1,0 +1,31 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.UI;
+using System;
+using System.Windows.Data;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Utils.ValueConverters
+{
+    class ConnectionStatusImageConverter : IValueConverter
+    {
+		private ClientStateSingleton _clientState { get; } = ClientStateSingleton.Instance;
+
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			bool connected = (bool)value;
+			if (connected) {
+				return Images.IconConnected;
+			} else if (_clientState.IsConnectionErrored)
+			{
+				return Images.IconDisconnectedError;
+			} else
+			{
+				return Images.IconDisconnected;
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}


### PR DESCRIPTION
Switch all the connection status image indicators to use Bindings
instead of being set in code.

As part of thise we make the ClientStateSingleton the sole source of
truth for connection status which means added a few new members.

This lets us get rid of some disparate UI update code, including a UI
callback, which overall simplifies the code and is another step in
de-coupling the UI from the application business logic.