### PR TITLE
Extract to AudioInputSingleton Class

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -68,6 +68,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         public float SpeakerMax { get; set; } = -100;
 
         private ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
+        private AudioInputSingleton _audioInputSingleton = AudioInputSingleton.Instance;
         private WasapiOut _micWaveOut;
         private BufferedWaveProvider _micWaveOutBuffer;
 
@@ -223,7 +224,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                 }
             }
 
-            if (_clientStateSingleton.MicrophoneAvailable)
+            if (_audioInputSingleton.MicrophoneAvailable)
             {
                 try
                 {

--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Settings\RadioChannels\MockPresetChannelsStore.cs" />
     <Compile Include="Singletons\ClientStateSingleton.cs" />
     <Compile Include="Singletons\ConnectedClientsSingleton.cs" />
+    <Compile Include="Singletons\AudioInputSingleton.cs" />
     <Compile Include="UI\RadioOverlayWindow\TransponderPanel.xaml.cs">
       <DependentUpon>TransponderPanel.xaml</DependentUpon>
     </Compile>
@@ -281,6 +282,7 @@
     <Compile Include="Utils\RadioHelper.cs" />
     <Compile Include="Utils\TransponderHelper.cs" />
     <Compile Include="Utils\ValueConverters\ConnectionStatusImageConverter.cs" />
+    <Compile Include="Utils\ValueConverters\MicAvailabilityTooltipConverter.cs" />
     <Compile Include="Utils\WPFElementHelper.cs" />
     <Page Include="UI\RadioOverlayWindow\TransponderPanel.xaml">
       <SubType>Designer</SubType>

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -14,7 +14,6 @@ using System.Windows.Threading;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons;
-using Ciribob.DCS.SimpleRadio.Standalone.Client.UI;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
@@ -34,7 +33,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private readonly IPAddress _address;
         private readonly AudioManager _audioManager;
         private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
-
+        private readonly AudioInputSingleton _audioInputSingleton = AudioInputSingleton.Instance;
 
         private readonly BlockingCollection<byte[]> _encodedAudio = new BlockingCollection<byte[]>();
         private readonly string _guid;
@@ -726,7 +725,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             if (_ready
                 && _listener != null
                 && _clientStateSingleton.DcsPlayerRadioInfo.IsCurrent()
-                && _clientStateSingleton.MicrophoneAvailable
+                && _audioInputSingleton.MicrophoneAvailable
                 && (bytes != null)
                 && (transmittingRadios = PTTPressed(out sendingOn)).Count >0 )
                 //can only send if DCS is connected

--- a/DCS-SR-Client/Singletons/AudioInputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioInputSingleton.cs
@@ -1,0 +1,102 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow;
+using NAudio.Wave;
+using NLog;
+using System;
+using System.Collections.Generic;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
+{
+    public class AudioInputSingleton
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        #region Singleton Definition
+        private static volatile AudioInputSingleton _instance;
+        private static object _lock = new Object();
+
+        public static AudioInputSingleton Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_instance == null)
+                            _instance = new AudioInputSingleton();
+                    }
+                }
+
+                return _instance;
+            }
+        }
+        #endregion
+
+        #region Instance Definition
+
+        public List<AudioDeviceListItem> InputAudioDevices { get; }
+
+        public AudioDeviceListItem SelectedAudioInput { get; set; }
+
+        // Indicates whether a valid microphone is available - deactivating audio input controls and transmissions otherwise
+        public bool MicrophoneAvailable { get; }
+
+        private AudioInputSingleton()
+        {
+            InputAudioDevices = BuildAudioInputs();
+            MicrophoneAvailable = DetectMicrophone();
+        }
+
+        private List<AudioDeviceListItem> BuildAudioInputs()
+        {
+            Logger.Info("Audio Input - Saved ID " +
+            GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).StringValue);
+
+            var inputs = new List<AudioDeviceListItem>();
+
+            if (WaveIn.DeviceCount == 0)
+            {
+                Logger.Info("Audio Input - No audio input devices available, disabling mic preview");
+                return inputs;
+            }
+
+            Logger.Info("Audio Input - " + WaveIn.DeviceCount.ToString() + " audio input devices available, configuring as usual");
+
+            inputs.Add(new AudioDeviceListItem()
+            {
+                Text = "Default Microphone",
+                Value = null
+            });
+            SelectedAudioInput = inputs[0];
+
+            for (var i = 0; i < WaveIn.DeviceCount; i++)
+            {
+
+                var item = WaveIn.GetCapabilities(i);
+                inputs.Add(new AudioDeviceListItem()
+                {
+                    Text = item.ProductName,
+                    Value = item
+                });
+
+                Logger.Info("Audio Input - " + item.ProductName + " " + item.ProductGuid.ToString() + " - Name GUID" +
+                            item.NameGuid + " - CHN:" + item.Channels);
+
+                if (item.ProductName.Trim().StartsWith(GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).StringValue.Trim()))
+                {
+                    SelectedAudioInput = inputs[i + 1];
+                    Logger.Info("Audio Input - Found Saved ");
+                }
+            }
+
+            return inputs;
+        }
+
+        private bool DetectMicrophone()
+        {
+            return (WaveIn.DeviceCount > 0);
+        }
+        #endregion
+    }
+}

--- a/DCS-SR-Client/Singletons/ClientStateSingleton.cs
+++ b/DCS-SR-Client/Singletons/ClientStateSingleton.cs
@@ -36,9 +36,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         //store radio channels here?
         public PresetChannelsViewModel[] FixedChannels { get; }
 
-        // Indicates whether a valid microphone is available - deactivating audio input controls and transmissions otherwise
-        public bool MicrophoneAvailable { get; set; }
-
         public long LastSent { get; set; }
 
         private static readonly DispatcherTimer _timer = new DispatcherTimer();
@@ -120,8 +117,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 FixedChannels[i] = new PresetChannelsViewModel(new FilePresetChannelsStore(), i + 1);
             }
-
-            MicrophoneAvailable = true;
 
             LastSent = 0;
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -18,6 +18,9 @@
                       mc:Ignorable="d">
 
     <TabControl x:Name="TabControl">
+        <TabControl.Resources>
+            <converters:MicAvailabilityTooltipConverter x:Key="MicAvailabilityTooltipConverter"/>
+        </TabControl.Resources>
         <TabItem Header="General">
             <GroupBox x:Name="GroupBox"
                       Margin="5"
@@ -29,7 +32,10 @@
                     <ComboBox x:Name="Mic"
                               Width="250"
                               HorizontalAlignment="Center"
-                              VerticalAlignment="Top" />
+                              VerticalAlignment="Top"
+                              ItemsSource="{Binding Path=AudioInput.InputAudioDevices}"
+                              SelectedItem="{Binding Path=AudioInput.SelectedAudioInput, Mode=TwoWay}"
+                              ToolTip="{Binding Path=AudioInput.MicrophoneAvailable, Converter={StaticResource MicAvailabilityTooltipConverter}}" />
                     <StackPanel Margin="0"
                                 HorizontalAlignment="Center"
                                 Orientation="Horizontal">
@@ -39,7 +45,8 @@
                                      Margin="10,10,0,0"
                                      Value="-100"
                                      Maximum="18"
-                                     Minimum="-100"  />
+                                     Minimum="-100"
+                                     ToolTip="{Binding Path=AudioInput.MicrophoneAvailable, Converter={StaticResource MicAvailabilityTooltipConverter}}" />
                     </StackPanel>
 
                     <StackPanel Margin="0"
@@ -53,8 +60,9 @@
                             Click="PreviewAudio"
                             Content="Audio Preview"
                             Style="{DynamicResource SquareButtonStyle}"
-                            ToolTipService.ShowOnDisabled="True" />
-
+                            ToolTipService.ShowOnDisabled="True"
+                            IsEnabled="{Binding AudioInput.MicrophoneAvailable}"
+                            ToolTip="{Binding Path=AudioInput.MicrophoneAvailable, Converter={StaticResource MicAvailabilityTooltipConverter}}" />
 
                     <Label x:Name="SpeakerLabel"
                            HorizontalAlignment="Center"
@@ -151,7 +159,8 @@
                                 HorizontalAlignment="Center"
                                 Command="{Binding Path=ConnectCommand}"
                                 Content="Connect"
-                                Style="{DynamicResource SquareButtonStyle}" />
+                                Style="{DynamicResource SquareButtonStyle}"
+                                ToolTip="{Binding Path=AudioInput.MicrophoneAvailable, Converter={StaticResource MicAvailabilityTooltipConverter}}" />
                         <Button x:Name="ToggleServerSettings"
                                 Width="125"
                                 Margin="0,10,0,0"

--- a/DCS-SR-Client/UI/ToolTips.cs
+++ b/DCS-SR-Client/UI/ToolTips.cs
@@ -8,7 +8,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         public static ToolTip ExternalAWACSMode;
         public static ToolTip ExternalAWACSModeName;
         public static ToolTip ExternalAWACSModePassword;
-        public static ToolTip NoMicAvailable;
 
         public static void Init()
         {
@@ -66,26 +65,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             });
 
             ExternalAWACSModePassword.Content = externalAWACSModePasswordContent;
-
-
-            NoMicAvailable = new ToolTip();
-            StackPanel noMicAvailableContent = new StackPanel();
-
-            noMicAvailableContent.Children.Add(new TextBlock
-            {
-                Text = "No microphone available",
-                FontWeight = FontWeights.Bold
-            });
-            noMicAvailableContent.Children.Add(new TextBlock
-            {
-                Text = "No valid microphone is available - others will not be able to hear you."
-            });
-            noMicAvailableContent.Children.Add(new TextBlock
-            {
-                Text = "You can still use SRS to listen to radio calls, but will not be able to transmit anything yourself."
-            });
-
-            NoMicAvailable.Content = noMicAvailableContent;
         }
     }
 }

--- a/DCS-SR-Client/Utils/ValueConverters/MicAvailabilityTooltipConverter.cs
+++ b/DCS-SR-Client/Utils/ValueConverters/MicAvailabilityTooltipConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Utils.ValueConverters
+{
+    class MicAvailabilityTooltipConverter : IValueConverter
+    {
+		private static ToolTip _noMicAvailable = BuildTooltip();
+
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			bool micAvailable = (bool)value;
+			if (micAvailable)
+			{
+				return null;
+			}
+			else
+			{
+				return _noMicAvailable;
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+
+		private static ToolTip BuildTooltip()
+		{
+			var NoMicAvailable = new ToolTip();
+			StackPanel noMicAvailableContent = new StackPanel();
+
+			noMicAvailableContent.Children.Add(new TextBlock
+			{
+				Text = "No microphone available",
+				FontWeight = FontWeights.Bold
+			});
+			noMicAvailableContent.Children.Add(new TextBlock
+			{
+				Text = "No valid microphone is available - others will not be able to hear you."
+			});
+			noMicAvailableContent.Children.Add(new TextBlock
+			{
+				Text = "You can still use SRS to listen to radio calls, but will not be able to transmit anything yourself."
+			});
+
+			NoMicAvailable.Content = noMicAvailableContent;
+			return NoMicAvailable;
+		}
+	}
+}


### PR DESCRIPTION
Create a new `AudionInputSingleton` that acts as the source of truth for
the audio input devices available on the machine SRS is running on and
extract code to this new class.

All checks for microphone availability have been switched from
`ClientStateSingleton` to this new class. This reduces the number of
responsibilities `ClientStateSingleton` has to deal with and makes it
more network client oriented.

As part of this change we will switch the UI elements that rely on this
information to use bindings that access this new class. This gets rid of
more coupling between the business logic and the UI.

Since the availability of audio input devices is checked once at
application startup there is no chance of chance so we don't need to
implement the `INotifyPropertyChanged` interface as we did  on the other
Singleton classes.