### PR TITLE
Extract to AudioOutputSingleton Class

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Settings\Favourites\MockFavouriteServerStore.cs" />
     <Compile Include="Settings\RadioChannels\FilePresetChannelsStore.cs" />
     <Compile Include="Settings\RadioChannels\MockPresetChannelsStore.cs" />
+    <Compile Include="Singletons\AudioOutputSingleton.cs" />
     <Compile Include="Singletons\ClientStateSingleton.cs" />
     <Compile Include="Singletons\ConnectedClientsSingleton.cs" />
     <Compile Include="Singletons\AudioInputSingleton.cs" />

--- a/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
@@ -1,0 +1,155 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow;
+using NAudio.CoreAudioApi;
+using NAudio.Dmo;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
+{
+    public class AudioOutputSingleton
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        #region Singleton Definition
+        private static volatile AudioOutputSingleton _instance;
+        private static object _lock = new Object();
+
+        public static AudioOutputSingleton Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_instance == null)
+                            _instance = new AudioOutputSingleton();
+                    }
+                }
+
+                return _instance;
+            }
+        }
+        #endregion
+
+        #region Instance Definition
+
+        public List<AudioDeviceListItem> OutputAudioDevices { get; }
+        public AudioDeviceListItem SelectedAudioOutput { get; set; }
+
+        public List<AudioDeviceListItem> MicOutputAudioDevices { get; }
+        public AudioDeviceListItem SelectedMicAudioOutput { get; set; }
+
+
+        // Version of Windows without bundled multimedia stuff as part of European anti-trust settlement
+        // https://support.microsoft.com/en-us/help/11529/what-is-a-windows-7-n-edition
+        public bool WindowsN { get; set; }
+
+        private AudioOutputSingleton()
+        {
+            WindowsN = DetectWindowsN();
+            OutputAudioDevices = BuildNormalAudioOutputs();
+            MicOutputAudioDevices = BuildMicAudioOutputs();
+        }
+
+        private List<AudioDeviceListItem> BuildNormalAudioOutputs()
+        {
+            Logger.Info("Building Normal Audio Outputs");
+            Logger.Info("Audio Output - Saved ID " +
+                         GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId).RawValue);
+
+            return BuildAudioOutputs("Default Speakers", false);
+        }
+
+        private List<AudioDeviceListItem> BuildMicAudioOutputs()
+        {
+            Logger.Info("Building Microphone Audio Outputs");
+            Logger.Info("Mic Audio Output - Saved ID " +
+                                   GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue);
+
+            return BuildAudioOutputs("NO MIC OUTPUT / PASSTHROUGH", true);
+        }
+
+        private List<AudioDeviceListItem> BuildAudioOutputs(string defaultItemText, bool micOutput)
+        {
+            var outputs = new List<AudioDeviceListItem>
+            {
+                new AudioDeviceListItem()
+                {
+                    Text = defaultItemText,
+                    Value = null
+                }
+            };
+
+            if (micOutput)
+            {
+                SelectedMicAudioOutput = outputs[0];
+            } else
+            {
+                SelectedAudioOutput = outputs[0];
+            }
+
+            var enumerator = new MMDeviceEnumerator();
+            var outputDeviceList = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+
+            var i = 1;
+            foreach (var device in outputDeviceList)
+            {
+                try
+                {
+                    Logger.Info("Audio Output - " + device.DeviceFriendlyName + " " + device.ID + " CHN:" +
+                            device.AudioClient.MixFormat.Channels + " Rate:" +
+                            device.AudioClient.MixFormat.SampleRate.ToString());
+
+                    outputs.Add(new AudioDeviceListItem()
+                    {
+                        Text = device.FriendlyName,
+                        Value = device
+                    });
+
+                    if (device.ID == GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue)
+                    {
+                        if (micOutput)
+                        {
+                            SelectedMicAudioOutput = outputs[i];
+                        }
+                        else
+                        {
+                            SelectedAudioOutput = outputs[i];
+                        }
+                    }
+
+                    i++;
+
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Audio Output - Error processing device - device skipped");
+                }
+            }
+
+            return outputs;
+        }
+
+        private bool DetectWindowsN()
+        {
+            try
+            {
+                var dmoResampler = new DmoResampler();
+                dmoResampler.Dispose();
+                return false;
+            }
+            catch (Exception)
+            {
+                Logger.Warn("Windows N Detected - using inbuilt resampler");
+                return true;
+            }
+        }
+        #endregion
+    }
+}

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -73,11 +73,15 @@
                         <ComboBox x:Name="Speakers"
                                   Width="200"
                                   HorizontalAlignment="Center"
-                                  VerticalAlignment="Top" Margin="0,0,5,0" />
+                                  VerticalAlignment="Top" Margin="0,0,5,0"
+                                  ItemsSource="{Binding Path=AudioOutput.OutputAudioDevices}"
+                                  SelectedItem="{Binding Path=AudioOutput.SelectedAudioOutput, Mode=TwoWay}" />
                         <ComboBox x:Name="MicOutput"
                                   Width="200"
                                   HorizontalAlignment="Center"
-                                  VerticalAlignment="Top" Margin="5,0,0,0" />
+                                  VerticalAlignment="Top" Margin="5,0,0,0"
+                                  ItemsSource="{Binding Path=AudioOutput.MicOutputAudioDevices}"
+                                  SelectedItem="{Binding Path=AudioOutput.SelectedMicAudioOutput, Mode=TwoWay}" />
                     </StackPanel>
 
 


### PR DESCRIPTION
Create a new `AudionOutputSingleton` that acts as the source of truth
for the audio output devices available on the machine SRS is running on
and extract code to this new class.

As part of this change we will switch the UI elements that rely on this
information to use bindings that access this new class. This gets rid of
more coupling between the business logic and the UI.

We are also making this class the source of truth as to whether the OS
is WindowsN or not. It could be argued that this is a
`ClientStateSingleton` responsibility but since this is only used for
Audio Output related functions (and only two places) I think this class
is the correct place for that.

Since the availability of audio output devices is checked once at
application startup there is no chance of change so we don't need to
implement the `INotifyPropertyChanged` interface.