### PR TITLE
Simplify EAM field enabling / disabling

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Utils\DelegateCommand.cs" />
     <Compile Include="Utils\RadioHelper.cs" />
     <Compile Include="Utils\TransponderHelper.cs" />
+    <Compile Include="Utils\ValueConverters\BooleanInverterConverter.cs" />
     <Compile Include="Utils\ValueConverters\ConnectionStatusImageConverter.cs" />
     <Compile Include="Utils\ValueConverters\MicAvailabilityTooltipConverter.cs" />
     <Compile Include="Utils\WPFElementHelper.cs" />

--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -72,7 +72,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         public void ConnectExternalAWACSMode(string password, ExternalAWACSModeConnectCallback callback)
         {
-            if (_clientStateSingleton.InExternalAWACSMode)
+            if (_clientStateSingleton.ExternalAWACSModelSelected)
             {
                 return;
             }
@@ -97,7 +97,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         public void DisconnectExternalAWACSMode()
         {
-            if (!_clientStateSingleton.InExternalAWACSMode || _radioDCSSync == null)
+            if (!_clientStateSingleton.ExternalAWACSModelSelected || _radioDCSSync == null)
             {
                 return;
             }
@@ -355,7 +355,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 //                                                        serverMessage.Client.Coalition);
                                         }
 
-                                        if (_clientStateSingleton.InExternalAWACSMode &&
+                                        if (_clientStateSingleton.ExternalAWACSModelSelected &&
                                             !_serverSettings.GetSettingAsBool(Common.Setting.ServerSettingsKeys.EXTERNAL_AWACS_MODE))
                                         {
                                             DisconnectExternalAWACSMode();
@@ -405,7 +405,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         //add server settings
                                         _serverSettings.Decode(serverMessage.ServerSettings);
 
-                                        if (_clientStateSingleton.InExternalAWACSMode &&
+                                        if (_clientStateSingleton.ExternalAWACSModelSelected &&
                                             !_serverSettings.GetSettingAsBool(Common.Setting.ServerSettingsKeys.EXTERNAL_AWACS_MODE))
                                         {
                                             DisconnectExternalAWACSMode();
@@ -421,7 +421,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         _serverSettings.Decode(serverMessage.ServerSettings);
                                         ServerVersion = serverMessage.Version;
 
-                                        if (_clientStateSingleton.InExternalAWACSMode &&
+                                        if (_clientStateSingleton.ExternalAWACSModelSelected &&
                                             !_serverSettings.GetSettingAsBool(Common.Setting.ServerSettingsKeys.EXTERNAL_AWACS_MODE))
                                         {
                                             DisconnectExternalAWACSMode();

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -197,6 +197,9 @@
                     <StackPanel Margin="0"
                                 HorizontalAlignment="Center"
                                 Orientation="Horizontal">
+                        <StackPanel.Resources>
+                            <converters:BooleanInverterConverter x:Key="BooleanInverterConverter"/>
+                        </StackPanel.Resources>
                         <StackPanel Margin="0"
                                 HorizontalAlignment="Center"
                                 Orientation="Vertical">
@@ -205,13 +208,13 @@
                                 HorizontalContentAlignment="Center"
                                 Margin="0,10,10,0"
                                 Content="EAM coalition password"
-                                IsEnabled="False" />
+                                IsEnabled="{Binding Path=ClientState.ExternalAWACSModeConnected, Converter={StaticResource BooleanInverterConverter}}" />
                             <PasswordBox x:Name="ExternalAWACSModePassword"
-                                 Width="200"
-                                 Height="23"
-                                 Margin="0,0,10,0"
-                                 HorizontalAlignment="Center"
-                                 IsEnabled="False" />
+                                Width="200"
+                                Height="23"
+                                Margin="0,0,10,0"
+                                HorizontalAlignment="Center"
+                                IsEnabled="{Binding Path=ClientState.ExternalAWACSModeConnected, Converter={StaticResource BooleanInverterConverter}}" />
                         </StackPanel>
                         <StackPanel Margin="0"
                                 HorizontalAlignment="Center"
@@ -221,7 +224,7 @@
                                 HorizontalContentAlignment="Center"
                                 Margin="0,10,0,0"
                                 Content="EAM name"
-                                IsEnabled="False" />
+                                 IsEnabled="{Binding Path=ClientState.ExternalAWACSModeConnected, Converter={StaticResource BooleanInverterConverter}}" />
                             <TextBox x:Name="ExternalAWACSModeName"
                                  Width="200"
                                  Height="23"
@@ -229,7 +232,7 @@
                                  MaxLines="1"
                                  TextWrapping="Wrap"
                                  HorizontalAlignment="Center"
-                                 IsEnabled="False" />
+                                 IsEnabled="{Binding Path=ClientState.ExternalAWACSModeConnected, Converter={StaticResource BooleanInverterConverter}}" />
                         </StackPanel>
                     </StackPanel>
                     <StackPanel Margin="0"

--- a/DCS-SR-Client/Utils/ValueConverters/BooleanInverterConverter.cs
+++ b/DCS-SR-Client/Utils/ValueConverters/BooleanInverterConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Windows.Data;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Utils.ValueConverters
+{
+	class BooleanInverterConverter : IValueConverter
+    {
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			return !(bool)value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}


### PR DESCRIPTION
Simplify the code surrounding the enabling and disabling of the
ExternalAWACSMode username and password fields.

This means moving them to a data-binding on the ClientStateSingleton
and removing all the code in the mainwindow.xaml.cs that was manually
updating the enabled setting.

Doing so reduces a lot of duplication and removes the RedrawUI callback.