### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: windows-2019
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+
+    - name: Restore NuGet packages
+      run: nuget restore
+
+    - name: Build
+      run: msbuild /p:Configuration=Release /p:Platform=x64 /p:SourceLinkCreate=false
+
+    - name: Archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: DCS-SimpleRadioStandalone
+        path: install-build
+
+    - name: Setup VSTest
+      uses: Malcolmnixon/Setup-VSTest@v3
+
+    - name: VSTest DCS-SR-CommonTests
+      run: VSTest.Console DCS-SR-CommonTests\bin\x64\Release\DCS-SR-CommonTests.dll


### PR DESCRIPTION
Builds projects and runs test for every commit and pull request. The resulting output `install-build` is available as an artifact of each build and can be downloaded for local testing.