### PR TITLE
Allow device changes while connected

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -115,13 +115,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             }
             else 
             {
-                speakers = (MMDevice)_audioOutputSingleton.SelectedAudioOutput.Value;
+                speakers = _audioOutputSingleton.SelectedAudioOutput.Value;
             }
 
             MMDevice micOutput = null;
             if (_audioOutputSingleton.SelectedMicAudioOutput.Value != null)
             {
-                micOutput = (MMDevice)_audioOutputSingleton.SelectedMicAudioOutput.Value;
+                micOutput = _audioOutputSingleton.SelectedMicAudioOutput.Value;
             }
 
             try
@@ -291,6 +291,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
         {
             Logger.Error("Recording Stopped");
         }
+        
         Stopwatch _stopwatch = new Stopwatch();
        
         private void WasapiCaptureOnDataAvailable(object sender, WaveInEventArgs e)

--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Settings\Favourites\MockFavouriteServerStore.cs" />
     <Compile Include="Settings\RadioChannels\FilePresetChannelsStore.cs" />
     <Compile Include="Settings\RadioChannels\MockPresetChannelsStore.cs" />
+    <Compile Include="Singletons\AudioDevicesBase.cs" />
     <Compile Include="Singletons\AudioOutputSingleton.cs" />
     <Compile Include="Singletons\ClientStateSingleton.cs" />
     <Compile Include="Singletons\ConnectedClientsSingleton.cs" />

--- a/DCS-SR-Client/Singletons/AudioDevicesBase.cs
+++ b/DCS-SR-Client/Singletons/AudioDevicesBase.cs
@@ -1,7 +1,9 @@
-﻿using NAudio.CoreAudioApi;
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow;
+using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
 using NLog;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -29,6 +31,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         /// Override this method to react to changes in the device list.
         /// </summary>
         protected abstract void OnDeviceEnumChanged(string deviceId);
+
+
+        protected void DisposeListMembers(List<AudioDeviceListItem> list)
+        {
+            foreach (var item in list)
+            {
+                item.Dispose();
+            }
+        }
 
         public void Dispose()
         {

--- a/DCS-SR-Client/Singletons/AudioDevicesBase.cs
+++ b/DCS-SR-Client/Singletons/AudioDevicesBase.cs
@@ -1,0 +1,82 @@
+﻿using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+using NLog;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
+{
+    public abstract class AudioDevicesBase : IMMNotificationClient, IDisposable, INotifyPropertyChanged
+    {
+        private bool _disposed = false;
+        private readonly Logger _logger;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected MMDeviceEnumerator DeviceEnum { get; private set; }
+
+        protected AudioDevicesBase(Logger logger)
+        {
+            DeviceEnum = new MMDeviceEnumerator();
+            DeviceEnum.RegisterEndpointNotificationCallback(this);
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Override this method to react to changes in the device list.
+        /// </summary>
+        protected abstract void OnDeviceEnumChanged(string deviceId);
+
+        public void Dispose()
+        {
+            Debug.Assert(!_disposed);
+            if (_disposed) { return; }
+
+            DeviceEnum?.UnregisterEndpointNotificationCallback(this);
+            DeviceEnum?.Dispose();
+            DeviceEnum = null;
+
+            _disposed = true;
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #region IMMNotificationClient
+        // implement explicitly to reduce surface area of inheriting objects
+
+        void IMMNotificationClient.OnDeviceStateChanged([MarshalAs(UnmanagedType.LPWStr)] string deviceId, [MarshalAs(UnmanagedType.I4)] DeviceState newState)
+        {
+            _logger.Info("Device {deviceId} State Changed to {newState}, rebuilding device list", deviceId, newState);
+            OnDeviceEnumChanged(deviceId);
+        }
+
+        // The added and removed handlers don't seem to fire for me, but as the logic is the same I'm going to leave these handlers here.
+        void IMMNotificationClient.OnDeviceAdded([MarshalAs(UnmanagedType.LPWStr)] string deviceId)
+        {
+            _logger.Info("Device {deviceId} Added, rebuilding device list", deviceId);
+            OnDeviceEnumChanged(deviceId);
+        }
+
+        void IMMNotificationClient.OnDeviceRemoved([MarshalAs(UnmanagedType.LPWStr)] string deviceId)
+        {
+            _logger.Info("Device {deviceId} Removed, rebuilding device list.", deviceId);
+            OnDeviceEnumChanged(deviceId);
+        }
+
+        void IMMNotificationClient.OnDefaultDeviceChanged(DataFlow flow, Role role, [MarshalAs(UnmanagedType.LPWStr)] string defaultDeviceId)
+        {
+        }
+
+        void IMMNotificationClient.OnPropertyValueChanged([MarshalAs(UnmanagedType.LPWStr)] string pwstrDeviceId, PropertyKey key)
+        {
+        }
+
+        #endregion
+    }
+}

--- a/DCS-SR-Client/Singletons/AudioInputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioInputSingleton.cs
@@ -57,6 +57,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 _selectedAudioInput = value;
                 OnPropertyChanged();
+                OnSelectedInputChanged();
             }
         }
 
@@ -130,8 +131,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             return inputs;
         }
 
+        public event EventHandler SelectedInputChanged;
+        protected void OnSelectedInputChanged()
+        {
+            SelectedInputChanged?.Invoke(this, EventArgs.Empty);
+        }
+
         #endregion
 
-       
+
     }
 }

--- a/DCS-SR-Client/Singletons/AudioInputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioInputSingleton.cs
@@ -71,6 +71,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         protected override void OnDeviceEnumChanged(string deviceId)
         {
             //react naiively to any event to start, we can work on logic to reduce unnecessary churn later
+            DisposeListMembers(InputAudioDevices);
             InputAudioDevices = BuildAudioInputs();
         }
 

--- a/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
@@ -64,6 +64,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 _micOutputAudioDevices = value;
                 OnPropertyChanged();
+                OnSelectedOutputChanged();
             }
         }
         public AudioDeviceListItem SelectedMicAudioOutput
@@ -72,6 +73,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 _selectedMicAudioOutput = value;
                 OnPropertyChanged();
+                OnSelectedOutputChanged();
             }
         }
 
@@ -192,6 +194,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
                 Logger.Warn("Windows N Detected - using inbuilt resampler");
                 return true;
             }
+        }
+
+
+        public event EventHandler SelectedOutputChanged;
+        protected void OnSelectedOutputChanged()
+        {
+            SelectedOutputChanged?.Invoke(this, EventArgs.Empty);
         }
 
         #endregion

--- a/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
@@ -89,6 +89,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
 
         protected override void OnDeviceEnumChanged(string deviceId)
         {
+            // we need to dispose of the MMDevice objects contained in the lists, or we get com exceptions on hardware refresh
+            DisposeListMembers(OutputAudioDevices);
+            DisposeListMembers(MicOutputAudioDevices);
+
             OutputAudioDevices = BuildNormalAudioOutputs();
             MicOutputAudioDevices = BuildMicAudioOutputs();
         }

--- a/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
@@ -55,6 +55,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 _selectedAudioOutput = value;
                 OnPropertyChanged();
+                OnSelectedOutputChanged();
             }
         }
 
@@ -64,7 +65,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             {
                 _micOutputAudioDevices = value;
                 OnPropertyChanged();
-                OnSelectedOutputChanged();
             }
         }
         public AudioDeviceListItem SelectedMicAudioOutput

--- a/DCS-SR-Client/UI/ClientWindow/AudioDeviceListItem.cs
+++ b/DCS-SR-Client/UI/ClientWindow/AudioDeviceListItem.cs
@@ -1,15 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using NAudio.CoreAudioApi;
+using System;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow
 {
-    public class AudioDeviceListItem
+    public class AudioDeviceListItem: IDisposable
     {
         public string Text { get; set; }
-        public object Value { get; set; }
+        public MMDevice Value { get; set; }
+
+        public void Dispose()
+        {
+            Value?.Dispose();
+        }
 
         public override string ToString()
         {

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -62,6 +62,7 @@
                             Style="{DynamicResource SquareButtonStyle}"
                             ToolTipService.ShowOnDisabled="True"
                             IsEnabled="{Binding AudioInput.MicrophoneAvailable}"
+                            IsEnabledChanged="Preview_IsEnabledChanged"
                             ToolTip="{Binding Path=AudioInput.MicrophoneAvailable, Converter={StaticResource MicAvailabilityTooltipConverter}}" />
 
                     <Label x:Name="SpeakerLabel"

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -1111,6 +1111,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             _dcsAutoConnectListener?.Stop();
             _dcsAutoConnectListener = null;
+
+            AudioInput?.Dispose();
         }
 
         protected override void OnStateChanged(EventArgs e)

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -177,47 +177,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             _dcsAutoConnectListener = new DCSAutoConnectHandler(AutoConnect);
 
-            AudioOutput.SelectedOutputChanged += Audio_SelectedDeviceChanged;
-            AudioInput.SelectedInputChanged += Audio_SelectedDeviceChanged;
-
             _updateTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
             _updateTimer.Tick += UpdatePlayerLocationAndVUMeters;
             _updateTimer.Start();
 
-        }
-
-        public static void InvokeIfNecessary(Action action)
-        {
-            if (Thread.CurrentThread == Application.Current.Dispatcher.Thread)
-                action();
-            else
-            {
-                Application.Current.Dispatcher.Invoke(action);
-            }
-        }
-
-        private void Audio_SelectedDeviceChanged(object sender, EventArgs e)
-        {
-            //InvokeIfNecessary(() => { //This may be called from a background thread
-            //    // Allow users to change Mic/output device without also requiring them to disconnect/reconnect
-            //    if (ClientState.IsConnected)
-            //    {
-            //        var connectEAM = ClientState.ExternalAWACSModeConnected;
-            //        if (connectEAM)
-            //        {
-            //            // Disconnect first
-            //            _client.DisconnectExternalAWACSMode();
-            //        }
-
-            //        Stop();
-            //        Connect();
-
-            //        if (connectEAM) //connected when we changed device
-            //        {
-            //            //TODO: Reconnect EAM
-            //        }
-            //    }
-            //});
         }
 
         private void CheckWindowVisibility()

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -1113,6 +1113,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _dcsAutoConnectListener = null;
 
             AudioInput?.Dispose();
+            AudioOutput?.Dispose();
         }
 
         protected override void OnStateChanged(EventArgs e)

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -984,7 +984,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 }
                 else
                 {
-                    var input = ((MMDevice)AudioInput.SelectedAudioInput.Value).ID;
+                    var input = AudioInput.SelectedAudioInput.Value.ID;
                     _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, input);
                 }
             }
@@ -995,14 +995,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             }
             else
             {
-                var output = (MMDevice)AudioOutput.SelectedAudioOutput.Value;
+                var output = AudioOutput.SelectedAudioOutput.Value;
                 _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId, output.ID);
             }
 
             //check if we have optional output
             if (AudioOutput.SelectedMicAudioOutput.Value != null)
             {
-                var micOutput = (MMDevice)AudioOutput.SelectedMicAudioOutput.Value;
+                var micOutput = AudioOutput.SelectedMicAudioOutput.Value;
                 _globalSettings.SetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId, micOutput.ID);
             }
             else
@@ -1854,6 +1854,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private void HQEffect_Click(object sender, RoutedEventArgs e)
         {
             _globalSettings.ProfileSettingsStore.SetClientSetting(ProfileSettingsKeys.HAVEQUICKTone, (bool)HQEffectToggle.IsChecked);
+        }
+
+        private void Preview_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            //If the mic is unplugged while we are previewing audo we need to maintain consistent state.
+            if (_audioPreview != null && (bool)e.NewValue == false) //currently previewing audio but disabling the button as no mic attached
+            {
+                PreviewAudio(sender, null);
+            }
         }
     }
 }


### PR DESCRIPTION
Hey mate,

I'm opening this up now to make sure you're happy with the general approach I'm taking.  There's two real functional changes in here:
- Allowing a user to change the selected Mic/Output etc device while connected to a server (the request in #505)
- Detecting changes in the available hardware in real time (allowing me to plug my headset in and use it without restarting the client)

The first item is looking pretty good so far.  The second looks to be working, but actually _using_ the freshly plugged in device is throwing some low-level errors on me which I can't tell are related to this change globally, my device, my PC etc etc

If you'd like these split into to two PR's, or anything else let me know 👍