### PR TITLE
Allow Choice of speaker gender for DCS-SR-ExternalAudio

### DIFF
--- a/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
+++ b/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
@@ -26,8 +26,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
 
         private readonly float volume;
         private readonly VoiceGender SpeakerGender;
+        private string SpeakerCulture;
 
-        public AudioGenerator(string path, float volume, string SpeakerGender)
+        public AudioGenerator(string path, float volume, string SpeakerGender, string SpeakerCulture)
         {
             this.path = path;
             this.volume = volume;
@@ -43,6 +44,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
                 this.SpeakerGender = VoiceGender.Female;
             }
 
+            this.SpeakerCulture = SpeakerCulture;
+
         }
     
 
@@ -53,7 +56,19 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
                 using (var synth = new SpeechSynthesizer())
                 using (var stream = new MemoryStream())
                 {
-                    synth.SelectVoiceByHints(this.SpeakerGender, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
+                    bool isVoiceInstalled = false;
+                        foreach (var voice in synth.GetInstalledVoices())
+                    {
+                        var info = voice.VoiceInfo;
+                        if (this.SpeakerCulture == info.Culture.ToString())
+                        {
+                            isVoiceInstalled = true;
+                            break;
+                        }
+                    }
+                    if (!isVoiceInstalled) this.SpeakerCulture = "en-US";
+
+                    synth.SelectVoiceByHints(this.SpeakerGender, VoiceAge.Adult, 0, new CultureInfo(this.SpeakerCulture, false));
                     synth.Rate = 1;
 
                     var intVol = (int)(volume * 100.0);

--- a/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
+++ b/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
@@ -66,7 +66,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
                             break;
                         }
                     }
-                    if (!isVoiceInstalled) this.SpeakerCulture = "en-US";
+                    if (!isVoiceInstalled) this.SpeakerCulture = "en-GB";
 
                     synth.SelectVoiceByHints(this.SpeakerGender, VoiceAge.Adult, 0, new CultureInfo(this.SpeakerCulture, false));
                     synth.Rate = 1;

--- a/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
+++ b/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
@@ -54,7 +54,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
                 using (var stream = new MemoryStream())
                 {
                     synth.SelectVoiceByHints(this.SpeakerGender, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
-                    //synth.SelectVoiceByHints(VoiceGender.Female, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
                     synth.Rate = 1;
 
                     var intVol = (int)(volume * 100.0);

--- a/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
+++ b/DCS-SR-ExternalAudio/Audio/AudioGenerator.cs
@@ -25,12 +25,26 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
             ; //640 is 40ms as INPUT_SAMPLE_RATE / 1000 *40 = 640
 
         private readonly float volume;
+        private readonly VoiceGender SpeakerGender;
 
-        public AudioGenerator(string path, float volume)
+        public AudioGenerator(string path, float volume, string SpeakerGender)
         {
             this.path = path;
             this.volume = volume;
+            if (SpeakerGender.ToLower() == "male") {
+                this.SpeakerGender = VoiceGender.Male;
+            } 
+            else if (SpeakerGender.ToLower() == "neutral")
+            {
+                this.SpeakerGender = VoiceGender.Neutral;
+            }
+            else
+            {
+                this.SpeakerGender = VoiceGender.Female;
+            }
+
         }
+    
 
         private byte[] TextToSpeech()
         {
@@ -39,7 +53,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Audio
                 using (var synth = new SpeechSynthesizer())
                 using (var stream = new MemoryStream())
                 {
-                    synth.SelectVoiceByHints(VoiceGender.Female, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
+                    synth.SelectVoiceByHints(this.SpeakerGender, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
+                    //synth.SelectVoiceByHints(VoiceGender.Female, VoiceAge.Adult, 0, new CultureInfo("en-GB", false));
                     synth.Rate = 1;
 
                     var intVol = (int)(volume * 100.0);

--- a/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
+++ b/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
@@ -31,7 +31,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         private string name;
         private readonly float volume;
 
-        public ExternalAudioClient(string mp3Path, double[] freq, RadioInformation.Modulation[] modulation, int coalition, int port, string name, float volume)
+        private readonly string SpeakerGender;
+
+        public ExternalAudioClient(string mp3Path, double[] freq, RadioInformation.Modulation[] modulation, int coalition, int port, string name, float volume, string SpeakerGender)
         {
             this.mp3Path = mp3Path;
             this.freq = freq;
@@ -40,6 +42,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
             this.port = port;
             this.name = name;
             this.volume = volume;
+            this.SpeakerGender = SpeakerGender;
 
             this.modulationBytes = new byte[modulation.Length];
             for (int i = 0; i < modulationBytes.Length; i++)
@@ -71,6 +74,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
             Logger.Info($"Port: {port} ");
             Logger.Info($"Client Name: {name} ");
             Logger.Info($"Volume: {volume} ");
+            Logger.Info($"Speaker Gender: {SpeakerGender} ");
 
             var srsClientSyncHandler = new SRSClientSyncHandler(Guid, gameState,name, coalition);
 
@@ -105,7 +109,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         private void SendAudio()
         {
             Logger.Info("Sending Audio... Please Wait");
-            AudioGenerator mp3 = new AudioGenerator(mp3Path, volume);
+            AudioGenerator mp3 = new AudioGenerator(mp3Path, volume, SpeakerGender);
             var opusBytes = mp3.GetOpusBytes();
             int count = 0;
 

--- a/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
+++ b/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
@@ -32,8 +32,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         private readonly float volume;
 
         private readonly string SpeakerGender;
+        private readonly string SpeakerCulture;
 
-        public ExternalAudioClient(string mp3Path, double[] freq, RadioInformation.Modulation[] modulation, int coalition, int port, string name, float volume, string SpeakerGender)
+
+        public ExternalAudioClient(string mp3Path, double[] freq, RadioInformation.Modulation[] modulation, int coalition, int port, string name, float volume, string SpeakerGender, string SpeakerCulture)
         {
             this.mp3Path = mp3Path;
             this.freq = freq;
@@ -43,6 +45,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
             this.name = name;
             this.volume = volume;
             this.SpeakerGender = SpeakerGender;
+            this.SpeakerCulture = SpeakerCulture;
 
             this.modulationBytes = new byte[modulation.Length];
             for (int i = 0; i < modulationBytes.Length; i++)
@@ -109,7 +112,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         private void SendAudio()
         {
             Logger.Info("Sending Audio... Please Wait");
-            AudioGenerator mp3 = new AudioGenerator(mp3Path, volume, SpeakerGender);
+            AudioGenerator mp3 = new AudioGenerator(mp3Path, volume, SpeakerGender, SpeakerCulture);
             var opusBytes = mp3.GetOpusBytes();
             int count = 0;
 

--- a/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
+++ b/DCS-SR-ExternalAudio/Client/ExternalAudioClient.cs
@@ -77,7 +77,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
             Logger.Info($"Port: {port} ");
             Logger.Info($"Client Name: {name} ");
             Logger.Info($"Volume: {volume} ");
-            Logger.Info($"Speaker Gender: {SpeakerGender} ");
+            Logger.Info($"Voice: {SpeakerGender}|{SpeakerCulture} ");
+
 
             var srsClientSyncHandler = new SRSClientSyncHandler(Guid, gameState,name, coalition);
 

--- a/DCS-SR-ExternalAudio/Client/Program.cs
+++ b/DCS-SR-ExternalAudio/Client/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Speech.Synthesis;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
 using NLog;
 
@@ -22,8 +23,17 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         }
         public static void Main(string[] args)
         {
-            if ((args.Length < 7) || (args.Length > 8 ))
+            if ((args.Length < 7) || (args.Length > 9 ))
             {
+                CultureInfo[] Cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+                string availableCultures = "";
+                var synthesizer = new SpeechSynthesizer();
+                foreach (var voice in synthesizer.GetInstalledVoices())
+                {
+                    var info = voice.VoiceInfo;
+                    availableCultures += info.Culture+"/"+info.Gender + " ";
+                }
+
                 Console.WriteLine("Error incorrect parameters - should be path or text frequency modulation coalition port name volume");
                 Console.WriteLine("Example: \"C:\\FULL\\PATH\\TO\\File.mp3\" 251.0 AM 1 5002 ciribob-robot 0.5");
                 Console.WriteLine("Example: \"I want this read out over this frequency - hello world! \" 251.0 AM 1 5002 ciribob-robot 0.5");
@@ -36,6 +46,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 Console.WriteLine("Name - name of your transmitter - no spaces");
                 Console.WriteLine("Volume - 1.0 is max, 0.0 is silence");
                 Console.WriteLine("(optional) TTS Gender - male/female");
+                Console.WriteLine("(optional) TTS culture - local for the voice");
+                Console.WriteLine("currently installed Voices on this system: " + availableCultures);
 
             }
             else
@@ -50,9 +62,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 string name = args[5].Trim();
                 float volume = float.Parse(args[6].Trim(), CultureInfo.InvariantCulture);
                 string gender = "female";
+                string culture = "en-US";
                 if (args.Length > 7)
                 {
                     gender = args[7].Trim().ToLowerInvariant();
+                }
+                if (args.Length == 9)
+                {
+                    culture = args[8].Trim();
                 }
 
                 //process freqs
@@ -85,7 +102,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 else
                 {
 
-                    ExternalAudioClient client = new ExternalAudioClient(mp3, freqDouble.ToArray(), modulation.ToArray(), coalition, port, name, volume,gender);
+                    ExternalAudioClient client = new ExternalAudioClient(mp3, freqDouble.ToArray(), modulation.ToArray(), coalition, port, name, volume,gender,culture);
                     client.Start();
                 }
 

--- a/DCS-SR-ExternalAudio/Client/Program.cs
+++ b/DCS-SR-ExternalAudio/Client/Program.cs
@@ -62,7 +62,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 string name = args[5].Trim();
                 float volume = float.Parse(args[6].Trim(), CultureInfo.InvariantCulture);
                 string gender = "female";
-                string culture = "en-US";
+                string culture = "en-GB";
                 if (args.Length > 7)
                 {
                     gender = args[7].Trim().ToLowerInvariant();

--- a/DCS-SR-ExternalAudio/Client/Program.cs
+++ b/DCS-SR-ExternalAudio/Client/Program.cs
@@ -22,7 +22,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
         }
         public static void Main(string[] args)
         {
-            if (args.Length != 7)
+            if ((args.Length < 7) || (args.Length > 8 ))
             {
                 Console.WriteLine("Error incorrect parameters - should be path or text frequency modulation coalition port name volume");
                 Console.WriteLine("Example: \"C:\\FULL\\PATH\\TO\\File.mp3\" 251.0 AM 1 5002 ciribob-robot 0.5");
@@ -35,6 +35,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 Console.WriteLine("Port - 5002 is the default");
                 Console.WriteLine("Name - name of your transmitter - no spaces");
                 Console.WriteLine("Volume - 1.0 is max, 0.0 is silence");
+                Console.WriteLine("(optional) TTS Gender - male/female");
+
             }
             else
             {
@@ -47,9 +49,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 int port = int.Parse(args[4].Trim());
                 string name = args[5].Trim();
                 float volume = float.Parse(args[6].Trim(), CultureInfo.InvariantCulture);
+                string gender = "female";
+                if (args.Length > 7)
+                {
+                    gender = args[7].Trim().ToLowerInvariant();
+                }
 
                 //process freqs
-                var freqStr= freqs.Split(',');
+                var freqStr = freqs.Split(',');
 
                 List<double> freqDouble = new List<double>();
                 foreach (var s in freqStr)
@@ -78,7 +85,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.ExternalAudioClient.Client
                 else
                 {
 
-                    ExternalAudioClient client = new ExternalAudioClient(mp3, freqDouble.ToArray(), modulation.ToArray(), coalition, port, name, volume);
+                    ExternalAudioClient client = new ExternalAudioClient(mp3, freqDouble.ToArray(), modulation.ToArray(), coalition, port, name, volume,gender);
                     client.Start();
                 }
 


### PR DESCRIPTION
added an optional 8th argument that takes "male" or "female" for choice of TTS speaker (for verity mostly).
if not specified, defaults to "female" as currently card-coded.