### PR TITLE
Always allow EAM connection

### DIFF
--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
@@ -101,7 +101,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                         //sync with others
                         //Radio info is marked as Stale for FC3 aircraft after every frequency change
 
-                        ProcessRadioInfo(message);
+                        if (!_clientStateSingleton.ExternalAWACSModeConnected)
+                        {
+                            ProcessRadioInfo(message);
+                        }
                     }
                     catch (SocketException e)
                     {

--- a/DCS-SR-Client/Singletons/ClientStateSingleton.cs
+++ b/DCS-SR-Client/Singletons/ClientStateSingleton.cs
@@ -102,7 +102,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             get
             { 
                 bool EamEnabled = SyncedServerSettings.Instance.GetSettingAsBool(Common.Setting.ServerSettingsKeys.EXTERNAL_AWACS_MODE);
-                return IsConnected && EamEnabled && ExternalAWACSModelSelected && !IsGameExportConnected;
+                return IsConnected && EamEnabled && ExternalAWACSModelSelected;
             }
         }
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -1618,7 +1618,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             {
                 _client.DisconnectExternalAWACSMode();
             }
-            else if (!ClientState.IsGameExportConnected) //only if we're not in game
+            else
             {
                 ClientState.LastSeenName = ExternalAWACSModeName.Text;
                 _client.ConnectExternalAWACSMode(ExternalAWACSModePassword.Password.Trim(), ExternalAWACSModeConnectionChanged);


### PR DESCRIPTION
In my opinion, disabling the EAM connection button is not offering the full flexibility, most users would prefer. It would be most friendly to allow the community to choose how they want to use this great tool.

This patch will;
1. always allow to connect EAM, even if SRS scripts are installed and player is in a high fidelity model (EAM still must be enabled on SRS server)
2. fix flickering between EAM and in-cockpit mode when enabling EAM before entering the airframe