### PR TITLE
fix flickering radio overlay when getting in an aircraft while EAM is active

### DIFF
--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
@@ -121,7 +121,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                 Logger.Debug("Starting external AWACS mode loop");
 
                 _clientStateSingleton.IntercomOffset = 1;
-                while (!_stopExternalAWACSMode)
+                while (!_stopExternalAWACSMode && !_clientStateSingleton.IsGameExportConnected)
                 {
                     var unitId = DCSPlayerRadioInfo.UnitIdOffset + _clientStateSingleton.IntercomOffset;
 


### PR DESCRIPTION
As you suggested and in contrast to my last pull request: suppress EAM as soon as player gets into an airplane. This solves the overlay flickering between EAM and in-cockpit mode. Is this the change you had in mind?

I used the same condition as the EAM connect button handler.  Is this implementation done properly?