### PR TITLE
Keep current channel when exiting DL UFC via CLR

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1917,7 +1917,7 @@ function SR.exportRadioFA18C(_data)
                         local chan = tonumber(_ufc.UFC_ScratchPadNumberDisplay)
 
                         if chan == nil then
-                            return 0
+                            return currentChannel
                         end
                         return chan
                 end
@@ -1927,7 +1927,7 @@ function SR.exportRadioFA18C(_data)
                     local chan = tonumber(_ufc.UFC_ScratchPadNumberDisplay)
 
                     if chan == nil then
-                        return 0
+                        return currentChannel
                     end
                     return chan
                 end


### PR DESCRIPTION
Currently there is the following issue in SRS:

Select DL
Select VOCA
Enter channel (i.e. 123)
Press ENT (SRS will momentarily tune123)
Press CLR CLR to exit
MIDS A will turn off instead of keeping the entered channel.

This fix solves that issue.