### PR TITLE
Added Strict Radio Encryption

### DIFF
--- a/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
+++ b/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
@@ -158,7 +158,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
                 vhfVol = profileSettings.GetClientSettingFloat(ProfileSettingsKeys.VHFNoiseVolume);
             }
 
-            var decrytable = audio.Decryptable || (audio.Encryption == 0);
+            var decrytable = audio.Decryptable /* || (audio.Encryption == 0) <--- this test has already been performed by all callers and would require another call to check for STRICT_AUDIO_ENCRYPTION */;
 
             if (decrytable)
             {

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -410,8 +410,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         new List<RadioReceivingPriority>(frequencyCount);
                                     List<int> blockedRadios = CurrentlyBlockedRadios();
 
-                                    // Parse frequencies into receiving radio priority for selection below
-                                    for (var i = 0; i < frequencyCount; i++)
+                                    var strictEncryption = _serverSettings.GetSettingAsBool(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION);
+
+                                        // Parse frequencies into receiving radio priority for selection below
+                                        for (var i = 0; i < frequencyCount; i++)
                                     {
                                         RadioReceivingState state = null;
                                         bool decryptable;
@@ -429,6 +431,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                             udpVoicePacket.Frequencies[i],
                                             (RadioInformation.Modulation) udpVoicePacket.Modulations[i],
                                             udpVoicePacket.Encryptions[i],
+                                            strictEncryption,
                                             udpVoicePacket.UnitId,
                                             blockedRadios,
                                             out state,
@@ -451,9 +454,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                                 )
                                             )
                                             {
-                                                decryptable =
-                                                    (udpVoicePacket.Encryptions[i] == 0) ||
-                                                    (udpVoicePacket.Encryptions[i] == radio.encKey && radio.enc);
+                                                // This is already done in CanHearTransmission!!
+                                                //decryptable =
+                                                //    (udpVoicePacket.Encryptions[i] == radio.encKey && radio.enc) ||
+                                                //    (!strictEncryption && udpVoicePacket.Encryptions[i] == 0);
 
                                                 radioReceivingPriorities.Add(new RadioReceivingPriority()
                                                 {
@@ -517,7 +521,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                                 (radioState == null || radioState.PlayedEndOfTransmission ||
                                                  !radioState.IsReceiving))
                                             {
-                                                var audioDecryptable = audio.Decryptable || (audio.Encryption == 0);
+                                                var audioDecryptable = audio.Decryptable /* || (audio.Encryption == 0) <--- this has already been tested above */;
 
                                                 //mark that we have decrypted encrypted audio for sound effects
                                                 if (audioDecryptable && (audio.Encryption > 0))

--- a/DCS-SR-Client/Singletons/ConnectedClientsSingleton.cs
+++ b/DCS-SR-Client/Singletons/ConnectedClientsSingleton.cs
@@ -134,6 +134,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
                             var receivingRadio = radioInfo.CanHearTransmission(freq,
                                 modulation,
                                 0,
+                                false,
                                 currentUnitId,
                                 new List<int>(),
                                 out radioReceivingState,

--- a/DCS-SR-Client/UI/ClientWindow/ServerSettingsWindow/ServerSettingsWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/ServerSettingsWindow/ServerSettingsWindow.xaml
@@ -29,6 +29,7 @@
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
         <Label Grid.Row="0"
                Grid.Column="0"
@@ -154,9 +155,9 @@
                Grid.Column="0"
                HorizontalContentAlignment="Center"
                VerticalContentAlignment="Center"
-               Content="Show Tuned Client Count" />
+               Content="Strict Radio Encryption" />
 
-        <Label Name="TunedClientCount"
+        <Label Name="StrictRadioEncryption"
                Grid.Row="9"
                Grid.Column="1"
                HorizontalContentAlignment="Center"
@@ -167,9 +168,9 @@
                Grid.Column="0"
                HorizontalContentAlignment="Center"
                VerticalContentAlignment="Center"
-               Content="Show Transmitter Name" />
+               Content="Show Tuned Client Count" />
 
-        <Label Name="ShowTransmitterName"
+        <Label Name="TunedClientCount"
                Grid.Row="10"
                Grid.Column="1"
                HorizontalContentAlignment="Center"
@@ -180,9 +181,9 @@
                Grid.Column="0"
                HorizontalContentAlignment="Center"
                VerticalContentAlignment="Center"
-               Content="Server Version" />
+               Content="Show Transmitter Name" />
 
-        <Label Name="ServerVersion"
+        <Label Name="ShowTransmitterName"
                Grid.Row="11"
                Grid.Column="1"
                HorizontalContentAlignment="Center"
@@ -193,16 +194,29 @@
                Grid.Column="0"
                HorizontalContentAlignment="Center"
                VerticalContentAlignment="Center"
+               Content="Server Version" />
+
+        <Label Name="ServerVersion"
+               Grid.Row="12"
+               Grid.Column="1"
+               HorizontalContentAlignment="Center"
+               VerticalContentAlignment="Center"
+               Content="Unknown" />
+
+        <Label Grid.Row="13"
+               Grid.Column="0"
+               HorizontalContentAlignment="Center"
+               VerticalContentAlignment="Center"
                Content="Retransmit Node Limit" />
 
         <Label Name="NodeLimit"
-               Grid.Row="12"
+               Grid.Row="13"
                Grid.Column="1"
                HorizontalContentAlignment="Center"
                VerticalContentAlignment="Center"
                Content="0" />
 
-        <Button Grid.Row="13"
+        <Button Grid.Row="14"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Width="80"

--- a/DCS-SR-Client/UI/ClientWindow/ServerSettingsWindow/ServerSettingsWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/ServerSettingsWindow/ServerSettingsWindow.xaml.cs
@@ -60,6 +60,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
                 AllowRadioEncryption.Content = settings.GetSettingAsBool(ServerSettingsKeys.ALLOW_RADIO_ENCRYPTION) ? "ON" : "OFF";
 
+                StrictRadioEncryption.Content = settings.GetSettingAsBool(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION) ? "ON" : "OFF";
+
                 TunedClientCount.Content = settings.GetSettingAsBool(ServerSettingsKeys.SHOW_TUNED_COUNT) ? "ON" : "OFF";
 
                 ShowTransmitterName.Content = settings.GetSettingAsBool(ServerSettingsKeys.SHOW_TRANSMITTER_NAME) ? "ON" : "OFF";

--- a/DCS-SR-Common/DCSState/DCSPlayerRadioInfo.cs
+++ b/DCS-SR-Common/DCSState/DCSPlayerRadioInfo.cs
@@ -196,6 +196,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
         public RadioInformation CanHearTransmission(double frequency,
             RadioInformation.Modulation modulation,
             byte encryptionKey,
+            bool strictEncryption,
             uint sendingUnitId,
             List<int> blockedRadios,
             out RadioReceivingState receivingState,
@@ -250,7 +251,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                         && (receivingRadio.modulation == modulation)
                         && (receivingRadio.freq > 10000))
                     {
-                        bool isDecryptable = (encryptionKey == 0 || (receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey);
+                        bool isDecryptable = (receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey || (!strictEncryption && encryptionKey == 0);
 
                         if (isDecryptable && !blockedRadios.Contains(i))
                         {
@@ -276,7 +277,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                     if ((receivingRadio.secFreq == frequency)
                         && (receivingRadio.secFreq > 10000))
                     {
-                        if (encryptionKey == 0 || (receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey)
+                        if ((receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey || (!strictEncryption && encryptionKey == 0))
                         {
                             receivingState = new RadioReceivingState
                             {

--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -33,6 +33,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         LOTATC_EXPORT_IP = 22,
         UPNP_ENABLED = 23,
         RETRANSMISSION_NODE_LIMIT= 24,
+        STRICT_RADIO_ENCRYPTION = 25,
     }
 
     public class DefaultServerSettings
@@ -64,6 +65,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.UPNP_ENABLED.ToString(), "true" },
             { ServerSettingsKeys.SHOW_TRANSMITTER_NAME.ToString(), "false" },
             { ServerSettingsKeys.RETRANSMISSION_NODE_LIMIT.ToString(), "0" },
+            { ServerSettingsKeys.STRICT_RADIO_ENCRYPTION.ToString(), "false" },
         };
     }
 }

--- a/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
+++ b/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
@@ -306,6 +306,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
 
             var guid = fromClient.ClientGuid;
 
+            var strictEncryption = _serverSettings.GetGeneralSetting(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION).BoolValue;
+
             foreach (var client in _clientsList)
             {
                 if (!client.Key.Equals(guid))
@@ -347,6 +349,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                                     var receivingRadio = radioInfo.CanHearTransmission(udpVoice.Frequencies[i],
                                         (RadioInformation.Modulation)udpVoice.Modulations[i],
                                         udpVoice.Encryptions[i],
+                                        strictEncryption,
                                         udpVoice.UnitId,
                                         _emptyBlockedRadios,
                                         out radioReceivingState,

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -36,6 +36,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
 
                 <Button Grid.Row="0"
@@ -227,8 +228,24 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Check for beta updates" 
+                <Label Content="Strict Radio Encryption"
                        Grid.Row="10"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
+
+                <Button x:Name="StrictRadioEncryptionToggle"
+                        Content="{Binding StrictRadioEncryption}"
+                        Grid.Row="10"
+                        Grid.Column="2"
+                        Width="75"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"/>
+
+                <Label Content="Check for beta updates" 
+                       Grid.Row="11"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -236,7 +253,7 @@
 
                 <Button x:Name="CheckForBetaUpdatesToggle"
                        Content="{Binding CheckForBetaUpdates}" 
-                       Grid.Row="10"
+                       Grid.Row="11"
                        Grid.Column="2"
                        Width="75"
                        Height="20"
@@ -245,7 +262,7 @@
 
 
                 <Label Content="External AWACS Mode (EAM)" 
-                       Grid.Row="11"
+                       Grid.Row="12"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -253,7 +270,7 @@
 
                 <Button x:Name="ExternalAWACSModeToggle"
                         Content="{Binding ExternalAWACSMode}" 
-                        Grid.Row="11"
+                        Grid.Row="12"
                         Grid.Column="2"
                         Width="75"
                         Height="20"
@@ -261,7 +278,7 @@
                         HorizontalAlignment="Center"/>
 
                 <Label Content="EAM blue coal. password" 
-                       Grid.Row="12"
+                       Grid.Row="13"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -270,7 +287,7 @@
                 <TextBox x:Name="ExternalAWACSModeBluePassword"
                          IsEnabled="{Binding IsExternalAWACSModeEnabled}"
                          Text="{Binding Path=ExternalAWACSModeBluePassword, UpdateSourceTrigger=PropertyChanged}"
-                         Grid.Row="12"
+                         Grid.Row="13"
                          Grid.Column="2"
                          Width="75"
                          Height="20"
@@ -278,7 +295,7 @@
                          HorizontalAlignment="Center"/>
 
                 <Label Content="EAM red coal. password"
-                       Grid.Row="13"
+                       Grid.Row="14"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -287,7 +304,7 @@
                 <TextBox x:Name="ExternalAWACSModeRedPassword"
                          IsEnabled="{Binding IsExternalAWACSModeEnabled}"
                          Text="{Binding Path=ExternalAWACSModeRedPassword, UpdateSourceTrigger=PropertyChanged}"
-                         Grid.Row="13"
+                         Grid.Row="14"
                          Grid.Column="2"
                          Width="75"
                          Height="20"
@@ -295,7 +312,7 @@
                          HorizontalAlignment="Center"/>
 
                 <Label Content="Test Frequencies AM (MHz)"
-                       Grid.Row="14"
+                       Grid.Row="15"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -304,7 +321,7 @@
                 <TextBox x:Name="TestFrequencies"
                          IsEnabled="True"
                          Text="247.2,120.3"
-                         Grid.Row="14"
+                         Grid.Row="15"
                          Grid.Column="2"
                          Width="75"
                          Height="20"
@@ -313,7 +330,7 @@
 
 
                 <Label Content="Show Tuned/Client Count" 
-                       Grid.Row="15"
+                       Grid.Row="16"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -321,7 +338,7 @@
 
                 <Button x:Name="TunedCountToggle"
                        Content="{Binding TunedCountText}"
-                       Grid.Row="15"
+                       Grid.Row="16"
                        Grid.Column="2"
                        Width="75"
                        Height="20"
@@ -329,7 +346,7 @@
                        HorizontalAlignment="Center"/>
 
                 <Label Content="Global Lobby Freq. AM (MHz)"
-                       Grid.Row="16"
+                       Grid.Row="17"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -338,7 +355,7 @@
                 <TextBox x:Name="GlobalLobbyFrequencies"
                          IsEnabled="True"
                          Text="241.2,122.3"  
-                         Grid.Row="16"
+                         Grid.Row="17"
                          Grid.Column="2"
                          Width="75"
                          Height="20"
@@ -346,7 +363,7 @@
                          HorizontalAlignment="Center"/>
 
                 <Label Content="LotATC Transponder Export" 
-                       Grid.Row="17"
+                       Grid.Row="18"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -354,22 +371,6 @@
 
                 <Button x:Name="LotATCExportToggle"
                         Content="{Binding LotATCExportText}"
-                        Grid.Row="17"
-                        Grid.Column="2"
-                        Width="75"
-                        Height="20"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Center"/>
-
-                <Label Content="Show Transmitter Name" 
-                       Grid.Row="18"
-                       Grid.Column="0" 
-                       Grid.ColumnSpan="2"
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Center"/>
-
-                <Button x:Name="ShowTransmitterNameToggle"
-                        Content="{Binding ShowTransmitterNameText}" 
                         Grid.Row="18"
                         Grid.Column="2"
                         Width="75"
@@ -377,14 +378,30 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Retransmit Hop/Node Count"
+                <Label Content="Show Transmitter Name" 
                        Grid.Row="19"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
+
+                <Button x:Name="ShowTransmitterNameToggle"
+                        Content="{Binding ShowTransmitterNameText}" 
+                        Grid.Row="19"
+                        Grid.Column="2"
+                        Width="75"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"/>
+
+                <Label Content="Retransmit Hop/Node Count"
+                       Grid.Row="20"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="19"
+                            Grid.Row="20"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>
@@ -412,7 +429,7 @@
 
 
                 </StackPanel>
-                
+
             </Grid>
         </StackPanel>
     </ScrollViewer>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -95,6 +95,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
         public string AllowRadioEncryption
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.ALLOW_RADIO_ENCRYPTION).BoolValue ? "ON" : "OFF";
 
+        public string StrictRadioEncryption
+            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION).BoolValue ? "ON" : "OFF";
+
         public bool IsExternalAWACSModeEnabled { get; set; }
             = ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.EXTERNAL_AWACS_MODE).BoolValue;
 
@@ -316,6 +319,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
             var newSetting = AllowRadioEncryption != "ON";
             ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.ALLOW_RADIO_ENCRYPTION, newSetting);
             NotifyOfPropertyChange(() => AllowRadioEncryption);
+
+            _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+        }
+
+        public void StrictRadioEncryptionToggle()
+        {
+            var newSetting = StrictRadioEncryption != "ON";
+            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION, newSetting);
+            NotifyOfPropertyChange(() => StrictRadioEncryption);
 
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }


### PR DESCRIPTION
As discussed on issue #550 I send a pull request for this. I've implemented it as a server option, as it made more sense to have it behaving equally in all clients depending on server admin's preference. Our group would appreciate if it gets included in a future update.

Defaults to OFF. If enabled it will make plain transmissions sound as noise if the receiver has encryption switched on. UI option added with the name "Strict Radio Encryption", both to the server settings and client's "show server settings" dialog.

p.s. Cribob, while dong this I've noticed several duplicate tests for encryption == 0 that I've left commented. To my best knowledge they are duplicate and unneeded, as encryption == 0 is already tested upstream of them, but please take a look yourself as you definitely will know your code better.