### PR TITLE
Transmission Logging

### DIFF
--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -34,6 +34,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         UPNP_ENABLED = 23,
         RETRANSMISSION_NODE_LIMIT= 24,
         TRANSMISSION_LOG_ENABLED = 25,
+        TRANSMISSION_LOG_RETENTION = 26
     }
 
     public class DefaultServerSettings
@@ -66,6 +67,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.SHOW_TRANSMITTER_NAME.ToString(), "false" },
             { ServerSettingsKeys.RETRANSMISSION_NODE_LIMIT.ToString(), "0" },
             { ServerSettingsKeys.TRANSMISSION_LOG_ENABLED.ToString(), "false" },
+            { ServerSettingsKeys.TRANSMISSION_LOG_RETENTION.ToString(), "2" }
         };
     }
 }

--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -33,6 +33,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         LOTATC_EXPORT_IP = 22,
         UPNP_ENABLED = 23,
         RETRANSMISSION_NODE_LIMIT= 24,
+        TRANSMISSION_LOG_ENABLED = 25,
     }
 
     public class DefaultServerSettings
@@ -64,6 +65,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.UPNP_ENABLED.ToString(), "true" },
             { ServerSettingsKeys.SHOW_TRANSMITTER_NAME.ToString(), "false" },
             { ServerSettingsKeys.RETRANSMISSION_NODE_LIMIT.ToString(), "0" },
+            { ServerSettingsKeys.TRANSMISSION_LOG_ENABLED.ToString(), "false" },
         };
     }
 }

--- a/DCS-SimpleRadio Server/Bootstrapper.cs
+++ b/DCS-SimpleRadio Server/Bootstrapper.cs
@@ -10,7 +10,9 @@ using System.Windows.Threading;
 using Caliburn.Micro;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
 using Ciribob.DCS.SimpleRadio.Standalone.Server.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Server.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Server.UI.ClientAdmin;
 using Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow;
 using NLog;
@@ -49,6 +51,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server
             }
 
             var config = new LoggingConfiguration();
+            var transmissionFileTarget = new FileTarget
+            {
+                FileName = @"${date:format=yyyy-MM-dd}-transmissionlog.txt",
+                ArchiveFileName = @"${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.txt",
+                ArchiveNumbering = ArchiveNumberingMode.Date,
+                MaxArchiveFiles = ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_RETENTION).IntValue,
+                ArchiveEvery = FileArchivePeriod.Day,
+                Layout =
+                 @"${longdate} | ${message}"
+            };
             var fileTarget = new FileTarget
             {
                 FileName = "serverlog.txt",
@@ -60,8 +72,20 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server
             };
 
             var wrapper = new AsyncTargetWrapper(fileTarget, 5000, AsyncTargetWrapperOverflowAction.Discard);
+            var transmissionWrapper = new AsyncTargetWrapper(transmissionFileTarget, 5000, AsyncTargetWrapperOverflowAction.Discard);
             config.AddTarget("asyncFileTarget", wrapper);
-            config.LoggingRules.Add(new LoggingRule("*", LogLevel.Info, wrapper));
+            config.AddTarget("asyncTransmissionFileTarget", transmissionWrapper);
+
+
+            var transmissionRule = new LoggingRule(
+                "Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models.TransmissionLoggingQueue",
+                LogLevel.Info,
+                transmissionWrapper
+                );
+            transmissionRule.Final = true;
+
+            config.LoggingRules.Add(transmissionRule);
+            config.LoggingRules.Add(new LoggingRule("*", LogLevel.Info, transmissionWrapper));
 
             LogManager.Configuration = config;
             loggingReady = true;

--- a/DCS-SimpleRadio Server/Bootstrapper.cs
+++ b/DCS-SimpleRadio Server/Bootstrapper.cs
@@ -53,13 +53,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server
             var config = new LoggingConfiguration();
             var transmissionFileTarget = new FileTarget
             {
-                FileName = @"${date:format=yyyy-MM-dd}-transmissionlog.txt",
-                ArchiveFileName = @"${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.txt",
+                FileName = @"${date:format=yyyy-MM-dd}-transmissionlog.csv",
+                ArchiveFileName = @"${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.csv",
                 ArchiveNumbering = ArchiveNumberingMode.Date,
                 MaxArchiveFiles = ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_RETENTION).IntValue,
                 ArchiveEvery = FileArchivePeriod.Day,
                 Layout =
-                 @"${longdate} | ${message}"
+                 @"${longdate}, ${message}"
             };
             var fileTarget = new FileTarget
             {

--- a/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
+++ b/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
@@ -266,12 +266,14 @@
     <Compile Include="Network\Models\OutgoingUDPPackets.cs" />
     <Compile Include="Network\Models\PendingPacket.cs" />
     <Compile Include="Network\Models\ConnectionStateObject.cs" />
+    <Compile Include="Network\Models\TransmissionLog.cs" />
     <Compile Include="Network\NatHandler.cs" />
     <Compile Include="Network\NetCoreServer\Buffer.cs" />
     <Compile Include="Network\NetCoreServer\TcpClient.cs" />
     <Compile Include="Network\NetCoreServer\TcpServer.cs" />
     <Compile Include="Network\NetCoreServer\TcpSession.cs" />
     <Compile Include="Network\SRSClientSession.cs" />
+    <Compile Include="Network\Models\TransmissionLoggingQueue.cs" />
     <Compile Include="Network\UDPPositionHandler.cs" />
     <Compile Include="Network\UDPVoiceRouter.cs" />
     <Compile Include="UI\ClientAdmin\ClientAdminViewModel.cs" />

--- a/DCS-SimpleRadio Server/NLog.config
+++ b/DCS-SimpleRadio Server/NLog.config
@@ -16,9 +16,22 @@
               layout="${longdate} | ${logger} | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
       />
     </target>
+	  <target name="asyncTransmissionFileTarget" xsi:type="AsyncWrapper" queueLimit="1000" overflowAction="Discard" >
+		  <target name="fileTarget"
+				  xsi:type="File"
+				  fileName="${longdate}-transmissionlog.txt"
+				  archiveFileName="${basedir}/{#}-transmissionlog.old.txt"
+				  archiveNumbering="Date"
+		          archiveDateFormat="yyyy-MM-dd-HH-mm"
+				  archiveEvery="Day"
+				  maxArchiveFiles="2"
+				  layout="${longdate} | ${message}"
+      />
+	  </target>
   </targets>
 
   <rules>
+	<logger name ="Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models.TransmissionLoggingQueue" minlevel ="Info" writeTo="asyncTransmissionFileTarget" final="true"/>
     <logger name="*" minlevel="Info" writeTo="asyncFileTarget" />
   </rules>
 </nlog>

--- a/DCS-SimpleRadio Server/NLog.config
+++ b/DCS-SimpleRadio Server/NLog.config
@@ -16,11 +16,11 @@
               layout="${longdate} | ${logger} | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
       />
     </target>
-	  <target name="asyncTransmissionFileTarget" xsi:type="AsyncWrapper" queueLimit="1000" overflowAction="Discard" >
+	  <target name="asyncTransmissionFileTarget" xsi:type="AsyncWrapper" queueLimit="5000" overflowAction="Discard" >
 		  <target name="fileTarget"
 				  xsi:type="File"
-				  fileName="${longdate}-transmissionlog.txt"
-				  archiveFileName="${basedir}/{#}-transmissionlog.old.txt"
+                  FileName = "${date:format=yyyy-MM-dd}-transmissionlog.txt"
+                  ArchiveFileName = "${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.txt"
 				  archiveNumbering="Date"
 		          archiveDateFormat="yyyy-MM-dd-HH-mm"
 				  archiveEvery="Day"

--- a/DCS-SimpleRadio Server/NLog.config
+++ b/DCS-SimpleRadio Server/NLog.config
@@ -19,13 +19,13 @@
 	  <target name="asyncTransmissionFileTarget" xsi:type="AsyncWrapper" queueLimit="5000" overflowAction="Discard" >
 		  <target name="fileTarget"
 				  xsi:type="File"
-                  FileName = "${date:format=yyyy-MM-dd}-transmissionlog.txt"
-                  ArchiveFileName = "${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.txt"
+                  FileName = "${date:format=yyyy-MM-dd}-transmissionlog.csv"
+                  ArchiveFileName = "${basedir}/TransmissionLogArchive/{#}-transmissionlog.old.csv"
 				  archiveNumbering="Date"
 		          archiveDateFormat="yyyy-MM-dd-HH-mm"
 				  archiveEvery="Day"
 				  maxArchiveFiles="2"
-				  layout="${longdate} | ${message}"
+				  layout="${longdate}, ${message}"
       />
 	  </target>
   </targets>

--- a/DCS-SimpleRadio Server/Network/Models/TransmissionLog.cs
+++ b/DCS-SimpleRadio Server/Network/Models/TransmissionLog.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
+{
+    class TransmissionLog
+    {
+        public string TransmissionFrequency { get; set; }
+        public DateTime TransmissionStart { get; set; }
+        public DateTime TransmissionEnd { get; set; }
+
+        public TransmissionLog(DateTime time, string frequency)
+        {
+            TransmissionFrequency = frequency;
+            TransmissionStart = time;
+            TransmissionEnd = time;
+        }
+
+        public bool IsComplete() => DateTime.Now.Ticks - TransmissionEnd.Ticks > 4000000 ? true : false;
+    }
+}

--- a/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
+++ b/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
@@ -68,7 +68,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
                     _log = !_serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue;
                     string newSetting = _log ? "TRANSMISSION LOGGING ENABLED" : "TRANSMISSION LOGGING DISABLED";
 
-                    Logger.Info($"{newSetting}");
+                    Logger.Info($"EVENT, {newSetting}");
                 }
 
                 if (_fileTarget.MaxArchiveFiles != _serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_RETENTION).IntValue)
@@ -85,7 +85,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
                         {
                             if (_currentTransmissionLog.TryRemove(LoggedTransmission.Key, out TransmissionLog completedLog))
                             {
-                                Logger.Info($"{LoggedTransmission.Key.ClientGuid}, {LoggedTransmission.Key.Name}, " +
+                                Logger.Info($"TRANSMISSION, {LoggedTransmission.Key.ClientGuid}, {LoggedTransmission.Key.Name}, " +
                                     $"{LoggedTransmission.Key.Coalition}, {LoggedTransmission.Value.TransmissionFrequency}. " +
                                     $"{completedLog.TransmissionStart}, {completedLog.TransmissionEnd}, {LoggedTransmission.Key.VoipPort}");
                             }

--- a/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
+++ b/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
@@ -64,6 +64,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
 
             while (!_stop)
             {
+                Thread.Sleep(500);
                 if (_log != !_serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue)
                 {
                     _log = !_serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue;

--- a/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
+++ b/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
@@ -36,7 +36,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
         {
             if (!_stop)
             {
-                _currentTransmissionLog.AddOrUpdate(client, new TransmissionLog(client.LastTransmissionReceived, client.TransmittingFrequency),
+                _currentTransmissionLog.AddOrUpdate(client, 
+                   new TransmissionLog(client.LastTransmissionReceived, client.TransmittingFrequency),
                    (k, v) => UpdateTransmission(client, v));
             }
         }

--- a/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
+++ b/DCS-SimpleRadio Server/Network/Models/TransmissionLoggingQueue.cs
@@ -1,0 +1,98 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
+using Ciribob.DCS.SimpleRadio.Standalone.Server.Settings;
+using NLog;
+using NLog.Targets;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models
+{
+    class TransmissionLoggingQueue
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private ConcurrentDictionary<SRClient, TransmissionLog> _currentTransmissionLog { get; } = new ConcurrentDictionary<SRClient, TransmissionLog>();
+        private bool _stop;
+        private bool _log;
+        private readonly ServerSettingsStore _serverSettings = ServerSettingsStore.Instance;
+        private readonly XDocument _nlogConfig = XDocument.Load("NLog.config");
+
+        public TransmissionLoggingQueue()
+        {
+            _log = _serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue;
+            _stop = false;
+        }
+        
+        //public int FileArchivePeriod { get {return _nlogConfig.Descendants(_nlogConfig.Root.GetDefaultNamespace() + "target")
+
+        public void LogTransmission(SRClient client)
+        {
+            if (!_stop)
+            {
+                _currentTransmissionLog.AddOrUpdate(client, new TransmissionLog(client.LastTransmissionReceived, client.TransmittingFrequency),
+                   (k, v) => UpdateTransmission(client, v));
+            }
+        }
+
+        private TransmissionLog UpdateTransmission(SRClient client, TransmissionLog log)
+        {
+            log.TransmissionEnd = client.LastTransmissionReceived;
+            return log;
+        }
+
+        public void Start()
+        {
+            new Thread(LogCompleteTransmissions).Start();
+        }
+
+        public void Stop()
+        {
+            _stop = true;
+                        
+        }
+
+        public void UpdateArchivePeriod(string days)
+        {
+            FileTarget target = (FileTarget)LogManager.Configuration.FindTargetByName("asyncTransmissionFileTarget");
+            Console.WriteLine(target.ArchiveEvery);
+            target.MaxArchiveFiles = int.Parse(days);
+            LogManager.ReconfigExistingLoggers();
+            Console.WriteLine(target.ArchiveEvery);
+        }
+
+        private void LogCompleteTransmissions()
+        {
+            while(!_stop)
+            {
+
+                if (_log != !_serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue)
+                {
+                    _log = !_serverSettings.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue;
+                    string newSetting = _log ? "TRANSMISSION LOGGING ENABLED" : "TRANSMISSION LOGGING DISABLED";
+
+                    Logger.Info($"{newSetting}");
+                }
+
+                if(_log && !_currentTransmissionLog.IsEmpty)
+                {
+                    foreach (KeyValuePair<SRClient, TransmissionLog> LoggedTransmission in _currentTransmissionLog)
+                    {
+                        if (LoggedTransmission.Value.IsComplete())
+                        {
+                            if (_currentTransmissionLog.TryRemove(LoggedTransmission.Key, out TransmissionLog completedLog))
+                            {
+                                Logger.Info($"{LoggedTransmission.Key.ClientGuid}, {LoggedTransmission.Key.Name}, " +
+                                    $"{LoggedTransmission.Key.Coalition}, {LoggedTransmission.Value.TransmissionFrequency}. " +
+                                    $"{completedLog.TransmissionStart}, {completedLog.TransmissionEnd}, {LoggedTransmission.Key.VoipPort}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
+++ b/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
@@ -243,7 +243,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                                                 }
                                                 client.LastTransmissionReceived = DateTime.Now;
 
-                                                transmissionLoggingQueue.LogTransmission(client);
+                                                // Only log the initial transmission
+                                                if (udpVoicePacket.RetransmissionCount == 0)
+                                                {
+                                                    transmissionLoggingQueue.LogTransmission(client);
+                                                }
                                             }
                                         }
 

--- a/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
+++ b/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
@@ -1,4 +1,4 @@
-using System;
+ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -11,6 +11,7 @@ using Caliburn.Micro;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
+using Ciribob.DCS.SimpleRadio.Standalone.Server.Network.Models;
 using Ciribob.DCS.SimpleRadio.Standalone.Server.Settings;
 using NLog;
 using LogManager = NLog.LogManager;
@@ -20,6 +21,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
     internal class UDPVoiceRouter: IHandle<ServerFrequenciesChanged>
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         private readonly ConcurrentDictionary<string, SRClient> _clientsList;
         private readonly IEventAggregator _eventAggregator;
 
@@ -39,6 +41,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
         private static readonly List<int> _emptyBlockedRadios = new List<int>(); // Used in radio reachability check below, server does not track blocked radios, so forward all
         private List<double> _testFrequencies = new List<double>();
         private List<double> _globalFrequencies = new List<double>();
+
+        private readonly TransmissionLoggingQueue transmissionLoggingQueue = new TransmissionLoggingQueue();
 
         public UDPVoiceRouter(ConcurrentDictionary<string, SRClient> clientsList, IEventAggregator eventAggregator)
         {
@@ -99,6 +103,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
             new Thread(ProcessPackets).Start();
             //outgoing packets
             new Thread(SendPendingPackets).Start();
+            transmissionLoggingQueue.Start();
 
             var port = _serverSettings.GetServerPort();
             _listener = new UdpClient();
@@ -221,7 +226,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                                         {
                                             //Add to the processing queue
                                             _outGoing.Add(outgoingVoice);
-
+                                            
                                             //mark as transmitting for the UI
                                             double mainFrequency = udpVoicePacket.Frequencies.FirstOrDefault();
                                             // Only trigger transmitting frequency update for "proper" packets (excluding invalid frequencies and magic ping packets with modulation 4)
@@ -237,6 +242,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                                                     client.TransmittingFrequency = $"{(mainFrequency / 1000000).ToString("0.000", CultureInfo.InvariantCulture)} {mainModulation}";
                                                 }
                                                 client.LastTransmissionReceived = DateTime.Now;
+
+                                                transmissionLoggingQueue.LogTransmission(client);
                                             }
                                         }
 
@@ -383,7 +390,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                     }
                 }
             }
-
             if (outgoingList.Count > 0)
             {
                 return new OutgoingUDPPackets

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -5,7 +5,7 @@
              xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Server.UI"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              Width="330"
-             Height="685"
+             Height="575"
              mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Visible"  Margin="0,0,0,0" >
         <StackPanel Orientation="Vertical" Margin="5" >
@@ -397,7 +397,7 @@
                         HorizontalAlignment="Center"/>
 
                 <Label Content="Log Received Transmissions"
-                       Grid.Row="20"
+                       Grid.Row="21"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
@@ -405,7 +405,7 @@
 
                 <Button x:Name="TransmissionLogEnabledToggle"
                         Content="{Binding TransmissionLogEnabledText}"
-                        Grid.Row="20"
+                        Grid.Row="21"
                         Grid.Column="2"
                         Width="75"
                         Height="20"
@@ -413,14 +413,14 @@
                         HorizontalAlignment="Center"/>
 
                 <Label Content="Transmission Archive Time"
-                       Grid.Row="21"
+                       Grid.Row="22"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="21"
+                            Grid.Row="22"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -5,7 +5,7 @@
              xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Server.UI"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              Width="330"
-             Height="655"
+             Height="685"
              mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Visible"  Margin="0,0,0,0" >
         <StackPanel Orientation="Vertical" Margin="5" >
@@ -395,15 +395,27 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Transmission Archive History"
+                <Label Content="Transmission Archive Time"
                        Grid.Row="21"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
-                <!--<Slider 
-                        Value="Test"
+                <StackPanel Orientation="Vertical"
+                            Grid.Row="21"
+                            Grid.Column="2">
+                    <Grid  Width="75">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Label Grid.Column="0" FontSize="10" Content="0" HorizontalAlignment="Left" />
+                        <Label HorizontalAlignment="Right" Grid.Column="1" FontSize="10" Content="7" />
+                    </Grid>
+                    
+                    <Slider 
+                        Value="{Binding ArchiveLimit}"
                         Width="75"
                         Height="40"
                         VerticalAlignment="Center"
@@ -414,7 +426,8 @@
                         TickPlacement="TopLeft"
                         IsSnapToTickEnabled="True"
                         HorizontalAlignment="Center">
-                </Slider>-->
+                    </Slider>
+                </StackPanel>
 
                 <Label Content="Retransmit Hop/Node Count"
                        Grid.Row="19"
@@ -445,10 +458,8 @@
                             TickPlacement="TopLeft"
                             IsSnapToTickEnabled="True"
                             HorizontalAlignment="Center">
-
                     </Slider>
                 </StackPanel>
-                
             </Grid>
         </StackPanel>
     </ScrollViewer>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -5,7 +5,7 @@
              xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Server.UI"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              Width="330"
-             Height="575"
+             Height="655"
              mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Visible"  Margin="0,0,0,0" >
         <StackPanel Orientation="Vertical" Margin="5" >
@@ -16,6 +16,8 @@
                     <ColumnDefinition Width="2*" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
@@ -377,6 +379,43 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
+                <Label Content="Log Received Transmissions"
+                       Grid.Row="20"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
+
+                <Button x:Name="TransmissionLogEnabledToggle"
+                        Content="{Binding TransmissionLogEnabledText}"
+                        Grid.Row="20"
+                        Grid.Column="2"
+                        Width="75"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"/>
+
+                <Label Content="Transmission Archive History"
+                       Grid.Row="21"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
+
+                <!--<Slider 
+                        Value="Test"
+                        Width="75"
+                        Height="40"
+                        VerticalAlignment="Center"
+                        Interval="1"
+                        Minimum="0"
+                        Maximum="7"
+                        Ticks="1,2,3,4,5,6,7"
+                        TickPlacement="TopLeft"
+                        IsSnapToTickEnabled="True"
+                        HorizontalAlignment="Center">
+                </Slider>-->
+
                 <Label Content="Retransmit Hop/Node Count"
                        Grid.Row="19"
                        Grid.Column="0" 
@@ -408,9 +447,6 @@
                             HorizontalAlignment="Center">
 
                     </Slider>
-
-
-
                 </StackPanel>
                 
             </Grid>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -425,5 +425,17 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
 
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }
+
+        public int ArchiveLimit
+        {
+            get => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_RETENTION).IntValue;
+            set
+            {
+                ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_RETENTION,
+                    value.ToString());
+
+                _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+            }
+        }
     }
 }

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -208,6 +208,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
 
         public string ShowTransmitterNameText
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.SHOW_TRANSMITTER_NAME).BoolValue ? "ON" : "OFF";
+
+        public string TransmissionLogEnabledText
+            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue ? "ON" : "OFF";
+
+        //public string TransmissionArchiveHistory
+        //    =>  
+
         public string ListeningPort
             => ServerSettingsStore.Instance.GetServerSetting(ServerSettingsKeys.SERVER_PORT).StringValue;
 
@@ -406,6 +413,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
             var newSetting = ShowTransmitterNameText != "ON";
             ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.SHOW_TRANSMITTER_NAME, newSetting);
             NotifyOfPropertyChange(() => ShowTransmitterNameText);
+
+            _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+        }
+
+        public void TransmissionLogEnabledToggle()
+        {
+            var newSetting = TransmissionLogEnabledText != "ON";
+            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED, newSetting);
+            NotifyOfPropertyChange(() => TransmissionLogEnabledText);
 
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }


### PR DESCRIPTION
Implement feature request as per #506 

Changes
- Updated Bootstrapper.cs to add new rule for writing transmissions and allow for runtime alteration of logging rules 
- Added server logging of client transmissions received to a .CSV file
- Included server settings for logging and logging duration (defaults to OFF and 2 days respectively)

