### PR TITLE
Server Favorites Drag & Drop

### DIFF
--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml
@@ -85,9 +85,22 @@
                   HorizontalAlignment="Center"
                   AutoGenerateColumns="False"
                   ItemsSource="{Binding Path=Addresses}"
-                  SelectedItem="{Binding Path=SelectedItem}">
+                  SelectedItem="{Binding Path=SelectedItem}"
+                  SelectionMode="Single"
+                  AllowDrop="True"
+                  DragOver="FavouritesGrid_DragOver"
+                  DragEnter="FavouritesGrid_DragEnter" CanUserResizeRows="False" CanUserDeleteRows="False"
+                    >
+
+            <DataGrid.CellStyle>
+                <Style TargetType="{x:Type DataGridCell}">
+                    <EventSetter Event="MouseMove" Handler="DataGridRow_MouseMove"/>
+                    <EventSetter Event="Drop" Handler="DataGridRow_Drop" />
+                </Style>
+            </DataGrid.CellStyle>
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding Path=Name}" Header="Name" />
+                <DataGridTextColumn Binding="{Binding Path=Name}" Header="Name">
+                </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding Path=Address}" Header="ServerAddress/port" />
                 <DataGridTextColumn Binding="{Binding Path=EAMCoalitionPassword}" Header="EAM coal. pass" />
                 <DataGridTemplateColumn Header="Is Default">

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml
@@ -88,16 +88,20 @@
                   SelectedItem="{Binding Path=SelectedItem}"
                   SelectionMode="Single"
                   AllowDrop="True"
-                  DragOver="FavouritesGrid_DragOver"
-                  DragEnter="FavouritesGrid_DragEnter" CanUserResizeRows="False" CanUserDeleteRows="False"
                     >
 
-            <DataGrid.CellStyle>
-                <Style TargetType="{x:Type DataGridCell}">
+            <DataGrid.RowStyle>
+                <Style TargetType="{x:Type DataGridRow}">
                     <EventSetter Event="MouseMove" Handler="DataGridRow_MouseMove"/>
                     <EventSetter Event="Drop" Handler="DataGridRow_Drop" />
+                    <Style.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="{x:Static SystemColors.HighlightBrush}"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                        </Trigger>
+                    </Style.Triggers>
                 </Style>
-            </DataGrid.CellStyle>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Path=Name}" Header="Name">
                 </DataGridTextColumn>

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -23,6 +25,62 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow
         public FavouriteServersView()
         {
             InitializeComponent();
+        }
+
+        private void DataGridRow_Drop(object sender, DragEventArgs e)
+        {
+            ServerAddress droppedAddress = (ServerAddress)e.Data.GetData(typeof(ServerAddress));
+
+            DataGridRow targetGridRow = sender as DataGridRow;
+            ServerAddress targetAddress = targetGridRow.DataContext as ServerAddress;
+
+
+
+            ObservableCollection<ServerAddress> serverAddresses = FavouritesGrid.ItemsSource as ObservableCollection<ServerAddress>;
+
+            serverAddresses.Move(serverAddresses.IndexOf(droppedAddress), serverAddresses.IndexOf(targetAddress));
+        }
+
+        private void DataGridRow_MouseMove(object sender, MouseEventArgs e)
+        {
+            DataGridCell selectedRow = sender as DataGridCell;
+
+            if (selectedRow != null && e.LeftButton == MouseButtonState.Pressed)
+            {
+                ServerAddress serverAddress = selectedRow.DataContext as ServerAddress;
+                
+                try 
+                {
+                    DragDrop.DoDragDrop(FavouritesGrid, serverAddress, DragDropEffects.Move);
+                }
+                catch(Exception ex)
+                {
+                    // catches any out of bounds movements, should probably be replaced with validation at some point
+                }
+                               
+            }
+        }
+        public void DataGridRow_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+
+        private void DataGridRow_DragEnter(object sender, DragEventArgs e)
+        {
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+        private void FavouritesGrid_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+
+        private void FavouritesGrid_DragEnter(object sender, DragEventArgs e)
+        {
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
         }
     }
 }

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersView.xaml.cs
@@ -43,7 +43,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow
 
         private void DataGridRow_MouseMove(object sender, MouseEventArgs e)
         {
-            DataGridCell selectedRow = sender as DataGridCell;
+            DataGridRow selectedRow = sender as DataGridRow;
 
             if (selectedRow != null && e.LeftButton == MouseButtonState.Pressed)
             {
@@ -56,31 +56,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow
                 catch(Exception ex)
                 {
                     // catches any out of bounds movements, should probably be replaced with validation at some point
-                }
-                               
+                }                              
             }
-        }
-        public void DataGridRow_DragOver(object sender, DragEventArgs e)
-        {
-            e.Effects = DragDropEffects.Move;
-            e.Handled = true;
-        }
-
-        private void DataGridRow_DragEnter(object sender, DragEventArgs e)
-        {
-            e.Effects = DragDropEffects.Move;
-            e.Handled = true;
-        }
-        private void FavouritesGrid_DragOver(object sender, DragEventArgs e)
-        {
-            e.Effects = DragDropEffects.Move;
-            e.Handled = true;
-        }
-
-        private void FavouritesGrid_DragEnter(object sender, DragEventArgs e)
-        {
-            e.Effects = DragDropEffects.Move;
-            e.Handled = true;
         }
     }
 }

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
@@ -146,6 +146,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.Favourites
                     address.PropertyChanged -= OnServerAddressPropertyChanged;
                 }
             }
+
+            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
+            {
+                Save();
+            }
         }
 
         private void OnServerAddressPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
Added drag and drop functionality as per feature request #297 

Changes

- Added drag and drop of row objects
- Added saving on move actions when CollectionChanged event fires

I'm not sure if this implementation is really the best possible option as I'm not that familiar with WPF. I do know that this does violate MVVM though, as the XAML code behind does manipulate an ObservableCollection, so this might need to get rewritten if that'll be an issue.