### PR TITLE
Fix for exporter error on dcs.log

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -208,6 +208,7 @@ function SR.exporter()
         SR.lastKnownPos = _point
 
         _lastUnitId = ""
+        _lastUnitType = ""
     end
 
     if SR.unicast then


### PR DESCRIPTION
Fixes error after player leaves slot due to _lastUnitType not being reset after leaving F/A-18C slot.