### PR TITLE
Fix for dcs.log error on F18 ejection

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -3952,8 +3952,11 @@ LuaExportBeforeNextFrame = function()
 
     -- Check F/A-18C ENT keypress (needs to be checked in LuaExportBeforeNextFrame not to be missed)
     if _lastUnitType == "FA-18C_hornet" then
-        if not _fa18ent and SR.getButtonPosition(122) > 0 then
-            _fa18ent = true
+        if not _fa18ent then
+            local st, rv = pcall(SR.getButtonPosition, 122)     -- pcall to prevent dcs.log error after ejection
+            if st and rv > 0 then
+                _fa18ent = true
+            end
         end
     end
 


### PR DESCRIPTION
May not actually be a necessary thing to fix as it is just nuisance and the extra pcall will waste some cycles, but, if you prefer it fixed, this fixes the dcs.log error on F18 ejection as in the title.