### PR TITLE
A10C KY-58 EMER/GRD fixes

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Export.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Export.lua
@@ -1804,10 +1804,10 @@ function SR.exportRadioA10C(_data)
         -- Power on!
 
         local _radio = nil
-        if SR.round(SR.getButtonPosition(781), 0.1) == 0.2 then
+        if SR.round(SR.getButtonPosition(781), 0.1) == 0.2 and SR.getSelectorPosition(149, 0.1) >= 2 then   -- encryption disabled when EMER AM/FM selected
             --crad/2 vhf - FM
             _radio = _data.radios[4]
-        elseif SR.getButtonPosition(781) == 0 then
+        elseif SR.getButtonPosition(781) == 0 and _selector ~= 2 then    -- encryption disabled when GRD selected
             --crad/1 uhf
             _radio = _data.radios[3]
         end


### PR DESCRIPTION
From the A-10C dash 1:
"The KY-58 will switch over from cipher to plain communications whenever GUARD is selected on the UHF radio or whenever EMER is selected on the VHF/FM radio."

This disables overrides encryption if GRD (UHF) or AM/FM EMER (VHF/FM) are selected in the actively encrypted radio.