### PR TITLE
Release 2.0.1.0

### DIFF
--- a/AutoUpdater/Properties/AssemblyInfo.cs
+++ b/AutoUpdater/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -567,7 +567,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                             break;
                         }
                         else if ((int)bindState.MainDevice.InputBind >= (int)InputBinding.Up100 &&
-                                 (int)bindState.MainDevice.InputBind <= (int)InputBinding.RadioVolumeDown)
+                                 (int)bindState.MainDevice.InputBind <= (int)InputBinding.IntercomPTT)
                         {
                             if (bindState.MainDevice.InputBind == _lastActiveBinding && !bindState.IsActive)
                             {
@@ -758,7 +758,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
             //REMEMBER TO UPDATE THIS WHEN NEW BINDINGS ARE ADDED
             //MIN + MAX bind numbers
-            for (int i = (int)InputBinding.Intercom; i <= (int)InputBinding.RadioVolumeDown; i++)
+            for (int i = (int)InputBinding.Intercom; i <= (int)InputBinding.IntercomPTT; i++)
             {
                 if (!currentInputProfile.ContainsKey((InputBinding)i))
                 {

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -62,6 +62,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private long _lastPTTPress; // to handle dodgy PTT - release time
         private long _firstPTTPress; // to delay start PTT time
 
+        private volatile bool _intercomPtt;
+
         private volatile bool _ready;
 
         private IPEndPoint _serverEndpoint;
@@ -166,6 +168,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 var currentPtt = _ptt;
 
                 var ptt = false;
+                var intercomPtt = false;
                 foreach (var inputBindState in pressed)
                 {
                     if (inputBindState.IsActive)
@@ -207,6 +210,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                         {
                             _lastPTTPress = DateTime.Now.Ticks;
                             ptt = true;
+                        }else if (inputBindState.MainDevice.InputBind == InputBinding.IntercomPTT)
+                        {
+                            intercomPtt = true;
+
                         }
                     }
                 }
@@ -271,8 +278,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                  * End Handle PTT HOLD after release
                  */
 
-            
 
+                _intercomPtt = intercomPtt;
                 _ptt = ptt;
             });
 
@@ -749,6 +756,17 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 return true;
             }
 
+            //anything below 30 MHz and AM ignore (AM stand-in for actual HF modulations)
+            for (int i = 0; i < udpVoicePacket.Frequencies.Length; i++)
+            {
+                if (udpVoicePacket.Modulations[i] == (int)Modulation.AM 
+                    && udpVoicePacket.Frequencies[i] <= RadioCalculator.HF_FREQUENCY_LOS_IGNORED)
+                {
+                    //assume HF is bouncing off the sky for now
+                    return true;
+                }
+            }
+
             SRClient transmittingClient;
             if (_clients.TryGetValue(udpVoicePacket.Guid, out transmittingClient))
             {
@@ -871,9 +889,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             //If its a hot intercom and thats not the currently selected radio
             //this is special logic currently for the gazelle as it has a hot mic, but no way of knowing if you're transmitting from the module itself
             //so we have to figure out what you're transmitting on in SRS
-            if (radioInfo.intercomHotMic 
+            if ((radioInfo.intercomHotMic
                 && radioInfo.control == DCSPlayerRadioInfo.RadioSwitchControls.IN_COCKPIT
                 && radioInfo.selected != 0 && !_ptt && !radioInfo.ptt)
+                || _intercomPtt)
             {
                 if (radioInfo.radios[0].modulation == RadioInformation.Modulation.INTERCOM)
                 {

--- a/DCS-SR-Client/Properties/AssemblyInfo.cs
+++ b/DCS-SR-Client/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -198,6 +198,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         RadioVolumeDown = 135,
         ModifierRadioVolumeDown = 235,
+
+        IntercomPTT = 136,
+        ModifierIntercomPTT = 236,
     }
 
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -420,189 +420,195 @@
                                                        ControlInputBinding="{x:Static settings:InputBinding.Intercom}"
                                                        InputName="Intercom Select" />
 
-                            <local:InputBindingControl x:Name="RadioOverlay"
+                            <local:InputBindingControl x:Name="IntercomPTT"
                                                        Grid.Row="6"
+                                                       Grid.ColumnSpan="5"
+                                                       ControlInputBinding="{x:Static settings:InputBinding.IntercomPTT}"
+                                                       InputName="Special Intercom Select &amp; PTT" />
+
+                            <local:InputBindingControl x:Name="RadioOverlay"
+                                                       Grid.Row="7"
                                                        Grid.ColumnSpan="6"
                                                        ControlInputBinding="{x:Static settings:InputBinding.OverlayToggle}"
                                                        InputName="Overlay Toggle" />
 
                             <local:InputBindingControl x:Name="Radio4"
-                                                       Grid.Row="7"
+                                                       Grid.Row="8"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch4}"
                                                        InputName="Radio 4" />
                             <local:InputBindingControl x:Name="Radio5"
-                                                       Grid.Row="8"
+                                                       Grid.Row="9"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch5}"
                                                        InputName="Radio 5" />
                             <local:InputBindingControl x:Name="Radio6"
-                                                       Grid.Row="9"
+                                                       Grid.Row="10"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch6}"
                                                        InputName="Radio 6" />
 
                             <local:InputBindingControl x:Name="Radio7"
-                                                       Grid.Row="10"
+                                                       Grid.Row="11"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch7}"
                                                        InputName="Radio 7" />
 
                             <local:InputBindingControl x:Name="Radio8"
-                                                       Grid.Row="11"
+                                                       Grid.Row="12"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch8}"
                                                        InputName="Radio 8" />
 
                             <local:InputBindingControl x:Name="Radio9"
-                                                       Grid.Row="12"
+                                                       Grid.Row="13"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch9}"
                                                        InputName="Radio 9" />
 
                             <local:InputBindingControl x:Name="Radio10"
-                                                       Grid.Row="13"
+                                                       Grid.Row="14"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch10}"
                                                        InputName="Radio 10" />
 
 
                             <local:InputBindingControl x:Name="Up100"
-                                                       Grid.Row="14"
+                                                       Grid.Row="15"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up100}"
                                                        InputName="Up 100MHz" />
 
                             <local:InputBindingControl x:Name="Up10"
-                                                       Grid.Row="15"
+                                                       Grid.Row="16"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up10}"
                                                        InputName="Up 10MHz" />
 
                             <local:InputBindingControl x:Name="Up1"
-                                                       Grid.Row="16"
+                                                       Grid.Row="17"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up1}"
                                                        InputName="Up 1MHz" />
 
                             <local:InputBindingControl x:Name="Up01"
-                                                       Grid.Row="17"
+                                                       Grid.Row="18"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up01}"
                                                        InputName="Up 0.1MHz" />
 
                             <local:InputBindingControl x:Name="Up001"
-                                                       Grid.Row="18"
+                                                       Grid.Row="19"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up001}"
                                                        InputName="Up 0.01MHz" />
 
                             <local:InputBindingControl x:Name="Up0001"
-                                                       Grid.Row="19"
+                                                       Grid.Row="20"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up0001}"
                                                        InputName="Up 0.001MHz" />
 
 
                             <local:InputBindingControl x:Name="Down100"
-                                                       Grid.Row="20"
+                                                       Grid.Row="21"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down100}"
                                                        InputName="Down 100MHz" />
 
                             <local:InputBindingControl x:Name="Down10"
-                                                       Grid.Row="21"
+                                                       Grid.Row="22"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down10}"
                                                        InputName="Down 10MHz" />
 
                             <local:InputBindingControl x:Name="Down1"
-                                                       Grid.Row="22"
+                                                       Grid.Row="23"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down1}"
                                                        InputName="Down 1MHz" />
 
                             <local:InputBindingControl x:Name="Down01"
-                                                       Grid.Row="23"
+                                                       Grid.Row="24"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down01}"
                                                        InputName="Down 0.1MHz" />
 
                             <local:InputBindingControl x:Name="Down001"
-                                                       Grid.Row="24"
+                                                       Grid.Row="25"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down001}"
                                                        InputName="Down 0.01MHz" />
 
                             <local:InputBindingControl x:Name="Down0001"
-                                                       Grid.Row="25"
+                                                       Grid.Row="26"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down0001}"
                                                        InputName="Down 0.001MHz" />
 
                             <local:InputBindingControl x:Name="ToggleGuard"
-                                                       Grid.Row="26"
+                                                       Grid.Row="27"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleGuard}"
                                                        InputName="Toggle Guard" />
 
                             <local:InputBindingControl x:Name="NextRadio"
-                                                       Grid.Row="27"
+                                                       Grid.Row="28"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.NextRadio}"
                                                        InputName="Next Radio" />
 
 
                             <local:InputBindingControl x:Name="PreviousRadio"
-                                                       Grid.Row="28"
+                                                       Grid.Row="29"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.PreviousRadio}"
                                                        InputName="Previous Radio" />
 
                             <local:InputBindingControl x:Name="ToggleEncryption"
-                                                       Grid.Row="29"
+                                                       Grid.Row="30"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleEncryption}"
                                                        InputName="Toggle Encryption" />
 
                             <local:InputBindingControl x:Name="EncryptionKeyIncrease"
-                                                       Grid.Row="30"
+                                                       Grid.Row="31"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyIncrease}"
                                                        InputName="Encryption Key Increase" />
 
                             <local:InputBindingControl x:Name="EncryptionKeyDecrease"
-                                                       Grid.Row="31"
+                                                       Grid.Row="32"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyDecrease}"
                                                        InputName="Encryption Key Decrease" />
 
                             <local:InputBindingControl x:Name="RadioChannelUp"
-                                                       Grid.Row="32"
+                                                       Grid.Row="33"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelUp}"
                                                        InputName="Radio Channel Up" />
 
                             <local:InputBindingControl x:Name="RadioChannelDown"
-                                                       Grid.Row="33"
+                                                       Grid.Row="34"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelDown}"
                                                        InputName="Radio Channel Down" />
 
                             <local:InputBindingControl x:Name="TransponderIDENT"
-                                                       Grid.Row="34"
+                                                       Grid.Row="35"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.TransponderIDENT}"
                                                        InputName="Transponder IDENT" />
 
                             <local:InputBindingControl x:Name="RadioVolumeUp"
-                                                       Grid.Row="35"
+                                                       Grid.Row="36"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeUp}"
                                                        InputName="Radio Volume Up" />
 
                             <local:InputBindingControl x:Name="RadioVolumeDown"
-                                                       Grid.Row="36"
+                                                       Grid.Row="37"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeDown}"
                                                        InputName="Radio Volume Down" />

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -365,6 +365,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             Intercom.ControlInputBinding = InputBinding.Intercom;
             Intercom.InputDeviceManager = InputManager;
 
+            IntercomPTT.InputName = "Special Intercom Select & PTT";
+            IntercomPTT.ControlInputBinding = InputBinding.IntercomPTT;
+            IntercomPTT.InputDeviceManager = InputManager;
+
             RadioOverlay.InputName = "Overlay Toggle";
             RadioOverlay.ControlInputBinding = InputBinding.OverlayToggle;
             RadioOverlay.InputDeviceManager = InputManager;
@@ -520,6 +524,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             Radio3.LoadInputSettings();
             PTT.LoadInputSettings();
             Intercom.LoadInputSettings();
+            IntercomPTT.LoadInputSettings();
             RadioOverlay.LoadInputSettings();
             Radio4.LoadInputSettings();
             Radio5.LoadInputSettings();

--- a/DCS-SR-Common/Helpers/RadioCalculator.cs
+++ b/DCS-SR-Common/Helpers/RadioCalculator.cs
@@ -5,6 +5,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 {
     public class RadioCalculator
     {
+        public static readonly double HF_FREQUENCY_LOS_IGNORED = 3e+7;
         public static readonly int TransmissonPowerdBm = 40; //10 watts
         public static readonly int RxAntennaGain = 1;
         public static readonly int TxAntennaGain = 1;

--- a/DCS-SR-Common/Network/UpdaterChecker.cs
+++ b/DCS-SR-Common/Network/UpdaterChecker.cs
@@ -21,7 +21,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 
         public static readonly string MINIMUM_PROTOCOL_VERSION = "1.9.0.0";
 
-        public static readonly string VERSION = "2.0.0.0";
+        public static readonly string VERSION = "2.0.1.0";
 
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/DCS-SR-ExternalAudio/Properties/AssemblyInfo.cs
+++ b/DCS-SR-ExternalAudio/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/DCS-SimpleRadio Server/Properties/AssemblyInfo.cs
+++ b/DCS-SimpleRadio Server/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/Installer/Properties/AssemblyInfo.cs
+++ b/Installer/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -1,4 +1,4 @@
--- Version 2.0.0.0
+-- Version 2.0.1.0
 -- ONLY COPY THIS WHOLE FILE IS YOU ARE GOING TO HOST A SERVER!
 -- The file must be in Saved Games\DCS\Scripts\Hooks or Saved Games\DCS.openalpha\Scripts\Hooks
 -- Make sure you enter the correct address into SERVER_SRS_HOST and SERVER_SRS_PORT (5002 by default) below.
@@ -225,4 +225,4 @@ SRSAuto.sendMessage = function(msg, showTime, gid)
 end
 
 DCS.setUserCallbacks(SRSAuto)
-net.log("Loaded - DCS-SRS-AutoConnect 2.0.0.0")
+net.log("Loaded - DCS-SRS-AutoConnect 2.0.1.0")

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
@@ -1,9 +1,9 @@
--- Version 2.0.0.0
+-- Version 2.0.1.0
 -- Make sure you COPY this file to the same location as the Export.lua as well! 
 -- Otherwise the Overlay will not work
 
 
-net.log("Loading - DCS-SRS Overlay GameGUI - Ciribob: 2.0.0.0 ")
+net.log("Loading - DCS-SRS Overlay GameGUI - Ciribob: 2.0.1.0 ")
 
 local base = _G
 
@@ -251,12 +251,15 @@ function srsOverlay.updateRadio()
                     fullMessage = fullMessage.." OFF"
                 end
             elseif _radio.modulation == 3 then
-                     fullMessage = ""
+                fullMessage = ""
                     
             elseif _radio.modulation == 2 then 
 
-                     fullMessage = "INTERCOM "
-                
+                fullMessage = "INTERCOM"
+
+                if srsOverlay.getMode() == _modes.minimum_vol or srsOverlay.getMode() == _modes.full  then
+                    fullMessage  = fullMessage.." - "..string.format("%.1f", _radio.volume*100).."%"
+                end 
             else
                  fullMessage = _radio.name.." - "
 
@@ -311,13 +314,14 @@ function srsOverlay.updateRadio()
 
             if _selected then
                 fullMessage = fullMessage.." *"
+            end
 
-                if _radioState.RadioSendingState
-                        and _radioState.RadioSendingState.SendingOn == _i -1
-                        and _radioState.RadioSendingState.IsSending then
+            if _radioState.RadioSendingState
+                and _radioState.RadioSendingState.SendingOn == _i -1
+                and _radioState.RadioSendingState.IsSending then
 
-                    fullMessage = fullMessage.." +TR"
-                end
+                fullMessage = fullMessage.." +TR"
+                
              elseif _radioState.RadioSendingState 
                 and  _radioState.RadioSendingState.IsSending 
                 and  _radio.simul 
@@ -668,4 +672,4 @@ end
 
 DCS.setUserCallbacks(srsOverlay)
 
-net.log("Loaded - DCS-SRS Overlay GameGUI - Ciribob: 2.0.0.0 ")
+net.log("Loaded - DCS-SRS Overlay GameGUI - Ciribob: 2.0.1.0 ")

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -1,13 +1,11 @@
--- Version 2.0.0.0
+-- Version 2.0.1.0
 -- Make sure you COPY this file to the same location as the Export.lua as well! 
 -- Otherwise the Radio Might not work
 
-net.log("Loading - DCS-SRS GameGUI - Ciribob: 2.0.0.0")
+net.log("Loading - DCS-SRS GameGUI - Ciribob: 2.0.1.0")
 local SRS = {}
 
 SRS.CLIENT_ACCEPT_AUTO_CONNECT = true --- Set to false if you want to disable AUTO CONNECT
-
-SRS.unicast = true
 
 SRS.dbg = {}
 SRS.logFile = io.open(lfs.writedir()..[[Logs\DCS-SRS-GameGUI.log]], "w")
@@ -97,15 +95,10 @@ SRS.sendUpdate = function(playerID)
 	    end
 	end
 
+	local _jsonUpdate = SRS.JSON:encode(_update).." \n"
     --SRS.log("Update -  Slot  ID:"..playerID.." Name: ".._update.name.." Side: ".._update.side)
-
-	if SRS.unicast then
-		socket.try(SRS.UDPSendSocket:sendto(SRS.JSON:encode(_update).." \n", "127.0.0.1", 5068))
-	else
-		socket.try(SRS.UDPSendSocket:sendto(SRS.JSON:encode(_update).." \n", "127.255.255.255", 5068))
-	end
-
-
+	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 5068))
+	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 9087))
 end
 
 SRS.MESSAGE_PREFIX_OLD = "This server is running SRS on - " -- DO NOT MODIFY!!!
@@ -134,21 +127,13 @@ end
 -- Register callbacks --
 
 SRS.sendConnect = function(_message)
-
-    if SRS.unicast then
-        socket.try(SRS.UDPSendSocket:sendto(_message.."\n", "127.0.0.1", 5069))
-    else
-        socket.try(SRS.UDPSendSocket:sendto(_message.."\n", "127.255.255.255", 5069))
-    end
+	socket.try(SRS.UDPSendSocket:sendto(_message.."\n", "127.0.0.1", 5069))
 end
 
 SRS.sendCommand = function(_message)
 
-    if SRS.unicast then
-        socket.try(SRS.UDPSendSocket:sendto(SRS.JSON:encode(_message).."\n", "127.0.0.1", 9040))
-    else
-        socket.try(SRS.UDPSendSocket:sendto(SRS.JSON:encode(_message).."\n", "127.255.255.255", 9040))
-    end
+    socket.try(SRS.UDPSendSocket:sendto(SRS.JSON:encode(_message).."\n", "127.0.0.1", 9040))
+   
 end
 
 SRS.findCommandValue = function(key, list)
@@ -369,5 +354,5 @@ end
 
 DCS.setUserCallbacks(SRS)
 
-net.log("Loaded - DCS-SRS GameGUI - Ciribob: 2.0.0.0")
+net.log("Loaded - DCS-SRS GameGUI - Ciribob: 2.0.1.0")
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1,12 +1,14 @@
--- Version 2.0.0.0
+-- Version 2.0.1.0
 -- Special thanks to Cap. Zeen, Tarres and Splash for all the help
 -- with getting the radio information :)
 -- Run the installer to correctly install this file
 local SR = {}
 
+SR.SEAT_INFO_PORT = 9087
 SR.LOS_RECEIVE_PORT = 9086
 SR.LOS_SEND_TO_PORT = 9085
 SR.RADIO_SEND_TO_PORT = 9084
+
 
 SR.LOS_HEIGHT_OFFSET = 20.0 -- sets the line of sight offset to simulate radio waves bending
 SR.LOS_HEIGHT_OFFSET_MAX = 200.0 -- max amount of "bend"
@@ -15,6 +17,7 @@ SR.LOS_HEIGHT_OFFSET_STEP = 20.0 -- Interval to "bend" in
 SR.unicast = true --DONT CHANGE THIS
 
 SR.lastKnownPos = { x = 0, y = 0, z = 0 }
+SR.lastKnownSeat = 0
 
 SR.MIDS_FREQ = 1030.0 * 1000000 -- Start at UHF 300
 SR.MIDS_FREQ_SEPARATION = 1.0 * 100000 -- 0.1 MHZ between MIDS channels
@@ -54,10 +57,14 @@ SR.JSON = JSON
 
 SR.UDPSendSocket = socket.udp()
 SR.UDPLosReceiveSocket = socket.udp()
+SR.UDPSeatReceiveSocket = socket.udp()
 
 --bind for listening for LOS info
 SR.UDPLosReceiveSocket:setsockname("*", SR.LOS_RECEIVE_PORT)
 SR.UDPLosReceiveSocket:settimeout(0) --receive timer was 0001
+
+SR.UDPSeatReceiveSocket:setsockname("*", SR.SEAT_INFO_PORT)
+SR.UDPSeatReceiveSocket:settimeout(0) 
 
 local terrain = require('terrain')
 
@@ -219,7 +226,7 @@ function SR.exporter()
 end
 
 
-function SR.readSocket()
+function SR.readLOSSocket()
     -- Receive buffer is 8192 in LUA Socket
     -- will contain 10 clients for LOS
     local _received = SR.UDPLosReceiveSocket:receive()
@@ -238,6 +245,21 @@ function SR.readSocket()
             else
                 socket.try(SR.UDPSendSocket:sendto(SR.JSON:encode(_losList) .. " \n", "127.255.255.255", SR.LOS_SEND_TO_PORT))
             end
+        end
+
+    end
+end
+
+function SR.readSeatSocket()
+    -- Receive buffer is 8192 in LUA Socket
+    local _received = SR.UDPSeatReceiveSocket:receive()
+
+    if _received then
+        local _decoded = SR.JSON:decode(_received)
+
+        if _decoded then
+            SR.lastKnownSeat = _decoded.seat
+            --SR.log("lastKnownSeat "..SR.lastKnownSeat)
         end
 
     end
@@ -501,47 +523,257 @@ function SR.exportRadioSU27(_data)
 end
 
 function SR.exportRadioAH64D(_data)
-    _data.capabilities = { dcsPtt = false, dcsIFF = false, dcsRadioSwitch = false, intercomHotMic = true, desc = "" }
+    _data.capabilities = { dcsPtt = false, dcsIFF = false, dcsRadioSwitch = true, intercomHotMic = true, desc = "Recommended: Always Allow SRS Hotkeys - OFF. Bind Intercom Select & PTT, Radio PTT and DCS RTS up down" }
+
+-- 17 is the pilot (back seat)
+-- 18 is the gunner (front seat)
+-- Rts_FM1 is LEFT (single underscore) - current radio selected
+-- Rts__FM1 is RIGHT (double underscore) - current radio selected in the OTHER seat (swaps if front or back)
+-- we only care bout LEFT
+-- { ["Net_FM1"] = ,
+-- ["Net_Standby_FM2"] = ,
+-- ["Frequency_Standby_VHF"] = 121.500,
+-- ["Idm_FM2"] = ,
+-- ["Idm_UHF"] = ,
+-- ["Transponder_ID"] = XPNDR,
+-- ["Net_VHF"] = ,
+-- ["PowerStatus_FM1"] = NORM,
+-- ["AdvisoryList_1"] = TAIL WHL LOCK SEL ,
+-- ["Rts__FM1"] = =,
+-- ["Idm_FM1"] = ],
+-- ["Squelch_FM2"] = *,
+-- ["Net_Standby_FM1"] = ,
+-- ["Net_Standby_VHF"] = ,
+-- ["Symbols_1"] = |,
+-- ["RadioStats_HF"] = ,
+-- ["Call_Standby_FM2"] = -----,
+-- ["Idm_VHF"] = [,
+-- ["Call_Standby_VHF"] = -----,
+-- ["PowerStatus_HF"] = LOW,
+-- ["Frequency_FM1"] =  30.000,
+-- ["Symbols_5"] = |,
+-- ["Arrows_3"] = |,
+-- ["Symbols_10"] = |,
+-- ["Rts_FM1_"] = =,
+-- ["Symbols_6"] = |,
+-- ["Radio_VHF"] = VHF,
+-- ["Symbols_4"] = |,
+-- ["Squelch_VHF"] = *,
+-- ["Transponder_MODE_3A"] = 1200,
+-- ["Rts__VHF"] = =,
+-- ["Call_Standby_FM1"] = -----,
+-- ["Call_UHF"] = -----,
+-- ["Frequency_VHF"] = 121.000,
+-- ["Radio_FM1"] = FM1,
+-- ["background"] = ,
+-- ["Frequency_Standby_UHF"] = 305.000,
+-- ["Transponder_MC"] = NORM,
+-- ["Call_VHF"] = -----,
+-- ["Call_FM2"] = -----,
+-- ["Net_UHF"] = ,
+-- ["Arrows_4"] = |,
+-- ["Symbols_7"] = |,
+-- ["Frequency_HF"] =   2.0000A,
+-- ["Watch_"] = 04:02:40 Z,
+-- ["Frequency_Standby_FM1"] =  30.000,
+-- ["Symbols_2"] = |,
+-- ["Frequency_FM2"] =  30.000,
+-- ["Rts__FM2"] = =,
+-- ["XPNDR_MODE_S"] = S,
+-- ["Call_FM1"] = -----,
+-- ["Fuel_"] = 3140,
+-- ["Fuel"] = FUEL,
+-- ["XPNDR_MODE_4"] = A,
+-- ["Call_Standby_HF"] = -----,
+-- ["Symbols_3"] = |,
+-- ["Call_Standby_UHF"] = -----,
+-- ["Frequency_Standby_HF"] =   2.0000A,
+-- ["Frequency_Standby_FM2"] =  30.000,
+-- ["Idm_HF"] = ,
+-- ["Net_FM2"] = ,
+-- ["Rts__UHF"] = >,
+-- ["Rts_HF_"] = =,
+-- ["Guard"] = ,
+-- ["Symbols_9"] = |,
+-- ["Squelch_HF"] = *,
+-- ["Radio_HF"] = HF ,
+-- ["Arrows_1"] = |,
+-- ["Squelch_UHF"] = *,
+-- ["Squelch_FM1"] = *,
+-- ["Radio_FM2"] = FM2,
+-- ["Rts__HF"] = =,
+-- ["Arrows_2"] = |,
+-- ["Symbols_8"] = |,
+-- ["Rts_VHF_"] = =,
+-- ["Frequency_UHF"] = 305.000,
+-- ["Call_HF"] = -----,
+-- ["Rts_UHF_"] = =,
+-- ["Rts_FM2_"] = <,
+-- ["Radio_UHF"] = UHF,
+-- ["Net_Standby_UHF"] = ,
+-- } 
+
+    -- Check if player is in a new aircraft
+    if _lastUnitId ~= _data.unitId then
+        -- New aircraft; SENS volume is at 0
+        local _device = GetDevice(0)
+
+        if _device then
+            _device:set_argument_value(345, 1.0) -- Pilot SENS
+            _device:set_argument_value(344, 1.0) -- Pilot Master
+            _device:set_argument_value(386, 1.0) -- Gunner SENS
+            _device:set_argument_value(385, 1.0) -- Gunner Master
+        end
+    end
 
     _data.radios[1].name = "Intercom"
     _data.radios[1].freq = 100.0
     _data.radios[1].modulation = 2 --Special intercom modulation
-    _data.radios[1].volume = 1.0
-    _data.radios[1].volMode = 1
+    _data.radios[1].volMode = 0
 
     _data.radios[2].name = "VHF-ARC-186"
     _data.radios[2].freq = SR.getRadioFrequency(58)
     _data.radios[2].modulation = SR.getRadioModulation(58)
-    _data.radios[2].volume = 1.0
-    _data.radios[2].volMode = 1
+    _data.radios[2].volMode = 0
 
     _data.radios[3].name = "UHF-ARC-164"
     _data.radios[3].freq = SR.getRadioFrequency(57)
     _data.radios[3].modulation = SR.getRadioModulation(57)
-    _data.radios[3].volume = 1.0
-    _data.radios[3].volMode = 1
+    _data.radios[3].volMode = 0
 
     _data.radios[4].name = "FM1-ARC-201D"
     _data.radios[4].freq = SR.getRadioFrequency(59)
     _data.radios[4].modulation = SR.getRadioModulation(59)
-    _data.radios[4].volume = 1.0
-    _data.radios[4].volMode = 1
+    _data.radios[4].volMode = 0
 
     _data.radios[5].name = "FM2-ARC-201D"
     _data.radios[5].freq = SR.getRadioFrequency(60)
     _data.radios[5].modulation = SR.getRadioModulation(60)
-    _data.radios[5].volume = 1.0
-    _data.radios[5].volMode = 1
+    _data.radios[5].volMode = 0
 
     _data.radios[6].name = "HF-ARC-220"
     _data.radios[6].freq = SR.getRadioFrequency(61)
     _data.radios[6].modulation = 0
-    _data.radios[6].volume = 1.0
-    _data.radios[6].volMode = 1
+    _data.radios[6].volMode = 0
 
-    _data.control = 0;
-    _data.selected = 1
+    local _radioPanel = nil
 
+    if SR.lastKnownSeat == 0 then
+
+        _radioPanel = SR.getListIndicatorValue(17)
+
+        local _masterVolume = SR.getRadioVolume(0, 344, { 0.0, 1.0 }, false) 
+        
+        --intercom 
+        _data.radios[1].volume = SR.getRadioVolume(0, 345, { 0.0, 1.0 }, false) * _masterVolume
+
+        -- VHF
+        if SR.getButtonPosition(449) == 0 then
+            _data.radios[2].volume = SR.getRadioVolume(0, 334, { 0.0, 1.0 }, false) * _masterVolume 
+        else
+            _data.radios[2].volume = 0
+        end
+
+        -- UHF
+        if SR.getButtonPosition(450) == 0 then
+            _data.radios[3].volume = SR.getRadioVolume(0, 335, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[3].volume = 0
+        end
+
+        -- FM1
+        if SR.getButtonPosition(451) == 0 then
+            _data.radios[4].volume = SR.getRadioVolume(0, 336, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[4].volume = 0
+        end
+
+         -- FM2
+        if SR.getButtonPosition(452) == 0 then
+            _data.radios[5].volume = SR.getRadioVolume(0, 337, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[5].volume = 0
+        end
+
+         -- HF
+        if SR.getButtonPosition(453) == 0 then
+            _data.radios[6].volume = SR.getRadioVolume(0, 338, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[6].volume = 0
+        end
+
+         if SR.getButtonPosition(346) ~= 1 then
+            _data.intercomHotMic = true
+        end
+
+    else
+        local _masterVolume = SR.getRadioVolume(0, 385, { 0.0, 1.0 }, false) 
+
+        _radioPanel = SR.getListIndicatorValue(18)
+
+        --intercom 
+        _data.radios[1].volume = SR.getRadioVolume(0, 386, { 0.0, 1.0 }, false) * _masterVolume
+
+        -- VHF
+        if SR.getButtonPosition(459) == 0 then
+            _data.radios[2].volume = SR.getRadioVolume(0, 375, { 0.0, 1.0 }, false) * _masterVolume 
+        else
+            _data.radios[2].volume = 0
+        end
+
+        -- UHF
+        if SR.getButtonPosition(460) == 0 then
+            _data.radios[3].volume = SR.getRadioVolume(0, 376, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[3].volume = 0
+        end
+
+        -- FM1
+        if SR.getButtonPosition(461) == 0 then
+            _data.radios[4].volume = SR.getRadioVolume(0, 377, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[4].volume = 0
+        end
+
+         -- FM2
+        if SR.getButtonPosition(462) == 0 then
+            _data.radios[5].volume = SR.getRadioVolume(0, 378, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[5].volume = 0
+        end
+
+         -- HF
+        if SR.getButtonPosition(463) == 0 then
+            _data.radios[6].volume = SR.getRadioVolume(0, 379, { 0.0, 1.0 }, false) * _masterVolume
+        else
+            _data.radios[6].volume = 0
+        end
+
+        if SR.getButtonPosition(387) ~= 1 then
+            _data.intercomHotMic = true
+        end
+
+    end
+
+    -- figure out selected
+    if _radioPanel['Rts_VHF_'] == '<' then
+        _data.selected = 1
+    elseif _radioPanel['Rts_UHF_'] == '<' then
+        _data.selected = 2
+    elseif _radioPanel['Rts_FM1_'] == '<' then
+        _data.selected = 3
+    elseif _radioPanel['Rts_FM2_'] == '<' then
+        _data.selected = 4
+    elseif _radioPanel['Rts_HF_'] == '<' then
+        _data.selected = 5
+    end
+
+    if _radioPanel['Guard'] == 'G' then
+        _data.radios[3].secFreq = 243e6
+    end
+
+    _data.control = 1
+    
     return _data
 
 end
@@ -1048,16 +1280,15 @@ end
 
 function SR.exportRadioUH1H(_data)
 
-    _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = false, desc = "" }
-
     local intercomOn =  SR.getButtonPosition(27)
     _data.radios[1].name = "Intercom"
     _data.radios[1].freq = 100.0
     _data.radios[1].modulation = 2 --Special intercom modulation
     _data.radios[1].volume =  SR.getRadioVolume(0, 29, { 0.3, 1.0 }, true)
 
-    if intercomOn < 0.5 then
-        _data.radios[1].modulation = 3
+    if intercomOn > 0.5 then
+        --- control hot mic instead of turning it on and off
+        _data.intercomHotMic = true
     end
 
     local fmOn =  SR.getButtonPosition(23)
@@ -1106,7 +1337,11 @@ function SR.exportRadioUH1H(_data)
 
     --_device:get_argument_value(_arg)
 
-    local _panel = GetDevice(0)
+    local _seat = SR.lastKnownSeat
+
+    if _seat == 0 then
+
+         local _panel = GetDevice(0)
 
     local switch = _panel:get_argument_value(30)
 
@@ -1134,6 +1369,20 @@ function SR.exportRadioUH1H(_data)
     end
 
     _data.control = 1; -- Full Radio
+
+
+        _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = true, desc = "Hot mic on INT switch" }
+    else
+        _data.control = 0; -- no copilot or gunner radio controls - allow them to switch
+        
+        _data.radios[1].volMode = 1 
+        _data.radios[2].volMode = 1 
+        _data.radios[3].volMode = 1 
+        _data.radios[4].volMode = 1
+
+        _data.capabilities = { dcsPtt = false, dcsIFF = true, dcsRadioSwitch = false, intercomHotMic = true, desc = "Hot mic on INT switch" }
+    end
+
 
     -- HANDLE TRANSPONDER
     _data.iff = {status=0,mode1=0,mode3=0,mode4=false,control=0,expansion=false}
@@ -1414,7 +1663,7 @@ end
 
 function SR.exportRadioMI24P(_data)
 
-    _data.capabilities = { dcsPtt = true, dcsIFF = false, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
+    _data.capabilities = { dcsPtt = true, dcsIFF = false, dcsRadioSwitch = true, intercomHotMic = true, desc = "Use Radio/ICS Switch to control Intercom Hot Mic" }
 
     _data.radios[1].name = "Intercom"
     _data.radios[1].freq = 100.0
@@ -1433,25 +1682,108 @@ function SR.exportRadioMI24P(_data)
         _data.radios[2].secFreq = 121.5 * 1000000
     end
 
-    _data.radios[3].name = "JADRO-1I"
-    _data.radios[3].freq = SR.getRadioFrequency(50, 500)
-    _data.radios[3].modulation = SR.getRadioModulation(50)
-    _data.radios[3].volume = SR.getRadioVolume(0, 426, { 0.0, 1.0 }, false)
+
+    _data.radios[3].name = "R-828"
+    _data.radios[3].freq = SR.getRadioFrequency(51)
+    _data.radios[3].modulation = 1 --SR.getRadioModulation(50)
+    _data.radios[3].volume = SR.getRadioVolume(0, 339, { 0.0, 1.0 }, false)
     _data.radios[3].volMode = 0
 
-    _data.radios[4].name = "R-828"
-    _data.radios[4].freq = SR.getRadioFrequency(51)
-    _data.radios[4].modulation = 1 --SR.getRadioModulation(50)
-    _data.radios[4].volume = SR.getRadioVolume(0, 339, { 0.0, 1.0 }, false)
+    _data.radios[4].name = "JADRO-1I"
+    _data.radios[4].freq = SR.getRadioFrequency(50, 500)
+    _data.radios[4].modulation = SR.getRadioModulation(50)
+    _data.radios[4].volume = SR.getRadioVolume(0, 426, { 0.0, 1.0 }, false)
     _data.radios[4].volMode = 0
 
+    -- listen only radio - moved to expansion
     _data.radios[5].name = "R-852"
     _data.radios[5].freq = SR.getRadioFrequency(52)
     _data.radios[5].modulation = SR.getRadioModulation(52)
     _data.radios[5].volume = SR.getRadioVolume(0, 517, { 0.0, 1.0 }, false)
     _data.radios[5].volMode = 0
+    _data.radios[5].expansion = true
 
-    _data.control = 0; -- HOTAS for now
+    local _seat = SR.lastKnownSeat
+
+    if _seat == 0 then
+
+         _data.radios[1].volume = SR.getRadioVolume(0, 457, { 0.0, 1.0 }, false)
+
+        --Pilot SPU-8 selection
+        local _switch = SR.getSelectorPosition(455, 0.2)
+        if _switch == 0 then
+            _data.selected = 1            -- R-863
+        elseif _switch == 1 then 
+            _data.selected = -1          -- No Function
+        elseif _switch == 2 then
+            _data.selected = 2            -- R-828
+        elseif _switch == 3 then
+            _data.selected = 3            -- JADRO
+        elseif _switch == 4 then
+            _data.selected = 4
+        else
+            _data.selected = -1
+        end
+
+        local _pilotPTT = SR.getButtonPosition(738) 
+        if _pilotPTT >= 0.1 then
+
+            if _pilotPTT == 0.5 then
+                -- intercom
+              _data.selected = 0
+            end
+
+            _data.ptt = true
+        end
+
+        --hot mic 
+        if SR.getButtonPosition(456) >= 1.0 then
+            _data.intercomHotMic = true
+        end
+
+    else
+
+        --- copilot
+        _data.radios[1].volume = SR.getRadioVolume(0, 661, { 0.0, 1.0 }, false)
+        -- For the co-pilot allow volume control
+        _data.radios[2].volMode = 1
+        _data.radios[3].volMode = 1
+        _data.radios[4].volMode = 1
+        _data.radios[5].volMode = 1
+        
+        local _switch = SR.getSelectorPosition(659, 0.2)
+        if _switch == 0 then
+            _data.selected = 1            -- R-863
+        elseif _switch == 1 then 
+            _data.selected = -1          -- No Function
+        elseif _switch == 2 then
+            _data.selected = 2            -- R-828
+        elseif _switch == 3 then
+            _data.selected = 3            -- JADRO
+        elseif _switch == 4 then
+            _data.selected = 4
+        else
+            _data.selected = -1
+        end
+
+        local _copilotPTT = SR.getButtonPosition(856) 
+        if _copilotPTT >= 0.1 then
+
+            if _copilotPTT == 0.5 then
+                -- intercom
+              _data.selected = 0
+            end
+
+            _data.ptt = true
+        end
+
+        --hot mic 
+        if SR.getButtonPosition(660) >= 1.0 then
+            _data.intercomHotMic = true
+        end
+    end
+    
+    _data.control = 1;
 
     return _data
 
@@ -2890,6 +3222,21 @@ function SR.exportRadioMosquitoFBMkVI (_data)
     _data.radios[2].freq = SR.getRadioFrequency(24)
     _data.radios[2].modulation = 0
     _data.radios[2].volume = SR.getRadioVolume(0, 364, { 0.0, 1.0 }, false)
+
+    local _seat = SR.lastKnownSeat
+
+    if _seat == 0 then
+
+         _data.capabilities = { dcsPtt = true, dcsIFF = false, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
+
+        local ptt =  SR.getButtonPosition(4)
+
+        if ptt == 1 then
+            _data.ptt = true
+        end
+    else
+         _data.capabilities = { dcsPtt = false, dcsIFF = false, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
+    end
 
     _data.radios[3].name = "R1155" 
     _data.radios[3].freq = SR.getRadioFrequency(27,500,true)
@@ -4401,10 +4748,16 @@ end
 LuaExportBeforeNextFrame = function()
 
     -- read from socket
-    local _status, _result = pcall(SR.readSocket)
+    local _status, _result = pcall(SR.readLOSSocket)
 
     if not _status then
-        SR.log('ERROR LuaExportBeforeNextFrame SRS: ' .. _result)
+        SR.log('ERROR LuaExportBeforeNextFrame readLOSSocket SRS: ' .. SR.debugDump(_result))
+    end
+
+    _status, _result = pcall(SR.readSeatSocket)
+
+    if not _status then
+        SR.log('ERROR LuaExportBeforeNextFrame readSeatSocket SRS: ' .. SR.debugDump(_result))
     end
 
     -- Check F/A-18C ENT keypress (needs to be checked in LuaExportBeforeNextFrame not to be missed)
@@ -4427,4 +4780,4 @@ LuaExportBeforeNextFrame = function()
 end
 
 
-SR.log("Loaded SimpleRadio Standalone Export version: 2.0.0.0")
+SR.log("Loaded SimpleRadio Standalone Export version: 2.0.1.0")

--- a/Scripts/DCS-SRS/entry.lua
+++ b/Scripts/DCS-SRS/entry.lua
@@ -4,7 +4,7 @@ declare_plugin("DCS-SRS", {
 	developerName = _("Ciribob"),
 	developerLink = _("https://github.com/ciribob/DCS-SimpleRadioStandalone"),
 	displayName = _("DCS SimpleRadio Standalone"),
-	version = "2.0.0.0",
+	version = "2.0.1.0",
 	state = "installed",
 	info = _("DCS-SimpleRadio Standalone\n\nBrings realistic VoIP comms to DCS with a cockpit integration with every aircraft\n\nCheck Special Settings for SRS integration settings\n\nSRS Discord for Support: https://discord.gg/baw7g3t"),
 	binaries = {"srs.dll"},


### PR DESCRIPTION
- UH1 - Only pilot has in-cockpit controls, other crew members get hotkeys by default (as each should have a comms panel but these are not implemented in DCS)
- Mi24 - Cockpit controls and DCS PTT support added for both seats - including the radio selector on both seats and optional hot mic. Thanks to Tarres & Zeen
- Mosquito - DCS PTT added for Pilot seat thanks to Tarres & Zeen. Support also added for the two other onboard radios
- Apache - Full integration including front and rear radio select via RTS as shown on EUFD and hot mic. Make sure always allow SRS Hotkeys is off for Hot Mic (and radio select) to work
- New Keybind - Added "Special Intercom Select & PTT" - this keybind will always temporarily select the intercom and transmit, when released, it'll switch back to whatever your last radio selected was. Added for the Apache but works on all relevant modules.
- Removed line of sight limitations on HF transmissions