### PR TITLE
Differing Radio Powers

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Network\LotATC\LotATCSyncHandler.cs" />
     <Compile Include="Network\UDPCommandHandler.cs" />
     <Compile Include="Network\UDPVoiceHandler.cs" />
+    <Compile Include="Settings\SynchedRadioSettings.cs" />
     <Compile Include="Settings\SynchedServerSettings.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -454,13 +454,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         }
                                         //add server settings
                                         _serverSettings.Decode(serverMessage.ServerSettings);
-
+                                        _radioSettings.DecodeRadios(serverMessage.RadioSettings);
+                                        _radioSettings.DecodeAircraft(serverMessage.AircraftSettings);
                                         if (_clientStateSingleton.ExternalAWACSModelSelected &&
                                             !_serverSettings.GetSettingAsBool(Common.Setting.ServerSettingsKeys.EXTERNAL_AWACS_MODE))
                                         {
                                             DisconnectExternalAWACSMode();
                                         }
-
+                                        Console.WriteLine("Sync");
                                         CallUpdateUIOnMain();
 
                                         break;
@@ -512,12 +513,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                                             _radioDCSSync.StartExternalAWACSModeLoop();
                                         }
-                                        break;
-                                    case NetworkMessage.MessageType.RADIO_SETTINGS:
-                                        _radioSettings.DecodeRadios(serverMessage.RadioSettings);
-                                        break;
-                                    case NetworkMessage.MessageType.AIRCRAFT_SETTINGS:
-                                        _radioSettings.DecodeAircraft(serverMessage.AircraftSettings);
                                         break;
                                     default:
                                         Logger.Error("Recevied unknown " + line);

--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -45,7 +45,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
         private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
         private readonly SyncedServerSettings _serverSettings = SyncedServerSettings.Instance;
         private readonly ConnectedClientsSingleton _clients = ConnectedClientsSingleton.Instance;
-
+        private readonly SynchedRadioSettings _radioSettings = SynchedRadioSettings.Instance;
 
         private DCSRadioSyncManager _radioDCSSync = null;
         private LotATCSyncHandler _lotATCSync;
@@ -512,6 +512,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
                                             _radioDCSSync.StartExternalAWACSModeLoop();
                                         }
+                                        break;
+                                    case NetworkMessage.MessageType.RADIO_SETTINGS:
+                                        _radioSettings.DecodeRadios(serverMessage.RadioSettings);
+                                        break;
+                                    case NetworkMessage.MessageType.AIRCRAFT_SETTINGS:
+                                        _radioSettings.DecodeAircraft(serverMessage.AircraftSettings);
                                         break;
                                     default:
                                         Logger.Error("Recevied unknown " + line);

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -458,7 +458,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         var equippedRadios = DefaultRadioInformation.GetAircraftDefaults()[client.RadioInfo.unit];
                                         var selfRadios = DefaultRadioInformation.GetAircraftDefaults()[_clientStateSingleton.DcsPlayerRadioInfo.unit];
                                         int arrayPos = Array.IndexOf(_clientStateSingleton.DcsPlayerRadioInfo.radios, radio);
-                                        var selfReceiving = equippedRadios.Length < arrayPos ? selfRadios[arrayPos] : Radios.Unknown;
+                                        var selfReceiving = equippedRadios.Length < arrayPos ? selfRadios[arrayPos] : Radios.Unknown.ToString();
                                         
                                         //Array.IndexOf(_clientStateSingleton.DcsPlayerRadioInfo.radios, radio)
                                         if (radio != null && state != null)

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -829,7 +829,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                 }
 
                 double max;
-                if(!SyncedServerSettings.Instance.GetSettingAsBool(ServerSettingsKeys.REALISTIC_RADIO_ENABLED))
+                if(!SyncedServerSettings.Instance.GetSettingAsBool(ServerSettingsKeys.DIFFERING_RADIO_ENABLED))
                 {
                     max = RadioCalculator.FriisMaximumTransmissionRange(frequency);
                 } 

--- a/DCS-SR-Client/Settings/SynchedRadioSettings.cs
+++ b/DCS-SR-Client/Settings/SynchedRadioSettings.cs
@@ -1,0 +1,70 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
+using NLog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
+{
+    internal class SynchedRadioSettings
+    {
+        private readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private static SynchedRadioSettings instance;
+        private static readonly object _lock = new object();
+        private static readonly Dictionary<string, RadioValues> radioDefaults = DefaultRadioInformation.RadioDefaults;
+        private static readonly Dictionary<string, string[]> aircraftDefaults = DefaultRadioInformation.AircraftDefaults;
+
+        private readonly ConcurrentDictionary<string, RadioValues> radioSettings;
+        private readonly ConcurrentDictionary<string, string[]> aircraftSettings;
+
+        public SynchedRadioSettings()
+        {
+            radioSettings = new ConcurrentDictionary<string, RadioValues>();
+            aircraftSettings = new ConcurrentDictionary<string, string[]>();
+        }
+
+        public static SynchedRadioSettings Instance
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    if (instance == null)
+                    {
+                        instance = new SynchedRadioSettings();
+                    }
+                }
+                return instance;
+            }
+        }
+
+        public RadioValues GetRadioSetting(string radio)
+        {
+            return radioSettings.GetOrAdd(radio, radioDefaults.ContainsKey(radio) ? radioDefaults[radio] : radioDefaults[Radios.Unknown.ToString()]);
+        }
+
+        public string[] GetAircraftSetting(string aircraft)
+        {
+            return aircraftSettings.GetOrAdd(aircraft, aircraftDefaults.ContainsKey(aircraft) ? aircraftDefaults[aircraft] : aircraftDefaults["JF-17"]); //TODO: Need some sort of sane default value here
+        }
+
+        public void DecodeRadios(Dictionary<string, RadioValues> encoded)
+        {
+            foreach (KeyValuePair<string, RadioValues> kvp in encoded)
+            {
+                radioSettings.AddOrUpdate(kvp.Key, kvp.Value, (key, oldVal) => kvp.Value);
+            }
+        }
+
+        public void DecodeAircraft(Dictionary<string, string[]> encoded)
+        {
+            foreach (KeyValuePair<string, string[]> kvp in encoded)
+            {
+                aircraftSettings.AddOrUpdate(kvp.Key, kvp.Value, (key, oldVal) => kvp.Value);
+            }
+        }
+    }
+}

--- a/DCS-SR-Common/DCS-SR-Common.csproj
+++ b/DCS-SR-Common/DCS-SR-Common.csproj
@@ -108,6 +108,8 @@
   <ItemGroup>
     <Compile Include="DCSState\DCSAircraftCapabilities.cs" />
     <Compile Include="DCSState\DCSLatLngPosition.cs" />
+    <Compile Include="DCSState\RadioValues.cs" />
+    <Compile Include="DCSState\RadioTypes.cs" />
     <Compile Include="DCSState\Transponder.cs" />
     <Compile Include="DCSState\RadioReceivingPriority.cs" />
     <Compile Include="DCSState\RadioReceivingState.cs" />

--- a/DCS-SR-Common/DCSState/RadioTypes.cs
+++ b/DCS-SR-Common/DCSState/RadioTypes.cs
@@ -135,7 +135,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
                                        Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString()} },
             {"CA", new [] { Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(),
                                        Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString()} },
-            {"AH-64D_BLK_II", new []  { Radios.Intercom.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC201D.ToString()} }
+            {"AH-64D_BLK_II", new []  { Radios.Intercom.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC201D.ToString()} },
             {"UH-1H", new [] { Radios.Intercom.ToString(), Radios.ANARC131.ToString(), Radios.ANARC51BX.ToString(), Radios.ANARC134.ToString() } },
             {"Ka-50", new [] {Radios.R800L14.ToString(), Radios.R828.ToString(), Radios.SPU9SW.ToString() } },
             {"Mi-8MT", new [] { Radios.Intercom.ToString(), Radios.R863.ToString(), Radios.JADRO1A.ToString(), Radios.R828.ToString() } },

--- a/DCS-SR-Common/DCSState/RadioTypes.cs
+++ b/DCS-SR-Common/DCSState/RadioTypes.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
 {
+    // TODO: the enums aren't really necessary and can be replaced by strings
     public enum Radios
     {
         Unknown,
@@ -27,7 +28,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
         FR22,
         FR24,
         FuG16ZY,
-        INTERCOM,
         JADRO1A,
         JADRO1I,
         KTR953HF,
@@ -66,132 +66,132 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
 
     public static class DefaultRadioInformation
     {
-        private static readonly Dictionary<Radios, RadioValues> RadioDefaults = new Dictionary<Radios, RadioValues>()
+        public static readonly Dictionary<string, RadioValues> RadioDefaults = new Dictionary<string, RadioValues>()
         {
             // Currently asssuming 50ohms for all radios when converting from uV to dbm, in addition to links below https://dpdproductions.com/pages/military-radio-reference-list was used for reference
             // Power information was used from above source if only minimums given in specific documentation and above documentation provided a specific power (i.e not a range of powers) 
-            {Radios.Unknown, new RadioValues(40) },
-            {Radios.Intercom, new RadioValues(0) }, // Dummy value for intercoms
-            {Radios.ANARC131, new RadioValues(40) }, // possible sensitivity info https://apps.dtic.mil/sti/pdfs/ADA033368.pdf
-            {Radios.ANARC134, new RadioValues(46, -88) }, // https://www.liberatedmanuals.com/TM-11-5821-277-20.pdf
-            {Radios.ANARC150, new RadioValues(40, -113) }, // https://en.wikipedia.org/wiki/AN/PRC-150
-            {Radios.ANARC159, new RadioValues(40, -96)}, // https://www.columbiaelectronics.com/an_arc_159_v__uhf_transceiver.htm
-            {Radios.ANARC164, new RadioValues(40, -91)}, // https://tsc-60.cellmail.com/tsc-60/TSC-118/rtn_ncs_products_arc164_pdf.pdf
-            {Radios.ANARC182, new RadioValues(44, -110) }, // https://www.columbiaelectronics.com/an_arc_182_v__vhf_uhf_radio_set.htm, used AM parameters - modulation changes based on frequency with differing power outputs and sensitivity
-            {Radios.ANARC186, new RadioValues(40, -97) }, // https://www.columbiaelectronics.com/an_arc_186_v__radio_set.htm TODO: create ANARC186FM due to tx power and rx sensitivity differences
-            {Radios.ANARC210, RadioDefaults[Radios.Unknown] }, // http://static6.arrow.com/aropdfconversion/11eaff76e8fc9a992ea6cb5163f1efddd95392b2/arc-210integratedcommsystemswhitepaper.pdf.pdf, unable to find sensitivity information
-            {Radios.ANARC222, RadioDefaults[Radios.Unknown] }, // Having trouble finding SINGCARS configuration details for F16 Blk. 50 in relation to sensitivity, default values are likely a close approximation
-            {Radios.ANARC27,  new RadioValues(39)}, // https://web.archive.org/web/20100706140322/http://www.nj7p.org/cgi-bin/millist2?mode=normal&name=AN%2FARC-27
-            {Radios.ANARC51BX, new RadioValues(44)}, // No (good) documentation found yet 
-            {Radios.ARI1063, RadioDefaults[Radios.Unknown] }, // No documentation found yet
-            {Radios.ARI232591, RadioDefaults[Radios.Unknown] }, // No documentation found yet
-            {Radios.Baklan5, new RadioValues(37) }, // https://www.an2flyers.org/avionics.html, would prefer a better source
-            {Radios.FR22, RadioDefaults[Radios.Unknown]}, // Info from DCS manual, power is 10w UHF or 20w VHF - using lower power for the time being
-            {Radios.FR24, new RadioValues(35) }, // Info from DCS manual
-            {Radios.FuG16ZY, new RadioValues(40, -77) }, // https://www.esr.se/images/articles-pyssel/TME_11-227-2.pdf, document notes rated Tx power of 10w, testing shows 5w. Using 10w value for now.
-            {Radios.JADRO1A, new RadioValues(47, -93) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
-            {Radios.JADRO1I, new RadioValues(47, -97) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
-            {Radios.KTR953HF, new RadioValues(46, -97) }, // http://shop.avionics.co.nz/ktr953
-            {Radios.KY197A, new RadioValues(40, -100) }, // https://www.seaerospace.com/sales/product/BendixKing/KY-197A
-            {Radios.MIDS, RadioDefaults[Radios.ANARC210]}, // I assume MIDS communication will share the same values as the  AN/ARC-210
-            {Radios.R1155, new RadioValues(24, -86)  }, // http://www.vq5x79.f2s.com/greenradio/Wireless21a.html, would prefer a better source
-            {Radios.R800, new RadioValues(38)}, // http://www.radionic.ru/book/export/html/744, would prefer a better source
-            {Radios.R800L14, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.R828, RadioDefaults[Radios.Unknown]}, // https://pandia.ru/text/80/087/37141.php, would prefer a better source
-            {Radios.R832, RadioDefaults[Radios.R832]}, // Assume similar to R832M
-            {Radios.R832M, new RadioValues(42)}, // https://www.armedconflicts.com/Aviacionnaya-UKV-DMV-radiostanciya-R-832M-t80222, would prefer a better source
-            {Radios.R852, new RadioValues(40, -93)}, // https://lektsii.com/2-129490.html, would prefer a better source - assuming 10W Tx power
-            {Radios.R862, new RadioValues(44, -97)}, // https://radiotract.ru/radiostancia-r-862m.html, would prefer a better source
-            {Radios.R863, new RadioValues(40, -97) }, // https://radiotract.ru/radiostancia-r-863m.html, would prefer a better source
-            {Radios.R864, new RadioValues(50, -93)}, // http://www.radioscanner.ru/trx/military/r-864/, would prefer a better source
-            {Radios.RSI6K, new RadioValues(37)}, // https://archives.nato.int/uploads/r/null/1/1/116423/SG_253_1_FINAL_ENG_PDP.pdf, would prefer a better source
-            {Radios.RSIU4V, new RadioValues(39) }, // https://www.armedconflicts.com/Aviacionnaya-UKV-radiostanciya-R-801-RSIU-4B-t80161, would prefer better source (note that RSIU4V == R801V)
-            {Radios.RTA42ABENDIX, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.SCR522, RadioDefaults[Radios.SCR522A]}, // Assume values will be similar to SCR522A
-            {Radios.SCR522A, new RadioValues(40, -94)}, // http://www.radiomanual.info/schemi/Surplus_NATO/SCR-522A_SCR-542A_serv_AN16-40SCR522-3_1952.pdf, other sources provide different transmit power values
-            {Radios.SPU9SW, RadioDefaults[Radios.Unknown]}, // Fairly certain this is just an intercom?
-            {Radios.SRT651N, new RadioValues(40, -103)}, // https://www.yumpu.com/en/document/read/41736902/v-uhf-airborne-radio-systems-srt-651-e-a-se-008-v2-12-
-            {Radios.SUNAIRASB850, new RadioValues(46 ,-97)}, // https://www.sunairelectronics.com/workspace/uploads/asb-850_10-1-1981_2nd-1314220642.pdf
-            {Radios.T1154, new RadioValues(46)}, // http://www.shopingathome.com/1154%20Transmitter.htm, would prefer a better source
-            {Radios.TRAP138A, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.TRC9600PR4G, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.TRTERA7000, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.TRTERA7200, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.UHFTRA6031, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.VHF20B, new RadioValues(43) }, // https://www.seaerospace.com/sales/product/Collins%20Aerospace/VHF-20B
-            {Radios.VHFUHFExpansion, RadioDefaults[Radios.Unknown]}, // Standard Expansion Radios
-            {Radios.VTVU740, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.XT6013, RadioDefaults[Radios.Unknown]}, // No documentation found yet
-            {Radios.XT6313D, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.Unknown.ToString(), new RadioValues(40) },
+            {Radios.Intercom.ToString(), new RadioValues(0) }, // Dummy value for intercoms
+            {Radios.ANARC131.ToString(), new RadioValues(40) }, // possible sensitivity info https://apps.dtic.mil/sti/pdfs/ADA033368.pdf
+            {Radios.ANARC134.ToString(), new RadioValues(46, -88) }, // https://www.liberatedmanuals.com/TM-11-5821-277-20.pdf
+            {Radios.ANARC150.ToString(), new RadioValues(40, -113) }, // https://en.wikipedia.org/wiki/AN/PRC-150
+            {Radios.ANARC159.ToString(), new RadioValues(40, -96)}, // https://www.columbiaelectronics.com/an_arc_159_v__uhf_transceiver.htm
+            {Radios.ANARC164.ToString(), new RadioValues(40, -91)}, // https://tsc-60.cellmail.com/tsc-60/TSC-118/rtn_ncs_products_arc164_pdf.pdf
+            {Radios.ANARC182.ToString(), new RadioValues(44, -110) }, // https://www.columbiaelectronics.com/an_arc_182_v__vhf_uhf_radio_set.htm, used AM parameters - modulation changes based on frequency with differing power outputs and sensitivity
+            {Radios.ANARC186.ToString(), new RadioValues(40, -97) }, // https://www.columbiaelectronics.com/an_arc_186_v__radio_set.htm TODO: create ANARC186FM due to tx power and rx sensitivity differences
+            {Radios.ANARC210.ToString(), new RadioValues(40) }, // http://static6.arrow.com/aropdfconversion/11eaff76e8fc9a992ea6cb5163f1efddd95392b2/arc-210integratedcommsystemswhitepaper.pdf.pdf, unable to find sensitivity information
+            {Radios.ANARC222.ToString(), new RadioValues(40) }, // Having trouble finding SINGCARS configuration details for F16 Blk. 50 in relation to sensitivity, default values are likely a close approximation
+            {Radios.ANARC27.ToString(),  new RadioValues(39)}, // https://web.archive.org/web/20100706140322/http://www.nj7p.org/cgi-bin/millist2?mode=normal&name=AN%2FARC-27
+            {Radios.ANARC51BX.ToString(), new RadioValues(44)}, // No (good) documentation found yet 
+            {Radios.ARI1063.ToString(), new RadioValues(40) }, // No documentation found yet
+            {Radios.ARI232591.ToString(), new RadioValues(40) }, // No documentation found yet
+            {Radios.Baklan5.ToString(), new RadioValues(37) }, // https://www.an2flyers.org/avionics.html, would prefer a better source
+            {Radios.FR22.ToString(), new RadioValues(40)}, // Info from DCS manual, power is 10w UHF or 20w VHF - using lower power for the time being
+            {Radios.FR24.ToString(), new RadioValues(35) }, // Info from DCS manual
+            {Radios.FuG16ZY.ToString(), new RadioValues(40, -77) }, // https://www.esr.se/images/articles-pyssel/TME_11-227-2.pdf, document notes rated Tx power of 10w, testing shows 5w. Using 10w value for now.
+            {Radios.JADRO1A.ToString(), new RadioValues(47, -93) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
+            {Radios.JADRO1I.ToString(), new RadioValues(47, -97) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
+            {Radios.KTR953HF.ToString(), new RadioValues(46, -97) }, // http://shop.avionics.co.nz/ktr953
+            {Radios.KY197A.ToString(), new RadioValues(40, -100) }, // https://www.seaerospace.com/sales/product/BendixKing/KY-197A
+            {Radios.MIDS.ToString(), new RadioValues(40)}, // I assume MIDS communication will share the same values as the  AN/ARC-210
+            {Radios.R1155.ToString(), new RadioValues(24, -86)  }, // http://www.vq5x79.f2s.com/greenradio/Wireless21a.html, would prefer a better source
+            {Radios.R800.ToString(), new RadioValues(38)}, // http://www.radionic.ru/book/export/html/744, would prefer a better source
+            {Radios.R800L14.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.R828.ToString(), new RadioValues(40)}, // https://pandia.ru/text/80/087/37141.php, would prefer a better source
+            {Radios.R832.ToString(), new RadioValues(42)}, // Assume similar to R832M
+            {Radios.R832M.ToString(), new RadioValues(42)}, // https://www.armedconflicts.com/Aviacionnaya-UKV-DMV-radiostanciya-R-832M-t80222, would prefer a better source
+            {Radios.R852.ToString(), new RadioValues(40, -93)}, // https://lektsii.com/2-129490.html, would prefer a better source - assuming 10W Tx power
+            {Radios.R862.ToString(), new RadioValues(44, -97)}, // https://radiotract.ru/radiostancia-r-862m.html, would prefer a better source
+            {Radios.R863.ToString(), new RadioValues(40, -97) }, // https://radiotract.ru/radiostancia-r-863m.html, would prefer a better source
+            {Radios.R864.ToString(), new RadioValues(50, -93)}, // http://www.radioscanner.ru/trx/military/r-864/, would prefer a better source
+            {Radios.RSI6K.ToString(), new RadioValues(37)}, // https://archives.nato.int/uploads/r/null/1/1/116423/SG_253_1_FINAL_ENG_PDP.pdf, would prefer a better source
+            {Radios.RSIU4V.ToString(), new RadioValues(39) }, // https://www.armedconflicts.com/Aviacionnaya-UKV-radiostanciya-R-801-RSIU-4B-t80161, would prefer better source (note that RSIU4V == R801V)
+            {Radios.RTA42ABENDIX.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.SCR522.ToString(), new RadioValues(40, -94)}, // Assume values will be similar to SCR522A
+            {Radios.SCR522A.ToString(), new RadioValues(40, -94)}, // http://www.radiomanual.info/schemi/Surplus_NATO/SCR-522A_SCR-542A_serv_AN16-40SCR522-3_1952.pdf, other sources provide different transmit power values
+            {Radios.SPU9SW.ToString(), new RadioValues(40)}, // Fairly certain this is just an intercom?
+            {Radios.SRT651N.ToString(), new RadioValues(40, -103)}, // https://www.yumpu.com/en/document/read/41736902/v-uhf-airborne-radio-systems-srt-651-e-a-se-008-v2-12-
+            {Radios.SUNAIRASB850.ToString(), new RadioValues(46 ,-97)}, // https://www.sunairelectronics.com/workspace/uploads/asb-850_10-1-1981_2nd-1314220642.pdf
+            {Radios.T1154.ToString(), new RadioValues(46)}, // http://www.shopingathome.com/1154%20Transmitter.htm, would prefer a better source
+            {Radios.TRAP138A.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.TRC9600PR4G.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.TRTERA7000.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.TRTERA7200.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.UHFTRA6031.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.VHF20B.ToString(), new RadioValues(43) }, // https://www.seaerospace.com/sales/product/Collins%20Aerospace/VHF-20B
+            {Radios.VHFUHFExpansion.ToString(), new RadioValues(40)}, // Standard Expansion Radios
+            {Radios.VTVU740.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.XT6013.ToString(), new RadioValues(40)}, // No documentation found yet
+            {Radios.XT6313D.ToString(), new RadioValues(40)}, // No documentation found yet
         };
 
-        private static readonly Dictionary<string, Radios[]> AircraftDefaults = new Dictionary<string, Radios[]>()
+        public static readonly Dictionary<string, string[]> AircraftDefaults = new Dictionary<string, string[]>()
         {
-            {"UH-1H", new [] { Radios.Intercom, Radios.ANARC131, Radios.ANARC51BX, Radios.ANARC134 } },
-            {"Ka-50", new [] {Radios.R800L14, Radios.R828, Radios.SPU9SW } },
-            {"Mi-8MT", new [] { Radios.Intercom, Radios.R863, Radios.JADRO1A, Radios.R828 } },
-            {"Mi-24P", new [] { Radios.Intercom, Radios.R863, Radios.R828, Radios.JADRO1I, Radios.R852} },
-            {"Yak-52", new [] { Radios.Intercom, Radios.Baklan5, Radios.ANARC186, Radios.ANARC164} },
-            {"FA-18C_hornet", new [] { Radios.ANARC210, Radios.ANARC210, Radios.MIDS, Radios.MIDS} },
-            {"F-86F Sabre", new [] { Radios.ANARC27, Radios.ANARC186, Radios.ANARC164 } },
-            {"MiG-15bis", new [] {Radios.RSI6K, Radios.ANARC186, Radios.ANARC164 } },
-            {"MiG-19P", new [] {Radios.RSIU4V, Radios.ANARC186, Radios.ANARC164 } },
-            {"MiG-21Bis", new [] {Radios.R832, Radios.ANARC186, Radios.ANARC164 } },
-            {"F-5E-3", new [] {Radios.ANARC164, Radios.ANARC186, Radios.ANARC164} },
-            {"FW-190D9", new [] {Radios.FuG16ZY, Radios.ANARC186, Radios.ANARC164} },
-            {"FW-190A8", AircraftDefaults["FW-190D9"] },
-            {"Bf-109K-4", AircraftDefaults["FW-190D9"] },
-            {"C-101EB", new [] { Radios.Intercom, Radios.ANARC164, Radios.ANARC134} },
-            {"C-101CC", new [] { Radios.Intercom, Radios.VTVU740, Radios.VHF20B} },
-            {"MB-339A", new [] { Radios.Intercom, Radios.ANARC150, Radios.SRT651N } },
-            {"MB-339APAN", AircraftDefaults["MB-339A"] },
-            {"Hawk", new [] { Radios.ANARC164, Radios.ARI232591} },
-            {"Christen Eagle II", new [] { Radios.Intercom, Radios.KY197A, Radios.ANARC186, Radios.ANARC164 } },
-            {"M-2000C", new []  {Radios.TRTERA7000, Radios.TRTERA7200 } },
-            {"JF-17", new [] { Radios.Unknown, Radios.Unknown, Radios.VHFUHFExpansion} },
-            {"AV8BNA", new [] { Radios.ANARC210, Radios.ANARC210, Radios.ANARC210 } },
-            {"AJS37", new [] { Radios.FR22, Radios.FR24, Radios.ANARC164} },
-            {"A-10A", new [] { Radios.ANARC186, Radios.ANARC164, Radios.ANARC186} },
-            {"A-4E-C", new [] { Radios.ANARC51BX, Radios.ANARC186, Radios.ANARC186} }, //TODO: Radio 3 updated to 186FM when added
-            {"PUCARA", new [] { Radios.Intercom, Radios.SUNAIRASB850, Radios.RTA42ABENDIX} },
-            {"T-45", new [] {Radios.Intercom, Radios.ANARC182, Radios.ANARC182} },
-            {"A-29B", new [] { Radios.XT6013, Radios.XT6313D, Radios.KTR953HF } },
-            {"F-15C", new [] { Radios.ANARC164, Radios.ANARC164, Radios.ANARC186} },
-            {"MiG-29A", new [] { Radios.R862, Radios.ANARC186, Radios.ANARC164} },
-            {"MiG-29S", AircraftDefaults["MiG-29A"]},
-            {"MiG-29G", AircraftDefaults["MiG-29A"]},
-            {"Su-27", new [] {Radios.R800, Radios.R864, Radios.ANARC164 } },
-            {"Su-33", AircraftDefaults["Su-27"] },
-            {"Su-25", new [] { Radios.R862, Radios.R828, Radios.ANARC164 } },
-            {"Su-25T", AircraftDefaults["Su-25"]},
-            {"F-16C_50", new [] { Radios.ANARC164, Radios.ANARC222} },
-            {"SA342M", new [] { Radios.Intercom, Radios.TRAP138A, Radios.UHFTRA6031, Radios.TRC9600PR4G} },
-            {"SA342L", AircraftDefaults["SA342M"] },
-            {"SA342Mistral", AircraftDefaults["SA342M"]},
-            {"SA342Minigun", AircraftDefaults["SA342M"]},
-            {"L-39C", new [] { Radios.Intercom, Radios.R832M, Radios.ANARC186, Radios.ANARC164} },
-            {"L-39ZA", AircraftDefaults["L-39C"] },
-            {"F-14B", new [] { Radios.Intercom, Radios.ANARC159, Radios.ANARC182 } },
-            {"F-14A-135-GR", AircraftDefaults["F-14B"] },
-            {"A-10C", new [] { Radios.ANARC186, Radios.ANARC164, Radios.ANARC186 } },
-            {"A-10C_2", AircraftDefaults["A-10C_2"] },
-            {"P-51D", new [] {Radios.SCR522A, Radios.ANARC186, Radios.ANARC164 } },
-            {"P-51D-30-NA", AircraftDefaults["P-51D"] },
-            {"TF-51D", AircraftDefaults["P-51D"]},
-            {"P-47D-30", new [] {Radios.SCR522, Radios.ANARC186, Radios.ANARC164 } },
-            {"P-47D-30bl1", AircraftDefaults["P-47D-30"] },
-            {"P-47D-40", AircraftDefaults["P-47D-30"] },
-            {"SpitfireLFMkIX", new [] {Radios.ARI1063, Radios.ANARC186, Radios.ANARC164 } },
-            {"SpitfireLFMkIXCW", AircraftDefaults["SpitfireLFMkIX"] },
-            {"MosquitoFBMkVI", new [] { Radios.Intercom, Radios.SCR522A, Radios.R1155, Radios.T1154, Radios.ANARC210} },
+            {"UH-1H", new [] { Radios.Intercom.ToString(), Radios.ANARC131.ToString(), Radios.ANARC51BX.ToString(), Radios.ANARC134.ToString() } },
+            {"Ka-50", new [] {Radios.R800L14.ToString(), Radios.R828.ToString(), Radios.SPU9SW.ToString() } },
+            {"Mi-8MT", new [] { Radios.Intercom.ToString(), Radios.R863.ToString(), Radios.JADRO1A.ToString(), Radios.R828.ToString() } },
+            {"Mi-24P", new [] { Radios.Intercom.ToString(), Radios.R863.ToString(), Radios.R828.ToString(), Radios.JADRO1I.ToString(), Radios.R852.ToString()} },
+            {"Yak-52", new [] { Radios.Intercom.ToString(), Radios.Baklan5.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"FA-18C_hornet", new [] { Radios.ANARC210.ToString(), Radios.ANARC210.ToString(), Radios.MIDS.ToString(), Radios.MIDS.ToString()} },
+            {"F-86F Sabre", new [] { Radios.ANARC27.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"MiG-15bis", new [] {Radios.RSI6K.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"MiG-19P", new [] {Radios.RSIU4V.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"MiG-21Bis", new [] {Radios.R832.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"F-5E-3", new [] {Radios.ANARC164.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"FW-190D9", new [] {Radios.FuG16ZY.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"FW-190A8", new [] {Radios.FuG16ZY.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"Bf-109K-4", new [] {Radios.FuG16ZY.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"C-101EB", new [] { Radios.Intercom.ToString(), Radios.ANARC164.ToString(), Radios.ANARC134.ToString()} },
+            {"C-101CC", new [] { Radios.Intercom.ToString(), Radios.VTVU740.ToString(), Radios.VHF20B.ToString()} },
+            {"MB-339A", new [] { Radios.Intercom.ToString(), Radios.ANARC150.ToString(), Radios.SRT651N.ToString() } },
+            {"MB-339APAN", new [] { Radios.Intercom.ToString(), Radios.ANARC150.ToString(), Radios.SRT651N.ToString() } },
+            {"Hawk", new [] { Radios.ANARC164.ToString(), Radios.ARI232591.ToString()} },
+            {"Christen Eagle II", new [] { Radios.Intercom.ToString(), Radios.KY197A.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"M-2000C", new []  {Radios.TRTERA7000.ToString(), Radios.TRTERA7200.ToString() } },
+            {"JF-17", new [] { Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.VHFUHFExpansion.ToString()} },
+            {"AV8BNA", new [] { Radios.ANARC210.ToString(), Radios.ANARC210.ToString(), Radios.ANARC210.ToString() } },
+            {"AJS37", new [] { Radios.FR22.ToString(), Radios.FR24.ToString(), Radios.ANARC164.ToString()} },
+            {"A-10A", new [] { Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC186.ToString()} },
+            {"A-4E-C", new [] { Radios.ANARC51BX.ToString(), Radios.ANARC186.ToString(), Radios.ANARC186.ToString()} }, //TODO: Radio 3 updated to 186FM when added
+            {"PUCARA", new [] { Radios.Intercom.ToString(), Radios.SUNAIRASB850.ToString(), Radios.RTA42ABENDIX.ToString()} },
+            {"T-45", new [] {Radios.Intercom.ToString(), Radios.ANARC182.ToString(), Radios.ANARC182.ToString()} },
+            {"A-29B", new [] { Radios.XT6013.ToString(), Radios.XT6313D.ToString(), Radios.KTR953HF.ToString() } },
+            {"F-15C", new [] { Radios.ANARC164.ToString(), Radios.ANARC164.ToString(), Radios.ANARC186.ToString()} },
+            {"MiG-29A", new [] { Radios.R862.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"MiG-29S", new [] { Radios.R862.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"MiG-29G", new [] { Radios.R862.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"Su-27", new [] {Radios.R800.ToString(), Radios.R864.ToString(), Radios.ANARC164.ToString() } },
+            {"Su-33", new [] {Radios.R800.ToString(), Radios.R864.ToString(), Radios.ANARC164.ToString() } },
+            {"Su-25", new [] { Radios.R862.ToString(), Radios.R828.ToString(), Radios.ANARC164.ToString() } },
+            {"Su-25T", new [] { Radios.R862.ToString(), Radios.R828.ToString(), Radios.ANARC164.ToString() } },
+            {"F-16C_50", new [] { Radios.ANARC164.ToString(), Radios.ANARC222.ToString()} },
+            {"SA342M", new [] { Radios.Intercom.ToString(), Radios.TRAP138A.ToString(), Radios.UHFTRA6031.ToString(), Radios.TRC9600PR4G.ToString()} },
+            {"SA342L", new [] { Radios.Intercom.ToString(), Radios.TRAP138A.ToString(), Radios.UHFTRA6031.ToString(), Radios.TRC9600PR4G.ToString()} },
+            {"SA342Mistral", new [] { Radios.Intercom.ToString(), Radios.TRAP138A.ToString(), Radios.UHFTRA6031.ToString(), Radios.TRC9600PR4G.ToString()}},
+            {"SA342Minigun", new [] { Radios.Intercom.ToString(), Radios.TRAP138A.ToString(), Radios.UHFTRA6031.ToString(), Radios.TRC9600PR4G.ToString()}},
+            {"L-39C", new [] { Radios.Intercom.ToString(), Radios.R832M.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"L-39ZA", new [] { Radios.Intercom.ToString(), Radios.R832M.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString()} },
+            {"F-14B", new [] { Radios.Intercom.ToString(), Radios.ANARC159.ToString(), Radios.ANARC182.ToString() } },
+            {"F-14A-135-GR", new [] { Radios.Intercom.ToString(), Radios.ANARC159.ToString(), Radios.ANARC182.ToString() }  },
+            {"A-10C", new [] { Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC186.ToString() } },
+            {"A-10C_2", new [] { Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC186.ToString() } },
+            {"P-51D", new [] {Radios.SCR522A.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"P-51D-30-NA", new [] {Radios.SCR522A.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"TF-51D", new [] {Radios.SCR522A.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() }},
+            {"P-47D-30", new [] {Radios.SCR522.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"P-47D-30bl1", new [] {Radios.SCR522.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"P-47D-40", new [] {Radios.SCR522.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"SpitfireLFMkIX", new [] {Radios.ARI1063.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() } },
+            {"SpitfireLFMkIXCW", new [] {Radios.ARI1063.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString() }  },
+            {"MosquitoFBMkVI", new [] { Radios.Intercom.ToString(), Radios.SCR522A.ToString(), Radios.R1155.ToString(), Radios.T1154.ToString(), Radios.ANARC210.ToString()} },
         };
 
-        public static Dictionary<Radios, RadioValues> GetRadioDefaults()
+        public static Dictionary<string, RadioValues> GetRadioDefaults()
         {
             return RadioDefaults;
         }
 
-        public static Dictionary<string, Radios[]> GetAircraftDefaults()
+        public static Dictionary<string, string[]> GetAircraftDefaults()
         {
             return AircraftDefaults;
         }

--- a/DCS-SR-Common/DCSState/RadioTypes.cs
+++ b/DCS-SR-Common/DCSState/RadioTypes.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
+{
+    public enum Radios
+    {
+        Unknown,
+        Intercom,
+        ARI1063,
+        ANARC131,
+        ANARC134,
+        ANARC150,
+        ANARC159,
+        ANARC164,
+        ANARC182,
+        ANARC186,
+        ANARC210,
+        ANARC222,
+        ANARC27,
+        ANARC51BX,
+        ARI232591,
+        Baklan5,
+        FR22,
+        FR24,
+        FuG16ZY,
+        INTERCOM,
+        JADRO1A,
+        JADRO1I,
+        KTR953HF,
+        KY197A,
+        MIDS,
+        R800,
+        R800L14,
+        R828,
+        R832,
+        R832M,
+        R852,
+        R862,
+        R863,
+        R864,
+        R1155,
+        RSI6K,
+        RSIU4V,
+        RTA42ABENDIX,
+        SCR522,
+        SCR522A,
+        SPU9SW,
+        SRT651N,
+        SUNAIRASB850,
+        T1154,
+        TRAP138A,
+        TRC9600PR4G,
+        TRTERA7000,
+        TRTERA7200,
+        UHFTRA6031,
+        VTVU740,
+        VHF20B,
+        VHFUHFExpansion,
+        XT6013,
+        XT6313D,
+    }
+
+    public static class DefaultRadioInformation
+    {
+        private static readonly Dictionary<Radios, RadioValues> RadioDefaults = new Dictionary<Radios, RadioValues>()
+        {
+            // Currently asssuming 50ohms for all radios when converting from uV to dbm, in addition to links below https://dpdproductions.com/pages/military-radio-reference-list was used for reference
+            // Power information was used from above source if only minimums given in specific documentation and above documentation provided a specific power (i.e not a range of powers) 
+            {Radios.Unknown, new RadioValues(40) },
+            {Radios.Intercom, new RadioValues(0) }, // Dummy value for intercoms
+            {Radios.ANARC131, new RadioValues(40) }, // possible sensitivity info https://apps.dtic.mil/sti/pdfs/ADA033368.pdf
+            {Radios.ANARC134, new RadioValues(46, -88) }, // https://www.liberatedmanuals.com/TM-11-5821-277-20.pdf
+            {Radios.ANARC150, new RadioValues(40, -113) }, // https://en.wikipedia.org/wiki/AN/PRC-150
+            {Radios.ANARC159, new RadioValues(40, -96)}, // https://www.columbiaelectronics.com/an_arc_159_v__uhf_transceiver.htm
+            {Radios.ANARC164, new RadioValues(40, -91)}, // https://tsc-60.cellmail.com/tsc-60/TSC-118/rtn_ncs_products_arc164_pdf.pdf
+            {Radios.ANARC182, new RadioValues(44, -110) }, // https://www.columbiaelectronics.com/an_arc_182_v__vhf_uhf_radio_set.htm, used AM parameters - modulation changes based on frequency with differing power outputs and sensitivity
+            {Radios.ANARC186, new RadioValues(40, -97) }, // https://www.columbiaelectronics.com/an_arc_186_v__radio_set.htm TODO: create ANARC186FM due to tx power and rx sensitivity differences
+            {Radios.ANARC210, RadioDefaults[Radios.Unknown] }, // http://static6.arrow.com/aropdfconversion/11eaff76e8fc9a992ea6cb5163f1efddd95392b2/arc-210integratedcommsystemswhitepaper.pdf.pdf, unable to find sensitivity information
+            {Radios.ANARC222, RadioDefaults[Radios.Unknown] }, // Having trouble finding SINGCARS configuration details for F16 Blk. 50 in relation to sensitivity, default values are likely a close approximation
+            {Radios.ANARC27,  new RadioValues(39)}, // https://web.archive.org/web/20100706140322/http://www.nj7p.org/cgi-bin/millist2?mode=normal&name=AN%2FARC-27
+            {Radios.ANARC51BX, new RadioValues(44)}, // No (good) documentation found yet 
+            {Radios.ARI1063, RadioDefaults[Radios.Unknown] }, // No documentation found yet
+            {Radios.ARI232591, RadioDefaults[Radios.Unknown] }, // No documentation found yet
+            {Radios.Baklan5, new RadioValues(37) }, // https://www.an2flyers.org/avionics.html, would prefer a better source
+            {Radios.FR22, RadioDefaults[Radios.Unknown]}, // Info from DCS manual, power is 10w UHF or 20w VHF - using lower power for the time being
+            {Radios.FR24, new RadioValues(35) }, // Info from DCS manual
+            {Radios.FuG16ZY, new RadioValues(40, -77) }, // https://www.esr.se/images/articles-pyssel/TME_11-227-2.pdf, document notes rated Tx power of 10w, testing shows 5w. Using 10w value for now.
+            {Radios.JADRO1A, new RadioValues(47, -93) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
+            {Radios.JADRO1I, new RadioValues(47, -97) }, // https://fccid.io/ANATEL/01011-13-08760/Manual-Radio-HF/2908D16B-1059-472A-922E-9C9947678865
+            {Radios.KTR953HF, new RadioValues(46, -97) }, // http://shop.avionics.co.nz/ktr953
+            {Radios.KY197A, new RadioValues(40, -100) }, // https://www.seaerospace.com/sales/product/BendixKing/KY-197A
+            {Radios.MIDS, RadioDefaults[Radios.ANARC210]}, // I assume MIDS communication will share the same values as the  AN/ARC-210
+            {Radios.R1155, new RadioValues(24, -86)  }, // http://www.vq5x79.f2s.com/greenradio/Wireless21a.html, would prefer a better source
+            {Radios.R800, new RadioValues(38)}, // http://www.radionic.ru/book/export/html/744, would prefer a better source
+            {Radios.R800L14, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.R828, RadioDefaults[Radios.Unknown]}, // https://pandia.ru/text/80/087/37141.php, would prefer a better source
+            {Radios.R832, RadioDefaults[Radios.R832]}, // Assume similar to R832M
+            {Radios.R832M, new RadioValues(42)}, // https://www.armedconflicts.com/Aviacionnaya-UKV-DMV-radiostanciya-R-832M-t80222, would prefer a better source
+            {Radios.R852, new RadioValues(40, -93)}, // https://lektsii.com/2-129490.html, would prefer a better source - assuming 10W Tx power
+            {Radios.R862, new RadioValues(44, -97)}, // https://radiotract.ru/radiostancia-r-862m.html, would prefer a better source
+            {Radios.R863, new RadioValues(40, -97) }, // https://radiotract.ru/radiostancia-r-863m.html, would prefer a better source
+            {Radios.R864, new RadioValues(50, -93)}, // http://www.radioscanner.ru/trx/military/r-864/, would prefer a better source
+            {Radios.RSI6K, new RadioValues(37)}, // https://archives.nato.int/uploads/r/null/1/1/116423/SG_253_1_FINAL_ENG_PDP.pdf, would prefer a better source
+            {Radios.RSIU4V, new RadioValues(39) }, // https://www.armedconflicts.com/Aviacionnaya-UKV-radiostanciya-R-801-RSIU-4B-t80161, would prefer better source (note that RSIU4V == R801V)
+            {Radios.RTA42ABENDIX, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.SCR522, RadioDefaults[Radios.SCR522A]}, // Assume values will be similar to SCR522A
+            {Radios.SCR522A, new RadioValues(40, -94)}, // http://www.radiomanual.info/schemi/Surplus_NATO/SCR-522A_SCR-542A_serv_AN16-40SCR522-3_1952.pdf, other sources provide different transmit power values
+            {Radios.SPU9SW, RadioDefaults[Radios.Unknown]}, // Fairly certain this is just an intercom?
+            {Radios.SRT651N, new RadioValues(40, -103)}, // https://www.yumpu.com/en/document/read/41736902/v-uhf-airborne-radio-systems-srt-651-e-a-se-008-v2-12-
+            {Radios.SUNAIRASB850, new RadioValues(46 ,-97)}, // https://www.sunairelectronics.com/workspace/uploads/asb-850_10-1-1981_2nd-1314220642.pdf
+            {Radios.T1154, new RadioValues(46)}, // http://www.shopingathome.com/1154%20Transmitter.htm, would prefer a better source
+            {Radios.TRAP138A, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.TRC9600PR4G, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.TRTERA7000, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.TRTERA7200, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.UHFTRA6031, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.VHF20B, new RadioValues(43) }, // https://www.seaerospace.com/sales/product/Collins%20Aerospace/VHF-20B
+            {Radios.VHFUHFExpansion, RadioDefaults[Radios.Unknown]}, // Standard Expansion Radios
+            {Radios.VTVU740, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.XT6013, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+            {Radios.XT6313D, RadioDefaults[Radios.Unknown]}, // No documentation found yet
+        };
+
+        private static readonly Dictionary<string, Radios[]> AircraftDefaults = new Dictionary<string, Radios[]>()
+        {
+            {"UH-1H", new [] { Radios.Intercom, Radios.ANARC131, Radios.ANARC51BX, Radios.ANARC134 } },
+            {"Ka-50", new [] {Radios.R800L14, Radios.R828, Radios.SPU9SW } },
+            {"Mi-8MT", new [] { Radios.Intercom, Radios.R863, Radios.JADRO1A, Radios.R828 } },
+            {"Mi-24P", new [] { Radios.Intercom, Radios.R863, Radios.R828, Radios.JADRO1I, Radios.R852} },
+            {"Yak-52", new [] { Radios.Intercom, Radios.Baklan5, Radios.ANARC186, Radios.ANARC164} },
+            {"FA-18C_hornet", new [] { Radios.ANARC210, Radios.ANARC210, Radios.MIDS, Radios.MIDS} },
+            {"F-86F Sabre", new [] { Radios.ANARC27, Radios.ANARC186, Radios.ANARC164 } },
+            {"MiG-15bis", new [] {Radios.RSI6K, Radios.ANARC186, Radios.ANARC164 } },
+            {"MiG-19P", new [] {Radios.RSIU4V, Radios.ANARC186, Radios.ANARC164 } },
+            {"MiG-21Bis", new [] {Radios.R832, Radios.ANARC186, Radios.ANARC164 } },
+            {"F-5E-3", new [] {Radios.ANARC164, Radios.ANARC186, Radios.ANARC164} },
+            {"FW-190D9", new [] {Radios.FuG16ZY, Radios.ANARC186, Radios.ANARC164} },
+            {"FW-190A8", AircraftDefaults["FW-190D9"] },
+            {"Bf-109K-4", AircraftDefaults["FW-190D9"] },
+            {"C-101EB", new [] { Radios.Intercom, Radios.ANARC164, Radios.ANARC134} },
+            {"C-101CC", new [] { Radios.Intercom, Radios.VTVU740, Radios.VHF20B} },
+            {"MB-339A", new [] { Radios.Intercom, Radios.ANARC150, Radios.SRT651N } },
+            {"MB-339APAN", AircraftDefaults["MB-339A"] },
+            {"Hawk", new [] { Radios.ANARC164, Radios.ARI232591} },
+            {"Christen Eagle II", new [] { Radios.Intercom, Radios.KY197A, Radios.ANARC186, Radios.ANARC164 } },
+            {"M-2000C", new []  {Radios.TRTERA7000, Radios.TRTERA7200 } },
+            {"JF-17", new [] { Radios.Unknown, Radios.Unknown, Radios.VHFUHFExpansion} },
+            {"AV8BNA", new [] { Radios.ANARC210, Radios.ANARC210, Radios.ANARC210 } },
+            {"AJS37", new [] { Radios.FR22, Radios.FR24, Radios.ANARC164} },
+            {"A-10A", new [] { Radios.ANARC186, Radios.ANARC164, Radios.ANARC186} },
+            {"A-4E-C", new [] { Radios.ANARC51BX, Radios.ANARC186, Radios.ANARC186} }, //TODO: Radio 3 updated to 186FM when added
+            {"PUCARA", new [] { Radios.Intercom, Radios.SUNAIRASB850, Radios.RTA42ABENDIX} },
+            {"T-45", new [] {Radios.Intercom, Radios.ANARC182, Radios.ANARC182} },
+            {"A-29B", new [] { Radios.XT6013, Radios.XT6313D, Radios.KTR953HF } },
+            {"F-15C", new [] { Radios.ANARC164, Radios.ANARC164, Radios.ANARC186} },
+            {"MiG-29A", new [] { Radios.R862, Radios.ANARC186, Radios.ANARC164} },
+            {"MiG-29S", AircraftDefaults["MiG-29A"]},
+            {"MiG-29G", AircraftDefaults["MiG-29A"]},
+            {"Su-27", new [] {Radios.R800, Radios.R864, Radios.ANARC164 } },
+            {"Su-33", AircraftDefaults["Su-27"] },
+            {"Su-25", new [] { Radios.R862, Radios.R828, Radios.ANARC164 } },
+            {"Su-25T", AircraftDefaults["Su-25"]},
+            {"F-16C_50", new [] { Radios.ANARC164, Radios.ANARC222} },
+            {"SA342M", new [] { Radios.Intercom, Radios.TRAP138A, Radios.UHFTRA6031, Radios.TRC9600PR4G} },
+            {"SA342L", AircraftDefaults["SA342M"] },
+            {"SA342Mistral", AircraftDefaults["SA342M"]},
+            {"SA342Minigun", AircraftDefaults["SA342M"]},
+            {"L-39C", new [] { Radios.Intercom, Radios.R832M, Radios.ANARC186, Radios.ANARC164} },
+            {"L-39ZA", AircraftDefaults["L-39C"] },
+            {"F-14B", new [] { Radios.Intercom, Radios.ANARC159, Radios.ANARC182 } },
+            {"F-14A-135-GR", AircraftDefaults["F-14B"] },
+            {"A-10C", new [] { Radios.ANARC186, Radios.ANARC164, Radios.ANARC186 } },
+            {"A-10C_2", AircraftDefaults["A-10C_2"] },
+            {"P-51D", new [] {Radios.SCR522A, Radios.ANARC186, Radios.ANARC164 } },
+            {"P-51D-30-NA", AircraftDefaults["P-51D"] },
+            {"TF-51D", AircraftDefaults["P-51D"]},
+            {"P-47D-30", new [] {Radios.SCR522, Radios.ANARC186, Radios.ANARC164 } },
+            {"P-47D-30bl1", AircraftDefaults["P-47D-30"] },
+            {"P-47D-40", AircraftDefaults["P-47D-30"] },
+            {"SpitfireLFMkIX", new [] {Radios.ARI1063, Radios.ANARC186, Radios.ANARC164 } },
+            {"SpitfireLFMkIXCW", AircraftDefaults["SpitfireLFMkIX"] },
+            {"MosquitoFBMkVI", new [] { Radios.Intercom, Radios.SCR522A, Radios.R1155, Radios.T1154, Radios.ANARC210} },
+        };
+
+        public static Dictionary<Radios, RadioValues> GetRadioDefaults()
+        {
+            return RadioDefaults;
+        }
+
+        public static Dictionary<string, Radios[]> GetAircraftDefaults()
+        {
+            return AircraftDefaults;
+        }
+    }
+}

--- a/DCS-SR-Common/DCSState/RadioTypes.cs
+++ b/DCS-SR-Common/DCSState/RadioTypes.cs
@@ -19,7 +19,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
         ANARC164,
         ANARC182,
         ANARC186,
+        ANARC201D,
         ANARC210,
+        ANARC220,
         ANARC222,
         ANARC27,
         ANARC51BX,
@@ -74,12 +76,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
             {Radios.Intercom.ToString(), new RadioValues(0) }, // Dummy value for intercoms
             {Radios.ANARC131.ToString(), new RadioValues(40) }, // possible sensitivity info https://apps.dtic.mil/sti/pdfs/ADA033368.pdf
             {Radios.ANARC134.ToString(), new RadioValues(46, -88) }, // https://www.liberatedmanuals.com/TM-11-5821-277-20.pdf
-            {Radios.ANARC150.ToString(), new RadioValues(40, -113) }, // https://en.wikipedia.org/wiki/AN/PRC-150
+            {Radios.ANARC150.ToString(), new RadioValues(40) }, // Proving difficult to find information for - produced by MagnaVox
             {Radios.ANARC159.ToString(), new RadioValues(40, -96)}, // https://www.columbiaelectronics.com/an_arc_159_v__uhf_transceiver.htm
             {Radios.ANARC164.ToString(), new RadioValues(40, -91)}, // https://tsc-60.cellmail.com/tsc-60/TSC-118/rtn_ncs_products_arc164_pdf.pdf
             {Radios.ANARC182.ToString(), new RadioValues(44, -110) }, // https://www.columbiaelectronics.com/an_arc_182_v__vhf_uhf_radio_set.htm, used AM parameters - modulation changes based on frequency with differing power outputs and sensitivity
             {Radios.ANARC186.ToString(), new RadioValues(40, -97) }, // https://www.columbiaelectronics.com/an_arc_186_v__radio_set.htm TODO: create ANARC186FM due to tx power and rx sensitivity differences
+            {Radios.ANARC201D.ToString(), new RadioValues(40) }, // https://www.l3harris.com/sites/default/files/2020-11/cs-tcom-an-arc-201d-sincgars-airborne-radio-datasheet.pdf
             {Radios.ANARC210.ToString(), new RadioValues(40) }, // http://static6.arrow.com/aropdfconversion/11eaff76e8fc9a992ea6cb5163f1efddd95392b2/arc-210integratedcommsystemswhitepaper.pdf.pdf, unable to find sensitivity information
+            {Radios.ANARC220.ToString(), new RadioValues(50) }, // https://dpdproductions.com/pages/military-radio-reference-list
             {Radios.ANARC222.ToString(), new RadioValues(40) }, // Having trouble finding SINGCARS configuration details for F16 Blk. 50 in relation to sensitivity, default values are likely a close approximation
             {Radios.ANARC27.ToString(),  new RadioValues(39)}, // https://web.archive.org/web/20100706140322/http://www.nj7p.org/cgi-bin/millist2?mode=normal&name=AN%2FARC-27
             {Radios.ANARC51BX.ToString(), new RadioValues(44)}, // No (good) documentation found yet 
@@ -127,6 +131,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
 
         public static readonly Dictionary<string, string[]> AircraftDefaults = new Dictionary<string, string[]>()
         {
+            {"External AWACS", new [] { Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(),
+                                       Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString()} },
+            {"CA", new [] { Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(),
+                                       Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString(), Radios.Unknown.ToString()} },
+            {"AH-64D_BLK_II", new []  { Radios.Intercom.ToString(), Radios.ANARC186.ToString(), Radios.ANARC164.ToString(), Radios.ANARC201D.ToString()} }
             {"UH-1H", new [] { Radios.Intercom.ToString(), Radios.ANARC131.ToString(), Radios.ANARC51BX.ToString(), Radios.ANARC134.ToString() } },
             {"Ka-50", new [] {Radios.R800L14.ToString(), Radios.R828.ToString(), Radios.SPU9SW.ToString() } },
             {"Mi-8MT", new [] { Radios.Intercom.ToString(), Radios.R863.ToString(), Radios.JADRO1A.ToString(), Radios.R828.ToString() } },

--- a/DCS-SR-Common/DCSState/RadioValues.cs
+++ b/DCS-SR-Common/DCSState/RadioValues.cs
@@ -8,10 +8,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
 {
     public class RadioValues
     {
-        public int Power { get; }
-        public int Sensitivity { get; }
+        public byte Power { get; }
+        public int Sensitivity { get; } // this could probably be changed to a byte to express the abs value
 
-        public RadioValues(int power, int sensitivity = -90)
+        public RadioValues(byte power, int sensitivity = -90)
         {
             Power = power;
             Sensitivity = sensitivity;

--- a/DCS-SR-Common/DCSState/RadioValues.cs
+++ b/DCS-SR-Common/DCSState/RadioValues.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
+{
+    public class RadioValues
+    {
+        public int Power { get; }
+        public int Sensitivity { get; }
+
+        public RadioValues(int power, int sensitivity = -90)
+        {
+            Power = power;
+            Sensitivity = sensitivity;
+        }
+    }
+}

--- a/DCS-SR-Common/Helpers/RadioCalculator.cs
+++ b/DCS-SR-Common/Helpers/RadioCalculator.cs
@@ -36,25 +36,28 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 
         // TODO - this equation will be used to mix in static audio to the transmission audio
         // static will creep in in the last 20 % and be ramped up in volume based on distance
-        public static double FriisMaximumTransmissionRange(double frequency)
+        public static double FriisMaximumTransmissionRange(double frequency, int sensitivity = 0, byte power = 0)
         {
             //Friis equation http://www.daycounter.com/Calculators/Friis-Calculator.phtml
             //Prx= Ptx(dB)+ Gtx(dB)+ Grx(dB)  -  20log(4*PI*d/lambda);
             //Re-arranged to give maximum distance at receiving power of -90 based on transmitting power
-            //of 40 watts
+            //of 10 watts
 
-            //Hard coded value 995267.9264 based on re-arranged Friis with 40dbm transmissing
-            return (MagicPartiallySolvedFriis *
+            //Hard coded value 995267.9264 based on re-arranged Friis with 40dbm transmissing 
+            if (sensitivity + power == 0)
+            {
+                return (MagicPartiallySolvedFriis *
                     FrequencyToWaveLength(frequency)) / Math.PI;
-        }
+            }
+            else
+            {
+                double partialFriis = 2 * (-sensitivity + power + 1 + 1 - 40) / 20
+                    * 5 - (sensitivity - power - 1 - 1) / 20;
 
-        public static double CustomValueFriisMaximumTransmissionRange(double frequency, RadioValues receiving, RadioValues transmitting)
-        {
-            double partialFriis = 2 * (-receiving.Sensitivity + transmitting.Power + 1 + 1 - 40) / 20 
-                * 5 - (receiving.Sensitivity - transmitting.Power - 1 - 1) / 20;
+                return (partialFriis *
+                    FrequencyToWaveLength(frequency)) / Math.PI;
+            }
 
-            return (partialFriis * 
-                FrequencyToWaveLength(frequency)) / Math.PI;
         }
 
         //we can hear if the received power is more than the RX sensivity
@@ -107,6 +110,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
             return Math.Sqrt((distance * distance) + (height * height));
 
         }
-      
+
     }
 }

--- a/DCS-SR-Common/Helpers/RadioCalculator.cs
+++ b/DCS-SR-Common/Helpers/RadioCalculator.cs
@@ -48,6 +48,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
                     FrequencyToWaveLength(frequency)) / Math.PI;
         }
 
+        public static double CustomValueFriisMaximumTransmissionRange(double frequency, RadioValues receiving, RadioValues transmitting)
+        {
+            double partialFriis = 2 * (-receiving.Sensitivity + transmitting.Power + 1 + 1 - 40) / 20 
+                * 5 - (receiving.Sensitivity - transmitting.Power - 1 - 1) / 20;
+
+            return (partialFriis * 
+                FrequencyToWaveLength(frequency)) / Math.PI;
+        }
+
         //we can hear if the received power is more than the RX sensivity
         //Eventually this will scale the audio volume with distance
         public static bool CanHearTransmission(double distance, double frequency)

--- a/DCS-SR-Common/Helpers/RadioCalculator.cs
+++ b/DCS-SR-Common/Helpers/RadioCalculator.cs
@@ -43,7 +43,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
             //Re-arranged to give maximum distance at receiving power of -90 based on transmitting power
             //of 10 watts
 
-            //Hard coded value 995267.9264 based on re-arranged Friis with 40dbm transmissing 
+            //Hard coded value 995267.9264 based on re-arranged Friis with 40dbm transmissing
+            //Calculating the partial friis benchmarks at 1-3 ticks, can probably remove the hardcoded value?
             if (sensitivity + power == 0)
             {
                 return (MagicPartiallySolvedFriis *

--- a/DCS-SR-Common/Network/NetworkMessage.cs
+++ b/DCS-SR-Common/Network/NetworkMessage.cs
@@ -24,7 +24,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
             VERSION_MISMATCH,
             EXTERNAL_AWACS_MODE_PASSWORD, // Received server side to "authenticate"/pick side for external AWACS mode
             EXTERNAL_AWACS_MODE_DISCONNECT, // Received server side on "voluntary" disconnect by the client (without closing the server connection)
-            RADIO_SETTINGS,
+            RADIO_SETTINGS, // TODO: find a better way to combine aircraft and radiosettings request into one
             AIRCRAFT_SETTINGS,
         }
 

--- a/DCS-SR-Common/Network/NetworkMessage.cs
+++ b/DCS-SR-Common/Network/NetworkMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Helpers;
 using Newtonsoft.Json;
 using NLog.Layouts;
@@ -22,7 +23,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
             CLIENT_DISCONNECT, // Client disconnected
             VERSION_MISMATCH,
             EXTERNAL_AWACS_MODE_PASSWORD, // Received server side to "authenticate"/pick side for external AWACS mode
-            EXTERNAL_AWACS_MODE_DISCONNECT // Received server side on "voluntary" disconnect by the client (without closing the server connection)
+            EXTERNAL_AWACS_MODE_DISCONNECT, // Received server side on "voluntary" disconnect by the client (without closing the server connection)
+            RADIO_SETTINGS,
+            AIRCRAFT_SETTINGS,
         }
 
         public SRClient Client { get; set; }
@@ -36,6 +39,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
         public string ExternalAWACSModePassword { get; set; }
 
         public string Version { get; set; }
+
+        public Dictionary<string, RadioValues> RadioSettings { get; set; }
+
+        public Dictionary<string, string[]> AircraftSettings { get; set; }
 
         public string Encode()
         {

--- a/DCS-SR-Common/Network/UDPVoicePacket.cs
+++ b/DCS-SR-Common/Network/UDPVoicePacket.cs
@@ -81,7 +81,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
         public byte[] OriginalClientGuidBytes { get; set; }
         public string OriginalClientGuid { get; set; }
         public ulong PacketNumber { get; set; }
-        public byte[] TransmittingRadio { get; set; }
+        public byte[] TransmittedPower { get; set; }
         //Number of times its been retransmitted - added to stop retransmission loop with sensible limit
         public byte RetransmissionCount { get; set; } = new byte();
 
@@ -148,7 +148,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
                 combinedBytes[frequencyOffset + 7] = freq[7];
 
                 // Radio that is transmitting (1 byte)
-                combinedBytes[frequencyOffset + 8] = TransmittingRadio[i];
+                combinedBytes[frequencyOffset + 8] = TransmittedPower[i];
 
                 // Radio modulation (1 byte), defaults to AM if not defined for all frequencies
                 var mod = Modulations.Length > i ? Modulations[i] : (byte)4;
@@ -265,7 +265,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network
                     Encryptions = encryptions,
                     Modulations = modulations,
                     PacketNumber = packetNumber,
-                    TransmittingRadio = transmittingRadio,
+                    TransmittedPower = transmittingRadio,
                     PacketLength = packetLength,
                     OriginalClientGuid = transmissionGuid,
                     OriginalClientGuidBytes = transmissionBytes,

--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -38,7 +38,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         TRANSMISSION_LOG_RETENTION = 27,
         RADIO_EFFECT_OVERRIDE = 28,
         SERVER_IP = 29,
-        REALISTIC_RADIO_ENABLED = 30,
+        DIFFERING_RADIO_ENABLED = 30,
+        CUSTOM_RADIO_VALUE_ENABLE = 31,
     }
 
     public class DefaultServerSettings
@@ -75,7 +76,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.TRANSMISSION_LOG_RETENTION.ToString(), "2" },
             { ServerSettingsKeys.RADIO_EFFECT_OVERRIDE.ToString(), "false" },
             { ServerSettingsKeys.SERVER_IP.ToString(), "0.0.0.0" },
-            { ServerSettingsKeys.REALISTIC_RADIO_ENABLED.ToString(), "false" },
+            { ServerSettingsKeys.DIFFERING_RADIO_ENABLED.ToString(), "false" },
+            { ServerSettingsKeys.CUSTOM_RADIO_VALUE_ENABLE.ToString(), "false" },
         };
     }
 }

--- a/DCS-SR-Common/Setting/ServerSettingsKeys.cs
+++ b/DCS-SR-Common/Setting/ServerSettingsKeys.cs
@@ -38,6 +38,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
         TRANSMISSION_LOG_RETENTION = 27,
         RADIO_EFFECT_OVERRIDE = 28,
         SERVER_IP = 29,
+        REALISTIC_RADIO_ENABLED = 30,
     }
 
     public class DefaultServerSettings
@@ -73,7 +74,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Setting
             { ServerSettingsKeys.TRANSMISSION_LOG_ENABLED.ToString(), "false" },
             { ServerSettingsKeys.TRANSMISSION_LOG_RETENTION.ToString(), "2" },
             { ServerSettingsKeys.RADIO_EFFECT_OVERRIDE.ToString(), "false" },
-            { ServerSettingsKeys.SERVER_IP.ToString(), "0.0.0.0" }
+            { ServerSettingsKeys.SERVER_IP.ToString(), "0.0.0.0" },
+            { ServerSettingsKeys.REALISTIC_RADIO_ENABLED.ToString(), "false" },
         };
     }
 }

--- a/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
+++ b/DCS-SimpleRadio Server/DCS-SimpleRadio Server.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Network\Models\TransmissionLoggingQueue.cs" />
     <Compile Include="Network\UDPPositionHandler.cs" />
     <Compile Include="Network\UDPVoiceRouter.cs" />
+    <Compile Include="Settings\RadioSettingsStore.cs" />
     <Compile Include="UI\ClientAdmin\ClientAdminViewModel.cs" />
     <Compile Include="UI\ClientAdmin\ClientViewModel.cs" />
     <Compile Include="UI\MainWindow\MainViewModel.cs" />

--- a/DCS-SimpleRadio Server/Network/ServerSync.cs
+++ b/DCS-SimpleRadio Server/Network/ServerSync.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Windows;
 using Caliburn.Micro;
 using Ciribob.DCS.SimpleRadio.Standalone.Common;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
 using Ciribob.DCS.SimpleRadio.Standalone.Server.Settings;
@@ -29,6 +30,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
         private readonly IEventAggregator _eventAggregator;
 
         private readonly ServerSettingsStore _serverSettings;
+        private readonly RadioSettingsStore _radioSettingsStore;
         private NatHandler _natHandler;
 
 
@@ -40,6 +42,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
             _eventAggregator = eventAggregator;
             _eventAggregator.Subscribe(this);
             _serverSettings = ServerSettingsStore.Instance;
+            _radioSettingsStore = RadioSettingsStore.Instance;
 
             OptionKeepAlive = true;
 
@@ -498,6 +501,30 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
 
                 MulticastAllExeceptOne(message.Encode(), session.Id);
             }
+        }
+
+        private void HandleRadioSettingsMessage(SRSClientSession session)
+        {
+            // Due to size only send on request, do not multicast as with serversettings
+            var replyMessage = new NetworkMessage
+            {
+                MsgType = NetworkMessage.MessageType.RADIO_UPDATE,
+                RadioSettings = _radioSettingsStore.GetRadioSettings()
+            };
+
+            session.Send(replyMessage.Encode());
+        }
+
+        private void HandleAircraftSettingMessage(SRSClientSession session)
+        {
+            // Due to size only send on request, do not multicast as with serversettings
+            var replyMessage = new NetworkMessage
+            {
+                MsgType = NetworkMessage.MessageType.AIRCRAFT_SETTINGS,
+                AircraftSettings = _radioSettingsStore.GetAircraftSettings()
+            };
+
+            session.Send(replyMessage.Encode());
         }
 
         public void RequestStop()

--- a/DCS-SimpleRadio Server/Network/ServerSync.cs
+++ b/DCS-SimpleRadio Server/Network/ServerSync.cs
@@ -396,6 +396,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                 MsgType = NetworkMessage.MessageType.SYNC,
                 Clients = new List<SRClient>(_clients.Values),
                 ServerSettings = _serverSettings.ToDictionary(),
+                AircraftSettings = _radioSettingsStore.GetAircraftSettings(),
+                RadioSettings = _radioSettingsStore.GetRadioSettings(),
                 Version = UpdaterChecker.VERSION
             };
 
@@ -501,30 +503,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
 
                 MulticastAllExeceptOne(message.Encode(), session.Id);
             }
-        }
-
-        private void HandleRadioSettingsMessage(SRSClientSession session)
-        {
-            // Due to size only send on request, do not multicast as with serversettings
-            var replyMessage = new NetworkMessage
-            {
-                MsgType = NetworkMessage.MessageType.RADIO_UPDATE,
-                RadioSettings = _radioSettingsStore.GetRadioSettings()
-            };
-
-            session.Send(replyMessage.Encode());
-        }
-
-        private void HandleAircraftSettingMessage(SRSClientSession session)
-        {
-            // Due to size only send on request, do not multicast as with serversettings
-            var replyMessage = new NetworkMessage
-            {
-                MsgType = NetworkMessage.MessageType.AIRCRAFT_SETTINGS,
-                AircraftSettings = _radioSettingsStore.GetAircraftSettings()
-            };
-
-            session.Send(replyMessage.Encode());
         }
 
         public void RequestStop()

--- a/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
+++ b/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
@@ -201,7 +201,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                         if (_clientsList.ContainsKey(guid))
                         {
                             var client = _clientsList[guid];
-                            Console.WriteLine(client.RadioInfo.unit);
                             client.VoipPort = udpPacket.ReceivedFrom;
 
                             var spectatorAudioDisabled =

--- a/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
+++ b/DCS-SimpleRadio Server/Network/UDPVoiceRouter.cs
@@ -201,6 +201,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Network
                         if (_clientsList.ContainsKey(guid))
                         {
                             var client = _clientsList[guid];
+                            Console.WriteLine(client.RadioInfo.unit);
                             client.VoipPort = udpPacket.ReceivedFrom;
 
                             var spectatorAudioDisabled =

--- a/DCS-SimpleRadio Server/Settings/RadioSettingsStore.cs
+++ b/DCS-SimpleRadio Server/Settings/RadioSettingsStore.cs
@@ -1,0 +1,194 @@
+﻿using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
+{
+    internal class RadioSettingsStore
+    {
+
+        private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        public static readonly string DEFAULT_RADIO_CONFIG_FILE = "radioconfiguration.json";
+        public static readonly string DEFAULT_AIRCRAFT_CONFIG_FILE = "aircraftconfiguration.json";
+        private string _configRadioFile = DEFAULT_RADIO_CONFIG_FILE;
+        private string _configAircraftFile = DEFAULT_AIRCRAFT_CONFIG_FILE;
+
+        private static Dictionary<string, RadioValues> radioValues;
+        private static Dictionary<string, string[]> aircraftValues;
+
+        private static RadioSettingsStore instance;
+        private static readonly object _lock = new object();
+
+        public RadioSettingsStore()
+        {
+            var args = Environment.GetCommandLineArgs();
+
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith("-rad="))
+                {
+                    _configRadioFile = arg.Replace("-rad=", "").Trim();
+                }
+            }
+
+            radioValues = DefaultRadioInformation.RadioDefaults;
+            aircraftValues = DefaultRadioInformation.AircraftDefaults;
+
+            try
+            {
+                var deserializedRadios = JsonConvert.DeserializeObject<Dictionary<string, RadioValues>>((File.ReadAllText(_configRadioFile)));
+
+                foreach (KeyValuePair<string, RadioValues> kvp in deserializedRadios)
+                {
+                    if(radioValues.ContainsKey(kvp.Key))
+                    {
+                        radioValues[kvp.Key] = kvp.Value;
+                    }
+                    else
+                    {
+                        radioValues.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
+            catch(FileNotFoundException ex)
+            {
+                _logger.Info("Unable to find radio configuration file, using default values");
+                radioValues = DefaultRadioInformation.RadioDefaults;
+                aircraftValues = DefaultRadioInformation.AircraftDefaults;
+
+                SaveRadio();
+            }
+            catch(JsonReaderException ex)
+            {
+                _logger.Error(ex, "Failed to parse radio configuration, potentially corrupted.");
+
+                MessageBox.Show("Failed to read server config, it might have become corrupted.",
+                    "Radio configuration error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+
+                radioValues = DefaultRadioInformation.RadioDefaults;
+                aircraftValues = DefaultRadioInformation.AircraftDefaults;
+
+                SaveRadio();
+            }
+
+
+            try
+            {
+                var deserializedAircraft = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(File.ReadAllText(_configAircraftFile));
+
+                foreach(KeyValuePair<string, string[]> kvp in deserializedAircraft)
+                {
+                    if(deserializedAircraft.ContainsKey(kvp.Key))
+                    {
+                        aircraftValues[kvp.Key] = kvp.Value;
+                    }
+                    else
+                    {
+                        aircraftValues.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
+            catch (FileNotFoundException ex)
+            {
+                _logger.Info("Unable to find aircraft configuration file, using default values");
+                radioValues = DefaultRadioInformation.RadioDefaults;
+                aircraftValues = DefaultRadioInformation.AircraftDefaults;
+
+                SaveAircraft();
+            }
+            catch (JsonReaderException ex)
+            {
+                _logger.Error(ex, "Failed to parse radio configuration, potentially corrupted.");
+
+                MessageBox.Show("Failed to read server config, it might have become corrupted.",
+                    "Radio configuration error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+
+                radioValues = DefaultRadioInformation.RadioDefaults;
+                aircraftValues = DefaultRadioInformation.AircraftDefaults;
+
+                SaveAircraft();
+            }
+        }
+
+        public static RadioSettingsStore Instance
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    if (instance == null)
+                    {
+                        instance = new RadioSettingsStore();
+                    }
+                }
+                return instance;
+            }
+        }
+
+        public void SaveRadio()
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    JsonSerializer jsonSerializer = new JsonSerializer();
+                    jsonSerializer.Formatting = Formatting.Indented;
+
+                    using (StreamWriter sw = new StreamWriter(_configRadioFile))
+                    using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+                    {
+                        jsonSerializer.Serialize(jsonWriter, radioValues);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unable to save settings!");
+                }
+            }
+        }
+
+        public void SaveAircraft()
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    JsonSerializer jsonSerializer = new JsonSerializer();
+                    jsonSerializer.Formatting = Formatting.Indented;
+
+                    using (StreamWriter sw = new StreamWriter(_configAircraftFile))
+                    using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+                    {
+                        jsonSerializer.Serialize(jsonWriter, aircraftValues);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unable to save settings!");
+                }
+            }
+        }
+
+        public Dictionary<string, RadioValues> GetRadioSettings()
+        {
+            return radioValues;
+        }
+
+        public Dictionary<string, string[]> GetAircraftSettings()
+        {
+            return aircraftValues;
+        }
+    }
+}

--- a/DCS-SimpleRadio Server/Settings/RadioSettingsStore.cs
+++ b/DCS-SimpleRadio Server/Settings/RadioSettingsStore.cs
@@ -1,4 +1,5 @@
 ﻿using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -42,13 +43,21 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
             radioValues = DefaultRadioInformation.RadioDefaults;
             aircraftValues = DefaultRadioInformation.AircraftDefaults;
 
+            if (ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.CUSTOM_RADIO_VALUE_ENABLE).BoolValue)
+            {
+                ReadCustomConfig();
+            }
+        }
+
+        private void ReadCustomConfig()
+        {
             try
             {
                 var deserializedRadios = JsonConvert.DeserializeObject<Dictionary<string, RadioValues>>((File.ReadAllText(_configRadioFile)));
 
                 foreach (KeyValuePair<string, RadioValues> kvp in deserializedRadios)
                 {
-                    if(radioValues.ContainsKey(kvp.Key))
+                    if (radioValues.ContainsKey(kvp.Key))
                     {
                         radioValues[kvp.Key] = kvp.Value;
                     }
@@ -58,7 +67,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
                     }
                 }
             }
-            catch(FileNotFoundException ex)
+            catch (FileNotFoundException ex)
             {
                 _logger.Info("Unable to find radio configuration file, using default values");
                 radioValues = DefaultRadioInformation.RadioDefaults;
@@ -66,7 +75,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
 
                 SaveRadio();
             }
-            catch(JsonReaderException ex)
+            catch (JsonReaderException ex)
             {
                 _logger.Error(ex, "Failed to parse radio configuration, potentially corrupted.");
 
@@ -86,9 +95,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
             {
                 var deserializedAircraft = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(File.ReadAllText(_configAircraftFile));
 
-                foreach(KeyValuePair<string, string[]> kvp in deserializedAircraft)
+                foreach (KeyValuePair<string, string[]> kvp in deserializedAircraft)
                 {
-                    if(deserializedAircraft.ContainsKey(kvp.Key))
+                    if (deserializedAircraft.ContainsKey(kvp.Key))
                     {
                         aircraftValues[kvp.Key] = kvp.Value;
                     }
@@ -120,6 +129,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.Settings
 
                 SaveAircraft();
             }
+        }
+
+        private void ResetDefaultConfig()
+        {
+            radioValues = DefaultRadioInformation.RadioDefaults;
+            aircraftValues = DefaultRadioInformation.AircraftDefaults;
         }
 
         public static RadioSettingsStore Instance

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -415,15 +415,15 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Realistic Radio Values Enabled" 
+                <Label Content="Differing Radio Values Enabled" 
                        Grid.Row="21"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
-                <Button x:Name="RealisticRadioEnabledToggle"
-                        Content="{Binding RealisticRadioEnabledText}"
+                <Button x:Name="DifferingRadioEnabledToggle"
+                        Content="{Binding DifferingRadioEnabledText}"
                         Grid.Row="21"
                         Grid.Column="2"
                         Width="75"
@@ -431,15 +431,15 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Log Received Transmissions"
+                <Label Content="Use Custom Radio Values" 
                        Grid.Row="22"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
-                <Button x:Name="TransmissionLogEnabledToggle"
-                        Content="{Binding TransmissionLogEnabledText}"
+                <Button x:Name="CustomRadioValueEnabledToggle"
+                        Content="{Binding CustomRadioValueEnabledText}"
                         Grid.Row="22"
                         Grid.Column="2"
                         Width="75"
@@ -447,15 +447,31 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Transmission Archive Time"
+                <Label Content="Log Received Transmissions"
                        Grid.Row="23"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
+                <Button x:Name="TransmissionLogEnabledToggle"
+                        Content="{Binding TransmissionLogEnabledText}"
+                        Grid.Row="23"
+                        Grid.Column="2"
+                        Width="75"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"/>
+
+                <Label Content="Transmission Archive Time"
+                       Grid.Row="24"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
+
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="23"
+                            Grid.Row="24"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>
@@ -482,13 +498,13 @@
                 </StackPanel>
 
                 <Label Content="Retransmit Hop/Node Count"
-                       Grid.Row="24"
+                       Grid.Row="25"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="24"
+                            Grid.Row="25"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainView.xaml
@@ -41,6 +41,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
 
                 <Button Grid.Row="0"
@@ -414,15 +415,15 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Log Received Transmissions"
+                <Label Content="Realistic Radio Values Enabled" 
                        Grid.Row="21"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
-                <Button x:Name="TransmissionLogEnabledToggle"
-                        Content="{Binding TransmissionLogEnabledText}"
+                <Button x:Name="RealisticRadioEnabledToggle"
+                        Content="{Binding RealisticRadioEnabledText}"
                         Grid.Row="21"
                         Grid.Column="2"
                         Width="75"
@@ -430,15 +431,31 @@
                         VerticalAlignment="Center"
                         HorizontalAlignment="Center"/>
 
-                <Label Content="Transmission Archive Time"
+                <Label Content="Log Received Transmissions"
                        Grid.Row="22"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
 
+                <Button x:Name="TransmissionLogEnabledToggle"
+                        Content="{Binding TransmissionLogEnabledText}"
+                        Grid.Row="22"
+                        Grid.Column="2"
+                        Width="75"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"/>
+
+                <Label Content="Transmission Archive Time"
+                       Grid.Row="23"
+                       Grid.Column="0" 
+                       Grid.ColumnSpan="2"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center"/>
+
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="22"
+                            Grid.Row="23"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>
@@ -465,13 +482,13 @@
                 </StackPanel>
 
                 <Label Content="Retransmit Hop/Node Count"
-                       Grid.Row="23"
+                       Grid.Row="24"
                        Grid.Column="0" 
                        Grid.ColumnSpan="2"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"/>
                 <StackPanel Orientation="Vertical"
-                            Grid.Row="23"
+                            Grid.Row="24"
                             Grid.Column="2">
                     <Grid  Width="75">
                         <Grid.ColumnDefinitions>

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -218,6 +218,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
         public string TransmissionLogEnabledText
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue ? "ON" : "OFF";
 
+        public string RealisticRadioEnabledText
+            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.REALISTIC_RADIO_ENABLED).BoolValue ? "ON" : "OFF";
+
 
         public string ListeningPort
             => ServerSettingsStore.Instance.GetServerSetting(ServerSettingsKeys.SERVER_PORT).StringValue;
@@ -444,6 +447,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
             var newSetting = TransmissionLogEnabledText != "ON";
             ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED, newSetting);
             NotifyOfPropertyChange(() => TransmissionLogEnabledText);
+
+            _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+        }
+
+        public void RealisticRadioEnabledToggle()
+        {
+            var newSetting = RealisticRadioEnabledText != "ON";
+            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.REALISTIC_RADIO_ENABLED, newSetting);
+            NotifyOfPropertyChange(() => RealisticRadioEnabledText);
 
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }

--- a/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
+++ b/DCS-SimpleRadio Server/UI/MainWindow/MainViewModel.cs
@@ -218,9 +218,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
         public string TransmissionLogEnabledText
             => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.TRANSMISSION_LOG_ENABLED).BoolValue ? "ON" : "OFF";
 
-        public string RealisticRadioEnabledText
-            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.REALISTIC_RADIO_ENABLED).BoolValue ? "ON" : "OFF";
+        public string DifferingRadioEnabledText
+            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.DIFFERING_RADIO_ENABLED).BoolValue ? "ON" : "OFF";
 
+        public string CustomRadioValueEnabledText
+            => ServerSettingsStore.Instance.GetGeneralSetting(ServerSettingsKeys.CUSTOM_RADIO_VALUE_ENABLE).BoolValue ? "ON" : "OFF";
 
         public string ListeningPort
             => ServerSettingsStore.Instance.GetServerSetting(ServerSettingsKeys.SERVER_PORT).StringValue;
@@ -451,13 +453,25 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Server.UI.MainWindow
             _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
         }
 
-        public void RealisticRadioEnabledToggle()
+        public void DifferingRadioEnabledToggle()
         {
-            var newSetting = RealisticRadioEnabledText != "ON";
-            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.REALISTIC_RADIO_ENABLED, newSetting);
-            NotifyOfPropertyChange(() => RealisticRadioEnabledText);
+            var newSetting = DifferingRadioEnabledText != "ON";
+            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.DIFFERING_RADIO_ENABLED, newSetting);
+            NotifyOfPropertyChange(() => DifferingRadioEnabledText);
+            // Initial prototype changes only apply on restart - consider either bundling into server settings
+            // or creating a RadioSettingsChangedMessage and extending ServerLifeCycle to implement an IHandler for it
+            //_eventAggregator.PublishOnBackgroundThread(new RadioSettingsChangedMessage());
+        }
 
-            _eventAggregator.PublishOnBackgroundThread(new ServerSettingsChangedMessage());
+        public void CustomRadioValueEnabledToggle()
+        {
+            var newSetting = CustomRadioValueEnabledText != "ON";
+            ServerSettingsStore.Instance.SetGeneralSetting(ServerSettingsKeys.CUSTOM_RADIO_VALUE_ENABLE, newSetting);
+            NotifyOfPropertyChange(() => CustomRadioValueEnabledText);
+
+            // Initial prototype changes only apply on restart - consider either bundling into server settings
+            // or creating a RadioSettingsChangedMessage and extending ServerLifeCycle to implement an IHandler for it
+            //_eventAggregator.PublishOnBackgroundThread(new RadioSettingsChangedMessage());
         }
 
         public int ArchiveLimit


### PR DESCRIPTION
As per feature request #587.

The change to UDPVoicePacket is an additional byte in the frequency segment which expresses the Tx power of the sending radio. 

Additionally the custom radio values mentioned in #587 are also working,  allowing custom power/sensitivity for radios and which radio maps to which position in an aircraft. This adds two JSON config files, and changes to the NetworkMessage to include 2 new Dictionaries to transmit this info with a SYNC MessageType.

Server admins can choose to use differing radio powers or keep the previous system of all radios using the same values. If differing radio powers is enabled, they can also enable custom configurations which will then read from the JSON files.

One thing about the current implementation is that changes to radio power will only apply once the server is restarted. 

Setting this to draft as it needs a quick clean up at this stage but I'd like to confirm the changes to MessageType, and that requiring a server restart to alter radio values won't be a problem. Also if you'd prefer this PR to be split into two parts, one for differing radio values and custom radio values that should be easy enough.