### PR TITLE
Detect Intentional Input Binding for PTT

### DIFF
--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -159,6 +159,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
             var settings = GlobalSettingsStore.Instance;
             _inputManager.StartDetectPtt(pressed =>
             {
+                var activeBindings = pressed.Count(state =>
+                    state.IsActive && (int) state.MainDevice.InputBind >= (int) InputBinding.Intercom &&
+                    (int) state.MainDevice.InputBind <= (int) InputBinding.Switch10);
+
+                // By ensuring there was only one active binding during this loop, it would ensure
+                // the user is not surprised by any changes
+                if (activeBindings > 1) return;
+                
                 var radios = _clientStateSingleton.DcsPlayerRadioInfo;
 
                 var radioSwitchPtt = _globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.RadioSwitchIsPTT);


### PR DESCRIPTION
The number of active bindings must be no more than two so that users do not inadvertently switch radios when a neighbouring hat switch is toggled for a brief millisecond.

This is an implementation as per the algorithm suggested in issue: https://github.com/ciribob/DCS-SimpleRadioStandalone/issues/272

However, this PR would not resolve the illustrated scenario keybindings as the modifier would be superseded through the logic of the following lines:

https://github.com/ciribob/DCS-SimpleRadioStandalone/blob/e8b71add46d70b5da67e9f93de815059bfb5f29f/DCS-SR-Client/Input/InputDeviceManager.cs#L612-L638

To resolve the original issue completely, it is suggested that the PTT, radio switching, and radio tuning should be elevated up to a state machine.

This PR would resolve my specific use case where the neighbouring hats are being triggered for a fraction which causes the radio to switch rapidly during transmission.