### PR TITLE
fix potential freezes and crashes in instant connect/disconnect edge case

### DIFF
--- a/NAudio/Wave/WaveInputs/WasapiCapture.cs
+++ b/NAudio/Wave/WaveInputs/WasapiCapture.cs
@@ -250,7 +250,8 @@ namespace NAudio.CoreAudioApi
                 client.Stop();
                 // don't dispose - the AudioClient only gets disposed when WasapiCapture is disposed
             }
-            captureThread = null;
+            // dont nuke our captureThread reference here, dispose also checks it
+            // captureThread = null;
             captureState = CaptureState.Stopped;
             RaiseRecordingStopped(exception);
         }
@@ -356,7 +357,11 @@ namespace NAudio.CoreAudioApi
             StopRecording();
             if (captureThread != null)
             {
-                captureThread.Join();
+                if (captureThread.IsAlive)
+                {
+                    captureThread.Abort();
+                    captureThread.Join();
+                }
                 captureThread = null;
             }
             if (audioClient != null)


### PR DESCRIPTION
Hi, SRS kept freezing when joining some servers on 2.04.0. i narrowed the parent network cause to something related to a VPN, manifesting as connect and instantly disconnecting. luckily it happened 100% of the time so I dusted off the debugger and this revealed a few issues I was hitting in the WasapiCapture Dispose -

first and most common (100% of the time for me),  `captureThread.Join();` would block forever, and it appeared to be called from the wpf dispatcher.  I added an abort call first and left join, while abort is not bullet proof, if that thread is stuck it should hopefully terminate it and let join no-op.  join could probably be completely removed

secondly, occasionally within Dispose `if (captureThread != null)` check, captureThread would be written null in the middle of it 
causing exceptions. this seemed to be caused from the extreme timing where dispose would be executing while the CaptureThread delegate had just started and falling through from the exception and clearing it out at the same time

since making these changes I have no issues. while I understand its kinda contrived to fix something caused by a VPN derp,
I could see this perhaps happening in  other fast scenarios (mismatch, reconnects?).

I can still reproduce it 100% of the time if needed to explore any ideas or improvements. appreciate it 