### PR TITLE
Fix joystick button binding on pressed state only

### DIFF
--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -421,7 +421,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                                     {
                                         var buttonState = state.Buttons[j] ? 1 : 0;
 
-                                        if (buttonState != initial[i, j])
+                                        if (buttonState == 1 && buttonState != initial[i, j])
                                         {
                                             found = true;
 


### PR DESCRIPTION
Fix a missing check on joystick button state.
Current behavior: The state checker trigger a binding on first state that is changed, even if it's an unpressed stage.
This create issue with "radio button" toggle type where 1 button is turned OFF an another is turner ON (multiple selector position for example), where the lowest ID between the pressed and unpressed is actually bound.

By adding a pressed state validation, only new pressed button will be bound.

This logic bug only affect the keybind section of the app, which behave normally for radio change with the same button.