### PR TITLE
Gamepad inputs while in background (XInput)

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -143,6 +143,9 @@
     <Reference Include="SharpDX.DirectInput, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.DirectInput.4.2.0\lib\net45\SharpDX.DirectInput.dll</HintPath>
     </Reference>
+    <Reference Include="SharpDX.XInput, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.XInput.4.2.0\lib\net45\SharpDX.XInput.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>

--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -35,6 +35,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -46,6 +47,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -69,6 +71,7 @@
     <ApplicationIcon>audio-headset.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -77,8 +80,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>
     </DefineConstants>
@@ -259,6 +264,7 @@
     <Compile Include="Input\InputButtonDevice.cs" />
     <Compile Include="Input\InputDevice.cs" />
     <Compile Include="Input\InputDeviceBase.cs" />
+    <Compile Include="Input\XInputController.cs" />
     <Compile Include="Network\VAICOM\Models\VAICOMMessageWrapper.cs" />
     <Compile Include="Network\VAICOM\VAICOMSyncHandler.cs" />
     <Compile Include="Audio\Recording\AudioRecordingLameWriterBase.cs" />

--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -62,7 +62,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         };
 
         private readonly DirectInput _directInput;
-        private readonly Dictionary<Guid, Device> _inputDevices = new Dictionary<Guid, Device>();
+        private readonly Dictionary<Guid, dynamic> _inputDevices = new Dictionary<Guid, dynamic>();
         private readonly MainWindow.ToggleOverlayCallback _toggleOverlayCallback;
 
         private volatile bool _detectPtt;
@@ -95,12 +95,21 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         public void InitDevices()
         {
+            var allowXInput = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AllowXInputController);
             Logger.Info("Starting Device Search. Expand Search: " +
-            (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.ExpandControls)));
+            (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.ExpandControls)) +
+            ". Use XInput (for Xbox controllers): " + allowXInput);
+
 
             var deviceInstances = _directInput.GetDevices();
 
             _inputDevices.Clear();
+
+            if (allowXInput)
+            {
+                _inputDevices.Add(XInputController.DeviceGuid, new XInputController());
+            }
+            
 
             foreach (var deviceInstance in deviceInstances)
             {
@@ -294,7 +303,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                     }
 
                 }
-               
             }
         }
 
@@ -318,7 +326,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                     try
                     {
-                        if (deviceList[i] is Joystick)
+                        if (deviceList[i] is XInputController)
+                        {
+                            var state = (deviceList[i] as XInputController).GetCurrentState();
+                            var values = (SharpDX.XInput.GamepadButtonFlags[])Enum.GetValues(typeof(SharpDX.XInput.GamepadButtonFlags));
+                            for (var j = 0; j < values.Length; j++)
+                            {
+                                initial[i, j] = state.HasFlag(values[j]) ? 1 : 0;
+                            }
+                        }
+                        else if (deviceList[i] is Joystick)
                         {
 
                             var state = (deviceList[i] as Joystick).GetCurrentState();
@@ -388,9 +405,33 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                         try
                         {
-                            if (deviceList[i] is Joystick)
+                            if (deviceList[i] is XInputController)
                             {
+                                var state = (deviceList[i] as XInputController).GetCurrentState();
+                                var values = (SharpDX.XInput.GamepadButtonFlags[])Enum.GetValues(typeof(SharpDX.XInput.GamepadButtonFlags));
+                                for (var j = 0; j < values.Length; j++)
+                                {
+                                    var buttonState = state.HasFlag(values[j]) ? 1 : 0;
+                                    if (buttonState != initial[i, j])
+                                    {
+                                        found = true;
+                                        var inputDevice = new InputDevice
+                                        {
+                                            DeviceName = "XInputController",
+                                            Button = (int)values[j],
+                                            InstanceGuid = deviceList[i].Information.InstanceGuid,
+                                            ButtonValue = buttonState
+                                        };
 
+                                        Application.Current.Dispatcher.Invoke(
+                                            () => { callback(inputDevice); });
+
+                                        return;
+                                    }
+                                }
+                            }
+                            else if (deviceList[i] is Joystick)
+                            {
                                 var state = (deviceList[i] as Joystick).GetCurrentState();
 
                                 for (var j = 0; j < 128 + 4; j++)
@@ -561,7 +602,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                     }
                 }
             }
-
         }
 
         public void StartDetectPtt(DetectPttCallback callback)
@@ -787,7 +827,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                 try
                 {
-                    if (device is Joystick)
+                    if (device is XInputController)
+                    {
+                        var state = (device as XInputController).GetCurrentState();
+                        return state.HasFlag((SharpDX.XInput.GamepadButtonFlags)inputDeviceBinding.Button);
+                    }
+                    else if (device is Joystick)
                     {
                         //device.Poll();
                         var state = (device as Joystick).GetCurrentState();

--- a/DCS-SR-Client/Input/XInputController.cs
+++ b/DCS-SR-Client/Input/XInputController.cs
@@ -1,0 +1,92 @@
+using System.Runtime.InteropServices;
+using System;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Client
+{
+    static unsafe class Native
+    {
+        [DllImport("XINPUT1_4.DLL")]
+        public static extern uint XInputGetState(uint dwUserIndex, SharpDX.XInput.State* pState);
+    }
+
+    /// <summary>
+    /// Controller class that masquerades as a SharpDX.DirectInput.Device.
+    /// </summary>
+    public class XInputController : IDisposable
+    {
+        public struct InformationData
+        {
+            // Randomly generated Guid.
+            static Guid _productGuid = new Guid("bb78c26f-9bfd-41c1-81f0-2f1258d25075");
+
+            public string ProductName
+            {
+                get { return "XInputController"; }
+            }
+
+            public Guid InstanceGuid
+            {
+                get { return ProductGuid; }
+            }
+
+            public static Guid ProductGuid
+            {
+                get { return _productGuid; }
+            }
+        }
+
+        public static Guid DeviceGuid
+        {
+            get { return InformationData.ProductGuid; }
+        }
+
+        private InformationData _information;
+        private bool _disposed = false;
+        private SharpDX.XInput.State _state = new SharpDX.XInput.State();
+
+        // Dispose interface, not much to do.
+        public bool IsDisposed
+        {
+            get
+            {
+                return _disposed;
+            }
+        }
+
+        public void Dispose()
+        {
+            // noop.
+            _disposed = true;
+        }
+
+        // SharpDX.DirectInput.Device masquerading.
+        public bool Poll()
+        {
+            unsafe
+            {
+                fixed (SharpDX.XInput.State* pstate = &_state)
+                {
+                    return Native.XInputGetState(0, pstate) == 0;
+                }
+            }
+        }
+
+        public InformationData Information
+        {
+            get
+            {
+                return _information;
+            }
+        }
+
+        public SharpDX.XInput.GamepadButtonFlags GetCurrentState()
+        {
+            return _state.Gamepad.Buttons;
+        }
+
+        public void Unacquire()
+        {
+            // noop.
+        }
+    }
+}

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -97,7 +97,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         VOX,
         VOXMode,
         VOXMinimumTime,
-        VOXMinimumDB
+        VOXMinimumDB,
+
+        AllowXInputController
     }
 
     public enum InputBinding
@@ -469,6 +471,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             {GlobalSettingsKeys.VOXMode.ToString(), "3" },
             {GlobalSettingsKeys.VOXMinimumTime.ToString(), "300" },
             {GlobalSettingsKeys.VOXMinimumDB.ToString(), "-59.0" },
+
+
+            {GlobalSettingsKeys.AllowXInputController.ToString(), "false"},
 
         };
 

--- a/DCS-SR-Client/UI/ClientWindow/InputBindingControl.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/InputBindingControl.xaml.cs
@@ -112,6 +112,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 catch { }
 
             }
+            else if (name.ToLowerInvariant() == "xinputcontroller")
+            {
+                try
+                {
+                    var buttonFlag = (SharpDX.XInput.GamepadButtonFlags)button;
+                    return buttonFlag.ToString("G");
+                }
+                catch { }
+            }
             return button < 128 ? (button + 1).ToString() : "POV " + (button - 127);
         }
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -326,289 +326,289 @@
         </TabItem>
 
         <TabItem Header="Controls">
-                    <GroupBox x:Name="ControlsGroupBox" Header="Controls">
+            <GroupBox x:Name="ControlsGroupBox" Header="Controls">
 
                 <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Visible">
-                        <StackPanel>
-                            <Button Width="150px" Content="Rescan Controller Input Devices" Click="RescanInputDevices" />
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition Width="1*" />
-                                    <ColumnDefinition Width="1*" />
-                                    <ColumnDefinition Width="1*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                </Grid.RowDefinitions>
+                    <StackPanel>
+                        <Button Width="150px" Content="Rescan Controller Input Devices" Click="RescanInputDevices" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="1*" />
+                                <ColumnDefinition Width="1*" />
+                                <ColumnDefinition Width="1*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
 
 
-                                <Label x:Name="DeviceLabel"
+                            <Label x:Name="DeviceLabel"
                                    Grid.Row="0"
                                    Grid.Column="1"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Device" />
-                                <Label x:Name="ButtonLabel"
+                            <Label x:Name="ButtonLabel"
                                    Grid.Row="0"
                                    Grid.Column="2"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Button" />
 
-                                <local:InputBindingControl x:Name="Radio1"
+                            <local:InputBindingControl x:Name="Radio1"
                                                        Grid.Row="1"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch1}"
                                                        InputName="Radio 1" />
-                                <local:InputBindingControl x:Name="Radio2"
+                            <local:InputBindingControl x:Name="Radio2"
                                                        Grid.Row="2"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch2}"
                                                        InputName="Radio 2" />
-                                <local:InputBindingControl x:Name="Radio3"
+                            <local:InputBindingControl x:Name="Radio3"
                                                        Grid.Row="3"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch3}"
                                                        InputName="Radio 3" />
-                                <local:InputBindingControl x:Name="PTT"
+                            <local:InputBindingControl x:Name="PTT"
                                                        Grid.Row="4"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Ptt}"
                                                        InputName="Common PTT" />
-                                <local:InputBindingControl x:Name="Intercom"
+                            <local:InputBindingControl x:Name="Intercom"
                                                        Grid.Row="5"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Intercom}"
                                                        InputName="Intercom Select" />
 
-                                <local:InputBindingControl x:Name="IntercomPTT"
+                            <local:InputBindingControl x:Name="IntercomPTT"
                                                        Grid.Row="6"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.IntercomPTT}"
                                                        InputName="Special Intercom Select &amp; PTT" />
 
-                                <local:InputBindingControl x:Name="RadioOverlay"
+                            <local:InputBindingControl x:Name="RadioOverlay"
                                                        Grid.Row="7"
                                                        Grid.ColumnSpan="6"
                                                        ControlInputBinding="{x:Static settings:InputBinding.OverlayToggle}"
                                                        InputName="Overlay Toggle" />
 
-                                <local:InputBindingControl x:Name="Radio4"
+                            <local:InputBindingControl x:Name="Radio4"
                                                        Grid.Row="8"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch4}"
                                                        InputName="Radio 4" />
-                                <local:InputBindingControl x:Name="Radio5"
+                            <local:InputBindingControl x:Name="Radio5"
                                                        Grid.Row="9"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch5}"
                                                        InputName="Radio 5" />
-                                <local:InputBindingControl x:Name="Radio6"
+                            <local:InputBindingControl x:Name="Radio6"
                                                        Grid.Row="10"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch6}"
                                                        InputName="Radio 6" />
 
-                                <local:InputBindingControl x:Name="Radio7"
+                            <local:InputBindingControl x:Name="Radio7"
                                                        Grid.Row="11"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch7}"
                                                        InputName="Radio 7" />
 
-                                <local:InputBindingControl x:Name="Radio8"
+                            <local:InputBindingControl x:Name="Radio8"
                                                        Grid.Row="12"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch8}"
                                                        InputName="Radio 8" />
 
-                                <local:InputBindingControl x:Name="Radio9"
+                            <local:InputBindingControl x:Name="Radio9"
                                                        Grid.Row="13"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch9}"
                                                        InputName="Radio 9" />
 
-                                <local:InputBindingControl x:Name="Radio10"
+                            <local:InputBindingControl x:Name="Radio10"
                                                        Grid.Row="14"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch10}"
                                                        InputName="Radio 10" />
 
 
-                                <local:InputBindingControl x:Name="Up100"
+                            <local:InputBindingControl x:Name="Up100"
                                                        Grid.Row="15"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up100}"
                                                        InputName="Up 100MHz" />
 
-                                <local:InputBindingControl x:Name="Up10"
+                            <local:InputBindingControl x:Name="Up10"
                                                        Grid.Row="16"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up10}"
                                                        InputName="Up 10MHz" />
 
-                                <local:InputBindingControl x:Name="Up1"
+                            <local:InputBindingControl x:Name="Up1"
                                                        Grid.Row="17"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up1}"
                                                        InputName="Up 1MHz" />
 
-                                <local:InputBindingControl x:Name="Up01"
+                            <local:InputBindingControl x:Name="Up01"
                                                        Grid.Row="18"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up01}"
                                                        InputName="Up 0.1MHz" />
 
-                                <local:InputBindingControl x:Name="Up001"
+                            <local:InputBindingControl x:Name="Up001"
                                                        Grid.Row="19"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up001}"
                                                        InputName="Up 0.01MHz" />
 
-                                <local:InputBindingControl x:Name="Up0001"
+                            <local:InputBindingControl x:Name="Up0001"
                                                        Grid.Row="20"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up0001}"
                                                        InputName="Up 0.001MHz" />
 
 
-                                <local:InputBindingControl x:Name="Down100"
+                            <local:InputBindingControl x:Name="Down100"
                                                        Grid.Row="21"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down100}"
                                                        InputName="Down 100MHz" />
 
-                                <local:InputBindingControl x:Name="Down10"
+                            <local:InputBindingControl x:Name="Down10"
                                                        Grid.Row="22"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down10}"
                                                        InputName="Down 10MHz" />
 
-                                <local:InputBindingControl x:Name="Down1"
+                            <local:InputBindingControl x:Name="Down1"
                                                        Grid.Row="23"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down1}"
                                                        InputName="Down 1MHz" />
 
-                                <local:InputBindingControl x:Name="Down01"
+                            <local:InputBindingControl x:Name="Down01"
                                                        Grid.Row="24"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down01}"
                                                        InputName="Down 0.1MHz" />
 
-                                <local:InputBindingControl x:Name="Down001"
+                            <local:InputBindingControl x:Name="Down001"
                                                        Grid.Row="25"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down001}"
                                                        InputName="Down 0.01MHz" />
 
-                                <local:InputBindingControl x:Name="Down0001"
+                            <local:InputBindingControl x:Name="Down0001"
                                                        Grid.Row="26"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down0001}"
                                                        InputName="Down 0.001MHz" />
 
-                                <local:InputBindingControl x:Name="ToggleGuard"
+                            <local:InputBindingControl x:Name="ToggleGuard"
                                                        Grid.Row="27"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleGuard}"
                                                        InputName="Toggle Guard" />
 
-                                <local:InputBindingControl x:Name="NextRadio"
+                            <local:InputBindingControl x:Name="NextRadio"
                                                        Grid.Row="28"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.NextRadio}"
                                                        InputName="Next Radio" />
 
 
-                                <local:InputBindingControl x:Name="PreviousRadio"
+                            <local:InputBindingControl x:Name="PreviousRadio"
                                                        Grid.Row="29"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.PreviousRadio}"
                                                        InputName="Previous Radio" />
 
-                                <local:InputBindingControl x:Name="ToggleEncryption"
+                            <local:InputBindingControl x:Name="ToggleEncryption"
                                                        Grid.Row="30"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleEncryption}"
                                                        InputName="Toggle Encryption" />
 
-                                <local:InputBindingControl x:Name="EncryptionKeyIncrease"
+                            <local:InputBindingControl x:Name="EncryptionKeyIncrease"
                                                        Grid.Row="31"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyIncrease}"
                                                        InputName="Encryption Key Increase" />
 
-                                <local:InputBindingControl x:Name="EncryptionKeyDecrease"
+                            <local:InputBindingControl x:Name="EncryptionKeyDecrease"
                                                        Grid.Row="32"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyDecrease}"
                                                        InputName="Encryption Key Decrease" />
 
-                                <local:InputBindingControl x:Name="RadioChannelUp"
+                            <local:InputBindingControl x:Name="RadioChannelUp"
                                                        Grid.Row="33"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelUp}"
                                                        InputName="Radio Channel Up" />
 
-                                <local:InputBindingControl x:Name="RadioChannelDown"
+                            <local:InputBindingControl x:Name="RadioChannelDown"
                                                        Grid.Row="34"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelDown}"
                                                        InputName="Radio Channel Down" />
 
-                                <local:InputBindingControl x:Name="TransponderIDENT"
+                            <local:InputBindingControl x:Name="TransponderIDENT"
                                                        Grid.Row="35"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.TransponderIDENT}"
                                                        InputName="Transponder IDENT" />
 
-                                <local:InputBindingControl x:Name="RadioVolumeUp"
+                            <local:InputBindingControl x:Name="RadioVolumeUp"
                                                        Grid.Row="36"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeUp}"
                                                        InputName="Radio Volume Up" />
 
-                                <local:InputBindingControl x:Name="RadioVolumeDown"
+                            <local:InputBindingControl x:Name="RadioVolumeDown"
                                                        Grid.Row="37"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeDown}"
@@ -623,10 +623,10 @@
 
                         </Grid>
 
-                        </StackPanel>
+                    </StackPanel>
                 </ScrollViewer>
 
-                    </GroupBox>
+            </GroupBox>
 
         </TabItem>
 
@@ -737,7 +737,7 @@
                                         </ToggleButton.Style>
                                     </ToggleButton>
                                 </Grid>
-                                </GroupBox>
+                            </GroupBox>
                             <GroupBox Header="SRS Interface">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -904,7 +904,7 @@
                                     </ToggleButton>
                                 </Grid>
                             </GroupBox>
-                           
+
                             <GroupBox Header="Microphone">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -978,7 +978,7 @@
                                         </ToggleButton.Style>
                                     </ToggleButton>
 
-                                    
+
 
                                 </Grid>
                             </GroupBox>
@@ -997,7 +997,7 @@
                                         <RowDefinition />
 
                                     </Grid.RowDefinitions>
-                                    
+
                                     <Label Grid.Row="0"
                                            Grid.Column="0"
                                            HorizontalContentAlignment="Center"
@@ -1298,203 +1298,204 @@
                                 </Grid>
                             </GroupBox>
                             <GroupBox Header="Miscellanous Settings">
-                           
+
                                 <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="2*" />
-                                <ColumnDefinition Width="2*" />
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="2*" />
+                                        <ColumnDefinition Width="2*" />
 
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                            </Grid.RowDefinitions>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
 
 
-                            <Label Grid.Row="0"
+                                    <Label Grid.Row="0"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Auto Select Profile For Aircraft" />
 
-                            <ToggleButton Name="AutoSelectInputProfile"
+                                    <ToggleButton Name="AutoSelectInputProfile"
                                           Grid.Row="0"
                                           Grid.Column="1"
                                           HorizontalContentAlignment="Center"
                                           VerticalContentAlignment="Center"
                                           Click="AutoSelectInputProfile_OnClick">
-                                <ToggleButton.Style>
-                                    <Style TargetType="{x:Type ToggleButton}">
-                                        <Setter Property="Content" Value="ON" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked" Value="True">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
                                                 <Setter Property="Content" Value="ON" />
-                                            </Trigger>
-                                            <Trigger Property="IsChecked" Value="False">
-                                                <Setter Property="Content" Value="OFF" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ToggleButton.Style>
-                            </ToggleButton>
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
 
-                            <Label Grid.Row="1"
+                                    <Label Grid.Row="1"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Check for beta updates" />
 
-                            <ToggleButton Name="CheckForBetaUpdates"
+                                    <ToggleButton Name="CheckForBetaUpdates"
                                           Grid.Row="1"
                                           Grid.Column="1"
                                           HorizontalContentAlignment="Center"
                                           VerticalContentAlignment="Center"
                                           Click="CheckForBetaUpdates_OnClick">
-                                <ToggleButton.Style>
-                                    <Style TargetType="{x:Type ToggleButton}">
-                                        <Setter Property="Content" Value="ON" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked" Value="True">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
                                                 <Setter Property="Content" Value="ON" />
-                                            </Trigger>
-                                            <Trigger Property="IsChecked" Value="False">
-                                                <Setter Property="Content" Value="OFF" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ToggleButton.Style>
-                            </ToggleButton>
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
 
-                            
 
-                            <Label Grid.Row="2"
+
+                                    <Label Grid.Row="2"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Set SRS Path for DCS" />
 
-                            <Button Grid.Row="2"
+                                    <Button Grid.Row="2"
                                     Grid.Column="1"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Click="SetSRSPath_Click"
                                     Content="Set Path" />
 
-                            <Label Grid.Row="3"
+                                    <Label Grid.Row="3"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Require Admin" />
 
-                            <ToggleButton Name="RequireAdminToggle"
+                                    <ToggleButton Name="RequireAdminToggle"
                                           Grid.Row="3"
                                           Grid.Column="1"
                                           HorizontalContentAlignment="Center"
                                           VerticalContentAlignment="Center"
                                           Click="RequireAdminToggle_OnClick">
-                                <ToggleButton.Style>
-                                    <Style TargetType="{x:Type ToggleButton}">
-                                        <Setter Property="Content" Value="ON" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked" Value="True">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
                                                 <Setter Property="Content" Value="ON" />
-                                            </Trigger>
-                                            <Trigger Property="IsChecked" Value="False">
-                                                <Setter Property="Content" Value="OFF" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ToggleButton.Style>
-                            </ToggleButton>
-                            <Label Grid.Row="4"
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
+                                    <Label Grid.Row="4"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Allow VAICOM TX Inhibit" />
 
-                            <ToggleButton Name="VAICOMTXInhibitEnabled"
+                                    <ToggleButton Name="VAICOMTXInhibitEnabled"
                                           Grid.Row="4"
                                           Grid.Column="1"
                                           HorizontalContentAlignment="Center"
                                           VerticalContentAlignment="Center"
                                           Click="VAICOMTXInhibit_OnClick">
-                                <ToggleButton.Style>
-                                    <Style TargetType="{x:Type ToggleButton}">
-                                        <Setter Property="Content" Value="ON" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked" Value="True">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
                                                 <Setter Property="Content" Value="ON" />
-                                            </Trigger>
-                                            <Trigger Property="IsChecked" Value="False">
-                                                <Setter Property="Content" Value="OFF" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ToggleButton.Style>
-                            </ToggleButton>
-                            
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
 
-                            <Label Grid.Row="5"
+
+                                    <Label Grid.Row="5"
                                    Grid.Column="0"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Allow Anonymous Usage Stats" />
 
-                            <ToggleButton Name="AllowAnonymousUsage"
+                                    <ToggleButton Name="AllowAnonymousUsage"
                                           Grid.Row="5"
                                           Grid.Column="1"
                                           HorizontalContentAlignment="Center"
                                           VerticalContentAlignment="Center"
                                           Click="AllowAnonymousUsage_OnClick">
-                                <ToggleButton.Style>
-                                    <Style TargetType="{x:Type ToggleButton}">
-                                        <Setter Property="Content" Value="ON" />
-                                        <Style.Triggers>
-                                            <Trigger Property="IsChecked" Value="True">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
                                                 <Setter Property="Content" Value="ON" />
-                                            </Trigger>
-                                            <Trigger Property="IsChecked" Value="False">
-                                                <Setter Property="Content" Value="OFF" />
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ToggleButton.Style>
-                            </ToggleButton>
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
 
                                     <Label Grid.Row="6"
                                            Grid.Column="0"
@@ -1527,10 +1528,37 @@
                                            Grid.Column="0"
                                            HorizontalContentAlignment="Center"
                                            VerticalContentAlignment="Center"
+                                           Content="Allow XInput Controller (Xbox controller)" />
+
+                                    <ToggleButton Name="AllowXInputController"
+                                          Grid.Row="7"
+                                          Grid.Column="1"
+                                          HorizontalContentAlignment="Center"
+                                          VerticalContentAlignment="Center"
+                                          Click="AllowXInputController_OnClick_Click">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
+                                                <Setter Property="Content" Value="ON" />
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter Property="Content" Value="ON" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsChecked" Value="False">
+                                                        <Setter Property="Content" Value="OFF" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
+
+                                    <Label Grid.Row="8"
+                                           Grid.Column="0"
+                                           HorizontalContentAlignment="Center"
+                                           VerticalContentAlignment="Center"
                                            Content="Play connection sounds" />
 
                                     <ToggleButton Name="PlayConnectionSounds"
-                                                  Grid.Row="7"
+                                                  Grid.Row="8"
                                                   Grid.Column="1"
                                                   HorizontalContentAlignment="Center"
                                                   VerticalContentAlignment="Center"
@@ -2612,7 +2640,7 @@
                             </GroupBox>
                         </Grid>
                     </GroupBox>
-                  
+
                 </StackPanel>
             </ScrollViewer>
         </TabItem>

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -731,6 +731,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 _globalSettings.GetClientSettingDouble(GlobalSettingsKeys.VOXMinimumDB);
             VOXMinimumRMS.ValueChanged += VOXMinimumRMS_ValueChanged;
             VOXMinimumRMS.IsEnabled = true;
+
+            AllowXInputController.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AllowXInputController);
         }
 
         private void ReloadProfileSettings()
@@ -1643,6 +1645,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 MessageBoxImage.Warning);
 
             _globalSettings.SetClientSetting(GlobalSettingsKeys.ExpandControls, (bool)ExpandInputDevices.IsChecked);
+        }
+
+        private void AllowXInputController_OnClick_Click(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show(
+                "You must restart SRS for this setting to take effect.",
+                "Restart SimpleRadio Standalone", MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+
+            _globalSettings.SetClientSetting(GlobalSettingsKeys.AllowXInputController, (bool)AllowXInputController.IsChecked);
         }
 
         private void LaunchAddressTab(object sender, RoutedEventArgs e)

--- a/DCS-SR-Client/packages.config
+++ b/DCS-SR-Client/packages.config
@@ -18,6 +18,7 @@
   <package id="SharpConfig" version="3.2.9.1" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.XInput" version="4.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="6.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />


### PR DESCRIPTION
Using XInput allows SRS to read gamepad (at least Xbox/xbox compatible ones) while the game is in the foreground and SRS is in the background.

Added a setting to enable/disable (default disabled), since this is pretty niche.

Checked with a HOTAS and an Xbox gamepad plugged in - only the Xbox gamepad generates XInput data.