### PR TITLE
Add a recording toggle hotkey to replace the auto-record method used …

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -206,13 +206,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                 Environment.Exit(1);
             }
 
+            _passThroughAudioProvider = new ClientAudioProvider(true);
+
             if (micOutput != null) // && micOutput !=speakers
             {
                 //TODO handle case when they're the same?
 
                 try
                 {
-                    _passThroughAudioProvider = new ClientAudioProvider(true);
                     _micWaveOut = new WasapiOut(micOutput, AudioClientShareMode.Shared, true, 40,windowsN);
 
                     _micWaveOutBuffer = new BufferedWaveProvider(WaveFormat.CreateIeeeFloatWaveFormat(OUTPUT_SAMPLE_RATE, 1));
@@ -355,7 +356,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                         //check for voice before any pre-processing
                         bool voice = true;
 
-                        if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOX))
+                            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOX))
                         {
                             Buffer.BlockCopy(_pcmShort, 0, _pcmBytes, 0, _pcmBytes.Length);
                             voice = DoesFrameContainSpeech(_pcmBytes, _pcmShort);
@@ -397,12 +398,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                             // _beforeWaveFile.Write(pcmBytes, 0, pcmBytes.Length);
 
                             if (clientAudio != null && (_micWaveOutBuffer != null 
-                                                        || GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio)))
+                                                        || AudioRecordingManager.Instance.Enabled))
                             {
 
                                 //todo see if we can fix the resample / opus decode
                                 //send audio so play over local too
-                                var jitterBufferAudio = _passThroughAudioProvider?.AddClientAudioSamples(clientAudio);
+                                var jitterBufferAudio = _passThroughAudioProvider?.AddClientAudioSamples(clientAudio, AudioRecordingManager.Instance.Enabled);
                                 
                                 //TODO fix
                                 // //process bytes and add effects
@@ -420,14 +421,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                                         ReceivedRadio = jitterBufferAudio.ReceivedRadio,
                                         PCMMonoAudio = jitterBufferAudio.Audio,
                                         Guid = _guid,
-                                        OriginalClientGuid = _guid
+                                        OriginalClientGuid = _guid,
+                                        ReceiveTime = jitterBufferAudio.ReceiveTime
                                     };
 
                                     //process audio
                                     float[] tempFloat = _clientEffectsPipeline.ProcessClientAudioSamples(jitterBufferAudio.Audio,
                                         jitterBufferAudio.Audio.Length, 0, deJittered);
 
-                                    if (_micWaveOut != null)
+                                    if (_micWaveOut != null && _micWaveOutBuffer != null)
                                     {
                                        
                                         //now its a processed Mono audio
@@ -442,11 +444,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                                         _micWaveOutBuffer.AddSamples(_tempMicOutputBuffer, 0, tempFloat.Length * 4);
                                     }
 
-                                    if (GlobalSettingsStore.Instance.GetClientSettingBool(
-                                        GlobalSettingsKeys.RecordAudio))
+                                    if (AudioRecordingManager.Instance.Enabled)
                                     {
-                                        ///TODO cache this to avoid the contant lookup
-                                       // AudioRecordingManager.Instance.AppendClientAudio(deJittered);
+                                        AudioRecordingManager.Instance.AppendCaptureAudio(deJittered);
                                     }
                                    
                                 }

--- a/DCS-SR-Client/Audio/Models/DeJitteredTransmission.cs
+++ b/DCS-SR-Client/Audio/Models/DeJitteredTransmission.cs
@@ -29,5 +29,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Models
         public string Guid { get; set; }
 
         public string OriginalClientGuid { get; set; }
+
+        public long ReceiveTime { get; set; }
+
+        // required to avoid processing effects on recording silence
+        public bool IsSilence { get; set; }
     }
 }

--- a/DCS-SR-Client/Audio/Models/JitterBufferAudio.cs
+++ b/DCS-SR-Client/Audio/Models/JitterBufferAudio.cs
@@ -1,4 +1,5 @@
 ﻿using Ciribob.DCS.SimpleRadio.Standalone.Common;
+using System;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
 {
@@ -22,5 +23,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
 
         public string Guid { get; set; }
         public string OriginalClientGuid { get; set; }
+        public long ReceiveTime { get; set; }
     }
 }

--- a/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
+++ b/DCS-SR-Client/Audio/Providers/ClientAudioProvider.cs
@@ -75,7 +75,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
             return false;
         }
 
-        public JitterBufferAudio AddClientAudioSamples(ClientAudio audio)
+        public JitterBufferAudio AddClientAudioSamples(ClientAudio audio, bool record = false)
         {
 
             //sort out volume
@@ -101,12 +101,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
             //TODO reuse this buffer
             var tmp = new float[decodedLength/4];
             Buffer.BlockCopy(decoded, 0, tmp, 0, decodedLength);
-
-            //convert the byte buffer to a wave buffer
-         //   var waveBuffer = new WaveBuffer(tmp);
-
-       
-            
+    
             audio.PcmAudioFloat = tmp;
 
             var decrytable = audio.Decryptable /* || (audio.Encryption == 0) <--- this test has already been performed by all callers and would require another call to check for STRICT_AUDIO_ENCRYPTION */;
@@ -133,18 +128,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
 
             LastUpdate = DateTime.Now.Ticks;
 
-            //TODO handle recording
-            // if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio))
-            // {
-            //     AudioRecordingManager.Instance.AppendClientAudio(audio);
-            // }
-
-    //        waveWriter.WriteSamples(audio.PcmAudioFloat, 0,audio.PcmAudioFloat.Length);
-
             if (audio.OriginalClientGuid == ClientStateSingleton.Instance.ShortGUID)
             {
                 // catch own transmissions and prevent them from being added to JitterBuffer unless its passthrough
-                if (passThrough)
+                if (passThrough || record)
                 {
                     //return MONO PCM 16 as bytes
                     return new JitterBufferAudio
@@ -182,7 +169,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
                     Frequency = audio.Frequency,
                     NoAudioEffects = audio.NoAudioEffects,
                     Guid = audio.ClientGuid,
-                    OriginalClientGuid = audio.OriginalClientGuid
+                    OriginalClientGuid = audio.OriginalClientGuid,
+                    ReceiveTime = audio.ReceiveTime
                 });
 
                 return null;
@@ -202,7 +190,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client
                     Frequency = audio.Frequency,
                     NoAudioEffects = audio.NoAudioEffects,
                     Guid = audio.ClientGuid,
-                    OriginalClientGuid = audio.OriginalClientGuid
+                    OriginalClientGuid = audio.OriginalClientGuid,
+                    ReceiveTime = audio.ReceiveTime
                 };
             }
 

--- a/DCS-SR-Client/Audio/Providers/JitterBufferProviderInterface.cs
+++ b/DCS-SR-Client/Audio/Providers/JitterBufferProviderInterface.cs
@@ -87,7 +87,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
                         else
                         {
                             var audio = _bufferedAudio.First.Value;
-                            //no Pop?
+                            //no Pop? 
                             _bufferedAudio.RemoveFirst();
 
                             lastTransmission = new DeJitteredTransmission()
@@ -100,7 +100,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
                                 Volume = audio.Volume,
                                 NoAudioEffects = audio.NoAudioEffects,
                                 Guid = audio.Guid,
-                                OriginalClientGuid = audio.OriginalClientGuid
+                                OriginalClientGuid = audio.OriginalClientGuid,
+                                ReceiveTime = audio.ReceiveTime
                             };
 
                             if (_lastRead == 0)
@@ -115,7 +116,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
 
                                     // packet number is always discontinuous at the start of a transmission if you didnt receive a transmission for a while i.e different radio channel
                                     // if the gap is more than 4 assume its just a new transmission
-
                                     if (missing <= 4)
                                     {
                                         var fill = Math.Min(missing, 4);
@@ -135,11 +135,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio
                         }
                     }
                 } while (read < count);
-
-//                if (read == 0)
-//                {
-//                    _delayedUntil = Environment.TickCount + INITIAL_DELAY_MS;
-//                }
             }
 
             lastTransmission.PCMAudioLength = read;

--- a/DCS-SR-Client/Audio/Providers/RadioMixingProvider.cs
+++ b/DCS-SR-Client/Audio/Providers/RadioMixingProvider.cs
@@ -148,10 +148,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Providers
                 }
             }
 
-            //TODO
-            //copy to the recording service - as we have everything we need to know about the audio
-            //at this point
-
             if (_mainAudio.Count > 0 || _secondaryAudio.Count > 0)
             {
                 _audioRecordingManager.AppendClientAudio(_mainAudio, _secondaryAudio, radioId);
@@ -179,11 +175,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Providers
             //we're now stereo - double the samples
             outputSamples = outputSamples * 2;
 
-        //    waveWriter.WriteSamples(buffer,offset, outputSamples);
-
-            //clear
-           // _mainAudio.Clear();
-            //_secondaryAudio.Clear();
             return EnsureFullBuffer(buffer, outputSamples, offset, count);
         }
 

--- a/DCS-SR-Client/Audio/Recording/AudioManipulationHelper.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioManipulationHelper.cs
@@ -5,37 +5,17 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
 {
     public static class AudioManipulationHelper
     {
-        public static short[] MixSamplesClipped(short[] pcmAudioOne, short[] pcmAudioTwo, int samplesLength)
+        public static float[] MixSamplesWithHeadroom(List<float[]> samplesToMixdown, int samplesLength)
         {
-            short[] mixedDown = new short[samplesLength];
+            float[] mixedDown = new float[samplesLength];
 
-            for(int i = 0; i < samplesLength; i++)
-            {
-                int result = (pcmAudioOne[i] + pcmAudioTwo[i]);
-                if(result > short.MaxValue)
-                {
-                    result = short.MaxValue;
-                }
-                else if (result < short.MinValue)
-                {
-                    result = short.MinValue;
-                }
-                mixedDown[i] = (short)result;
-            }
-
-            return mixedDown;
-        }
-
-        public static short[] MixSamplesWithHeadroom(List<short[]> samplesToMixdown, int samplesLength)
-        {
-            short[] mixedDown = new short[samplesLength];
-
-            foreach(short[] sample in samplesToMixdown)
+            foreach(float[] sample in samplesToMixdown)
             { 
                 for(int i = 0; i < samplesLength; i++)
                 {
                     // Unlikely to have duplicate signals across n radios, can use sqrt to find a sensible headroom level
-                    mixedDown[i] += (short)(sample[i] / Math.Sqrt(samplesToMixdown.Count));
+                    // FIXME: Users likely want a consistent mixdown regardless of radios in airframe, just hardcode a constant term?
+                    mixedDown[i] += (float)(sample[i] / Math.Sqrt(samplesToMixdown.Count));
                 }
             }
 
@@ -43,10 +23,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
         }
 
 
-        public static (short[], short[]) SplitSampleByTime(long samplesRemaining, short[] samples)
+        public static (float[], float[]) SplitSampleByTime(long samplesRemaining, float[] samples)
         {
-            short[] toWrite = new short[samplesRemaining];
-            short[] remainder = new short[samples.Length - samplesRemaining];
+            float[] toWrite = new float[samplesRemaining];
+            float[] remainder = new float[samples.Length - samplesRemaining];
 
             Array.Copy(samples, 0, toWrite, 0, samplesRemaining);
             Array.Copy(samples, samplesRemaining, remainder, 0, remainder.Length);
@@ -57,7 +37,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
         public static float[] SineWaveOut(int sampleLength, int sampleRate, double volume)
         {
             float[] sineBuffer = new float[sampleLength];
-            double amplitude = volume * short.MaxValue;
+            double amplitude = volume * float.MaxValue;
 
             for (int i = 0; i < sineBuffer.Length; i++)
             {

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriterBase.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriterBase.cs
@@ -15,35 +15,36 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
         protected readonly WaveFormat _waveFormat;
         protected readonly int _sampleRate;
         protected long _lastWrite;
-        protected TransmissionAssembler _assembler;
+        //protected TransmissionAssembler _assembler;
 
         protected AudioRecordingLameWriterBase(int sampleRate)
         {
             _sampleRate = sampleRate;
             _waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate,1);
-            _assembler = new TransmissionAssembler();
+            //_assembler = new TransmissionAssembler();
         }
 
-        // protected short[] ProcessRadioAudio(ConcurrentQueue<DeJitteredTransmission>[] queues, int radio)
-        // {
-        //     while (queues[radio].Count > 0)
-        //     {
-        //         queues[radio].TryPeek(out DeJitteredTransmission firstInQueue);
-        //         int indexPosition = AudioManipulationHelper.CalculateSamplesStart(_lastWrite, firstInQueue.ReceiveTime, _sampleRate);
-        //
-        //         if (indexPosition < _sampleRate * 2)
-        //         {
-        //             queues[radio].TryDequeue(out DeJitteredTransmission dequeued);
-        //             _assembler.AddTransmission(dequeued);
-        //         }
-        //         else
-        //         {
-        //             break;
-        //         }
-        //     }
-        //
-        //     return _assembler.GetAssembledSample();
-        // }
+        // TODO: FIX THIS
+        protected float[] ProcessRadioAudio(ConcurrentQueue<DeJitteredTransmission>[] queues, int radio)
+        {
+            while (queues[radio].Count > 0)
+            {
+                queues[radio].TryPeek(out DeJitteredTransmission firstInQueue);
+                int indexPosition = AudioManipulationHelper.CalculateSamplesStart(_lastWrite, firstInQueue.ReceiveTime, _sampleRate);
+
+                if (indexPosition < _sampleRate * 2)
+                {
+                    queues[radio].TryDequeue(out DeJitteredTransmission dequeued);
+                    //_assembler.AddTransmission(dequeued);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return new float[0];
+            //return _assembler.GetAssembledSample();
+        }
 
         protected string CreateFilePath()
         {
@@ -58,8 +59,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
             return $"Recordings\\{sanitisedDate}-{sanitisedTime}";
         }
 
-        public abstract void ProcessAudio(List<CircularFloatBuffer> perRadioAudio);
-        public abstract void Start();
+        public abstract void ProcessAudio(List<CircularFloatBuffer> perRadioAudio, List<CircularFloatBuffer> selfAudio);
+        public abstract void Start(string aircraftName);
         public abstract void Stop();
     }
 }

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingManager.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingManager.cs
@@ -14,48 +14,50 @@ using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Setting;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
+using System.Linq;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Audio;
+using static Ciribob.DCS.SimpleRadio.Standalone.Common.RadioInformation;
+using MathNet.Numerics.Optimization;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
 {
     class AudioRecordingManager
     {
+        public bool Enabled { get { return !_stop; } }
+
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private static volatile AudioRecordingManager _instance = new AudioRecordingManager();
         private static object _lock = new Object();
 
-        private ClientEffectsPipeline pipeline = new ClientEffectsPipeline();
+        private readonly ClientEffectsPipeline pipeline = new ClientEffectsPipeline();
 
         private readonly int _sampleRate;
         private readonly List<CircularFloatBuffer> _clientMixDownQueue;
-        private readonly ConcurrentQueue<AudioRecordingSample>[] _playerAudioSampleQueue;
+        private readonly List<CircularFloatBuffer> _selfMixDownQueue;
 
-        //create 2 sets of queues with 10 each
+        private long[] _lastUpdate;
+        private long[] _lastUpdateSelf;
 
         private bool _stop;
         private AudioRecordingLameWriterBase _audioRecordingWriter;
 
-        private ConnectedClientsSingleton _connectedClientsSingleton = ConnectedClientsSingleton.Instance;
-        //private WaveFileWriter waveWriter;
+        private float[] _mixBuffer = new float[AudioManager.OUTPUT_SEGMENT_FRAMES * 10];
+        private float[] _secondaryMixBuffer = new float[AudioManager.OUTPUT_SEGMENT_FRAMES * 10];
+
+        private List<DeJitteredTransmission>[] _mainAudioWithSilence;
+        private List<DeJitteredTransmission>[] _secondaryAudioWithSilence;
+
+        private readonly ConnectedClientsSingleton _connectedClientsSingleton = ConnectedClientsSingleton.Instance;
 
         private AudioRecordingManager()
         {
             _sampleRate = 48000;
-            //TODO change that hardcoded 11 to run off number of radios
-            //TODO get proper format for MP3
-         //   _clientSampleQueue = new ConcurrentQueue<AudioRecordingSample>[11];
-
-    
-            _stop = true;
 
             _clientMixDownQueue = new List<CircularFloatBuffer>();
-            for (int i = 0; i < 11; i++)
-            {
-                //TODO check size
-                //5 seconds of audio
-                _clientMixDownQueue.Add(new CircularFloatBuffer(AudioManager.OUTPUT_SAMPLE_RATE*5));
-            //    _clientSampleQueue[i] = new ConcurrentQueue<AudioRecordingSample>();
-            }
+            _selfMixDownQueue = new List<CircularFloatBuffer>();
 
+            GlobalSettingsStore.Instance.SetClientSetting(GlobalSettingsKeys.RecordAudio, false);
+            _stop = true;
         }
 
         public static AudioRecordingManager Instance
@@ -84,12 +86,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
                     _stop = true;
                 }
 
-                Thread.Sleep(2000);
+                Thread.Sleep(2500);
                 try
                 {
-                    //we now have mixdown audio per queue
-                    //im worried it'll always be off by 2 seconds though
-                    _audioRecordingWriter.ProcessAudio(_clientMixDownQueue);
+                    _audioRecordingWriter.ProcessAudio(_clientMixDownQueue, _selfMixDownQueue);
                 }
                 catch (Exception ex)
                 {
@@ -100,12 +100,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
 
         private float[] SingleRadioMixDown(AudioRecordingSample sample, out int count)
         {
+            Array.Clear(_mixBuffer, 0, _mixBuffer.Length);
 
             //should be no more than 80 ms of audio
             //should really be 40 but just in case
-            //TODO reuse this but return a new array of the right length
-            float[] mixBuffer = new float[AudioManager.OUTPUT_SEGMENT_FRAMES * 10];
-            float[] secondaryMixBuffer = new float[0];
 
             int primarySamples = 0;
             int secondarySamples = 0;
@@ -113,136 +111,190 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
             //run this sample through - mix down all the audio for now PER radio 
             //we can then decide what to do with it later
             //same pipeline (ish) as RadioMixingProvider
-
             if (sample.MainRadioClientTransmissions?.Count > 0)
             {
-                mixBuffer = pipeline.ProcessClientTransmissions(mixBuffer, sample.MainRadioClientTransmissions,
+                _mixBuffer = pipeline.ProcessClientTransmissions(_mixBuffer, sample.MainRadioClientTransmissions,
                     out primarySamples);
             }
 
             //handle guard
             if (sample.SecondaryRadioClientTransmissions?.Count > 0)
             {
-                secondaryMixBuffer =  new float[AudioManager.OUTPUT_SEGMENT_FRAMES * 10];
-                secondaryMixBuffer = pipeline.ProcessClientTransmissions(secondaryMixBuffer, sample.SecondaryRadioClientTransmissions, out  secondarySamples);
+                _secondaryMixBuffer = pipeline.ProcessClientTransmissions(_secondaryMixBuffer, sample.SecondaryRadioClientTransmissions, out secondarySamples);
             }
 
-            mixBuffer = AudioManipulationHelper.MixArraysClipped(mixBuffer, primarySamples, secondaryMixBuffer, secondarySamples, out int outputSamples);
+            _mixBuffer = AudioManipulationHelper.MixArraysClipped(_mixBuffer, primarySamples, _secondaryMixBuffer, secondarySamples, out int outputSamples);
 
             count = outputSamples;
 
-            return mixBuffer;
+            return _mixBuffer;
         }
 
-      
-        public void AppendClientAudio(DeJitteredTransmission audio)
-        {
-            if (_stop)
-            {
-                Start();
-            }
-            
-            DeJitteredTransmission finalAudio;
-            
-            //TODO fix with the allowrecord enable
-            //TODO audio is now dejittered - so we dont need another degitter - just straight to a recording - or SINE wave if recording isnt allowed
-            // if(true)
-            
-            
-            
-            if(!_connectedClientsSingleton.TryGetValue(audio.OriginalClientGuid, out SRClient client))
-                return;
-            
-            //todo undo
-            if (true || client.AllowRecord 
-                || audio.OriginalClientGuid == ClientStateSingleton.Instance.ShortGUID) // Assume that client intends to record their outgoing transmissions
-            {
-                finalAudio = audio;
-            }
-            else if(GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.DisallowedAudioTone))
-            {
-                //TODO TEST
-                //replace their audio with 
-                finalAudio = new DeJitteredTransmission
-                {
-                    PCMMonoAudio = AudioManipulationHelper.SineWaveOut(audio.PCMMonoAudio.Length, _sampleRate, 0.25),
-                    ReceivedRadio = audio.ReceivedRadio,
-                };
-            }
-            else
-            {
-                return;
-            }
-            //TODO FIX
-           // _clientAudioQueues[audio.ReceivedRadio].Enqueue(finalAudio);
-        }
-
-        public void Start()
+        internal void Start()
         {
             _logger.Debug("Transmission recording started.");
-            // if(GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown))
-            // {
-            //     _audioRecordingWriter = new MixDownLameRecordingWriter(_sampleRate);
-            // }
-            // else
+
+            long startTime = DateTime.Now.Ticks;
+
+            int _radioNum = ClientStateSingleton.Instance.DcsPlayerRadioInfo.radios.Sum(x => x.modulation != RadioInformation.Modulation.DISABLED ? 1 : 0);
+
+            _mainAudioWithSilence = new List<DeJitteredTransmission>[_radioNum];
+            _secondaryAudioWithSilence = new List<DeJitteredTransmission>[_radioNum];
+            //_selfAudioWithSilence = new List<DeJitteredTransmission>[_radioNum];
+
+            _lastUpdate = new long[_radioNum];
+            _lastUpdateSelf = new long[_radioNum];
+
+            for (int i = 0; i < _lastUpdate.Length; i++)
             {
-                _audioRecordingWriter = new PerRadioLameRecordingWriter(_sampleRate);
+                _lastUpdate[i] = startTime;
             }
-            _audioRecordingWriter.Start();
+
+            //for (int i = 0; i < _radioNum; i++)
+            //{
+            //    //TODO check size
+            //    //5 seconds of audio
+            //    _clientMixDownQueue.Add(new CircularFloatBuffer((int)(AudioManager.OUTPUT_SAMPLE_RATE * 2.5)));
+            //    _selfMixDownQueue.Add(new CircularFloatBuffer((int)(AudioManager.OUTPUT_SAMPLE_RATE * 2.5)));
+            //}
+
+            //TODO: Implement a MixDownWriter for new pipeline
+            //if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown))
+            //{
+            //    //_audioRecordingWriter = new MixDownLameRecordingWriter(_sampleRate);
+            //}
+            //else
+            {
+                _audioRecordingWriter = new PerRadioLameRecordingWriter(_sampleRate, _radioNum);
+            }
+            _audioRecordingWriter.Start(ClientStateSingleton.Instance.DcsPlayerRadioInfo.unit);
             _stop = false;
 
             _clientMixDownQueue.Clear();
-            for (int i = 0; i < 11; i++)
+            _selfMixDownQueue.Clear();
+
+            for (int i = 0; i < _radioNum; i++)
             {
-                //TODO check size
-                //5 seconds of audio
-                _clientMixDownQueue.Add(new CircularFloatBuffer(AudioManager.OUTPUT_SAMPLE_RATE * 5));
-                //    _clientSampleQueue[i] = new ConcurrentQueue<AudioRecordingSample>();
+                //TODO: I changed this to 2.5 due to OutOfRange exceptions in CircularBuffer.Read when attempting to copy
+                //likely I've missed an implementation detail?
+                _clientMixDownQueue.Add(new CircularFloatBuffer((int)(AudioManager.OUTPUT_SAMPLE_RATE * 2.5)));
+                _selfMixDownQueue.Add(new CircularFloatBuffer((int)(AudioManager.OUTPUT_SAMPLE_RATE * 2.5)));
+
+                _mainAudioWithSilence[i] = new List<DeJitteredTransmission>();
+                _secondaryAudioWithSilence[i] = new List<DeJitteredTransmission>();
+                //_selfAudioWithSilence[i] = new List<DeJitteredTransmission>();
             }
-
-            //waveWriter = new NAudio.Wave.WaveFileWriter($@"C:\\temp\\output{Guid.NewGuid()}.wav", WaveFormat.CreateIeeeFloatWaveFormat(_sampleRate, 1));
-
 
             var processingThread = new Thread(ProcessQueues);
             processingThread.Start();
         }
 
-        public void Stop()
+        internal void Stop()
         {
             if (_stop) { return; }
             _stop = true;
             _audioRecordingWriter.Stop();
             _logger.Debug("Transmission recording stopped.");
+            Array.Clear(_mixBuffer, 0, _mixBuffer.Length);
+            Array.Clear(_secondaryMixBuffer, 0, _secondaryMixBuffer.Length);
+        }
 
-            //waveWriter.Flush();
-            //waveWriter.Dispose();
-
+        internal void AppendCaptureAudio(DeJitteredTransmission selfAudio)
+        {
+            if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio))
+            {
+                DeJitteredTransmission selfAudioWithSilence = ExpandGapSilence(selfAudio, ref _lastUpdateSelf);
+                _selfMixDownQueue[selfAudio.ReceivedRadio].Write(selfAudioWithSilence.PCMMonoAudio, 0, selfAudioWithSilence.PCMAudioLength);
+            }
         }
 
         internal void AppendClientAudio(List<DeJitteredTransmission> mainAudio, List<DeJitteredTransmission> secondaryAudio, int radioId)
         {
-            if (_stop)
-            {
-                Start();
-            }
-
             //only record if we need too
             if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio))
             {
-                //TODO
-                //represents a moment in time
-                //should I include time so we can line up correctly?
+                ProcessSilenceGaps(mainAudio, _mainAudioWithSilence[radioId], radioId);
+                ProcessSilenceGaps(secondaryAudio, _secondaryAudioWithSilence[radioId], radioId);
 
                 float[] buf = SingleRadioMixDown(new AudioRecordingSample()
                 {
-                    MainRadioClientTransmissions = mainAudio,
-                    SecondaryRadioClientTransmissions = secondaryAudio,
+                    MainRadioClientTransmissions = _mainAudioWithSilence[radioId],
+                    SecondaryRadioClientTransmissions = _secondaryAudioWithSilence[radioId],
                     RadioId = radioId
                 }, out int count);
                 if (count > 0)
                 {
                     _clientMixDownQueue[radioId].Write(buf, 0, count);
                 }
+
+                _mainAudioWithSilence[radioId].Clear();
+                _secondaryAudioWithSilence[radioId].Clear();
+            }
+        }
+
+        private void ProcessSilenceGaps(List<DeJitteredTransmission> audioSamples, List<DeJitteredTransmission> audioSamplesWithSilence, int radioId)
+        {
+            if (audioSamples.Count == 0)
+            {
+                long newTime = DateTime.Now.Ticks;
+                int silenceLength = (int)((newTime - _lastUpdate[radioId]) / TimeSpan.TicksPerSecond * _sampleRate);
+
+
+                audioSamplesWithSilence.Add(
+                    new DeJitteredTransmission
+                    {
+                        PCMMonoAudio = new float[silenceLength],
+                        PCMAudioLength = silenceLength,
+                        IsSilence = true
+                    }
+                    );
+
+                _lastUpdate[radioId] = newTime;
+
+                return;
+            }
+
+            foreach (DeJitteredTransmission dejitterSample in audioSamples)
+            {
+                audioSamplesWithSilence.Add(ExpandGapSilence(dejitterSample, ref _lastUpdate));
+            }
+        }
+
+
+        private DeJitteredTransmission ExpandGapSilence(DeJitteredTransmission audioSample, ref long[] lastUpdate)
+        {
+            long silenceLength = (audioSample.ReceiveTime - lastUpdate[audioSample.ReceivedRadio]) / TimeSpan.TicksPerSecond * _sampleRate;
+            // Guard against neg values when transmission recv before AudioRecordingManager instantiated
+            silenceLength = silenceLength < 0 ? 0 : silenceLength;
+
+            // DateTime.Now ticks accuracy is too coarse, assume only (comparatively) larger gaps may be silence
+            if (silenceLength / 10000 < 35)
+            {
+                return audioSample;
+            }
+            else
+            {
+                return
+                    new DeJitteredTransmission
+                    {
+                        PCMMonoAudio = new float[silenceLength],
+                        PCMAudioLength = (int)silenceLength,
+                        IsSilence = true
+                    };
+            }
+        }
+
+        internal void Toggle()
+        {
+            if (_stop)
+            {
+                Start();
+                GlobalSettingsStore.Instance.SetClientSetting(GlobalSettingsKeys.RecordAudio, true);
+            }
+            else
+            {
+                Stop();
+                GlobalSettingsStore.Instance.SetClientSetting(GlobalSettingsKeys.RecordAudio, false);
             }
         }
     }

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingSample.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingSample.cs
@@ -14,9 +14,5 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Recording
         public int RadioId { get; set;}
         public List<DeJitteredTransmission> MainRadioClientTransmissions { get; set; }
         public List<DeJitteredTransmission> SecondaryRadioClientTransmissions { get; set; }
-
-
-
-
     }
 }

--- a/DCS-SR-Client/Audio/Recording/PerRadioLameRecordingWriter.cs
+++ b/DCS-SR-Client/Audio/Recording/PerRadioLameRecordingWriter.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Models;
+using System.Linq;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
 {
@@ -16,15 +17,20 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
     {
         private readonly Dictionary<int, string> _filePaths;
         private readonly LameMP3FileWriter[] _mp3FileWriters;
-        private readonly WaveFileWriter waveWriter;
+        private int _radioNum;
+        private float[] _floatArray;
+        private float[] _selfArray;
+        private readonly int _bufferSize = 120000;
+        private readonly float[] _silenceArray;
 
-        public PerRadioLameRecordingWriter(int sampleRate) : base(sampleRate)
+        public PerRadioLameRecordingWriter(int sampleRate, int radioNum) : base(sampleRate)
         {
             _filePaths = new Dictionary<int, string>();
             _mp3FileWriters = new LameMP3FileWriter[11];
-
-            waveWriter = new NAudio.Wave.WaveFileWriter($@"C:\\temp\\output{Guid.NewGuid()}.wav", WaveFormat.CreateIeeeFloatWaveFormat(sampleRate,1));
-
+            _radioNum = radioNum;
+            _silenceArray = new float[_bufferSize];
+            _floatArray = new float[_bufferSize];
+            _selfArray = new float[_bufferSize];
         }
 
         private void OutputToFile(int radio, float[] floatArray)
@@ -39,14 +45,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
                     Buffer.BlockCopy(floatArray, 0, byteArray, 0, byteArray.Length);
 
                     _mp3FileWriters[radio].Write(byteArray, 0, byteArray.Length);
-
-                    if (radio == 1)
-                    {
-                        //figure out why the audio is terrible
-                        //calculate the time between the last write - and fill in the rest of the audio with blank audio?
-                        //The effects are now mixing in nicely - its just the actual audio thats wrecked for some reason
-                        waveWriter.WriteSamples(floatArray,0,floatArray.Length);
-                    }
                 }
             }
             catch (Exception ex)
@@ -55,33 +53,36 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
             }
         }
 
-        public override void ProcessAudio(List<CircularFloatBuffer> perRadioAudio)
+        public override void ProcessAudio(List<CircularFloatBuffer> perRadioAudio, List<CircularFloatBuffer> perSelfAudio)
         {
-            
             for (int i = 0; i < perRadioAudio.Count; i++)
             {
-                if (perRadioAudio[i].Count > 0)
+                if (perRadioAudio[i].Count > 0 || perSelfAudio[i].Count > 0)
                 {
-                    float[] floatArrray = new float[perRadioAudio[i].Count];
-
-                    perRadioAudio[i].Read(floatArrray, 0, floatArrray.Length);
-                    OutputToFile(i, floatArrray);
+                    perRadioAudio[i].Read(_floatArray, 0, perRadioAudio[i].Count);
+                    _floatArray = _floatArray.Zip(_silenceArray, (x, y) => x + y).ToArray();
+                    perSelfAudio[i].Read(_selfArray, 0, perSelfAudio[i].Count);
+                    _floatArray = AudioManipulationHelper.MixArraysClipped(_floatArray, _bufferSize, _selfArray, _bufferSize, out int _);
+                    OutputToFile(i, _floatArray);
+                    Array.Clear(_floatArray, 0, _bufferSize);
                 }
-            }
+                else
+                {
+                    OutputToFile(i, _silenceArray);
+                }
 
-            _lastWrite += TimeSpan.TicksPerSecond * 2;
+            }
         }
 
-        public override void Start()
+        public override void Start(string aircraftName)
         {
             string partialFilePath = base.CreateFilePath();
 
-            _lastWrite = DateTime.Now.Ticks;
             var lamePreset = (LAMEPreset)Enum.Parse(typeof(LAMEPreset),
                     GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.RecordingQuality).RawValue);
             for (int i = 0; i < 11; i++)
             {
-                _filePaths.Add(i, $"{partialFilePath}-Radio{i}.mp3");
+                _filePaths.Add(i, $"{partialFilePath}-{aircraftName}-Radio{i}.mp3");
 
                 _mp3FileWriters[i] = new LameMP3FileWriter(_filePaths[i], _waveFormat, lamePreset);
             }
@@ -95,8 +96,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
                 _mp3FileWriters[i].Dispose();
                 _mp3FileWriters[i] = null;
             }
-            waveWriter.Close();
-            waveWriter.Dispose();
         }
     }
 }

--- a/DCS-SR-Client/Audio/Recording/TransmissionAssembler.cs
+++ b/DCS-SR-Client/Audio/Recording/TransmissionAssembler.cs
@@ -1,69 +1,70 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿//using Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Models;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
 
-namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
-{
-    internal class TransmissionAssembler
-    {
-        private readonly Dictionary<string, ClientTransmissionBuffer> _clientAudioBuffers;
-        private short[] _sampleRemainders;
+//namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
+//{
+//    internal class TransmissionAssembler
+//    {
+//        private readonly Dictionary<string, ClientTransmissionBuffer> _clientAudioBuffers;
+//        private float[] _sampleRemainders;
 
-        public TransmissionAssembler()
-        {
-            _clientAudioBuffers = new Dictionary<string, ClientTransmissionBuffer>();
-            _sampleRemainders = new short[48000 * 2];
-        }
+//        public TransmissionAssembler()
+//        {
+//            _clientAudioBuffers = new Dictionary<string, ClientTransmissionBuffer>();
+//            _sampleRemainders = new float[48000 * 2];
+//        }
 
-        private short[] SplitRemainder(short[] sample)
-        {
-            (short[], short[]) splitArrays = AudioManipulationHelper.SplitSampleByTime(48000 * 2, sample);
-            short[] fullLengthRemainder = new short[48000 * 2];
-            splitArrays.Item2.CopyTo(fullLengthRemainder, 0);
-            _sampleRemainders = AudioManipulationHelper.MixSamplesClipped(_sampleRemainders, fullLengthRemainder, 48000 * 2);
+//        private float[] SplitRemainder(float[] sample)
+//        {
+//            (float[], float[]) splitArrays = AudioManipulationHelper.SplitSampleByTime(48000 * 2, sample);
+//            float[] fullLengthRemainder = new float[48000 * 2];
+//            splitArrays.Item2.CopyTo(fullLengthRemainder, 0);
+//            _sampleRemainders = AudioManipulationHelper.MixSamplesClipped(_sampleRemainders, fullLengthRemainder, 48000 * 2);
 
-            return splitArrays.Item1;
-        }
+//            return splitArrays.Item1;
+//        }
 
-        public void AddTransmission(ClientAudio audio)
-        {
-            string guid = audio.OriginalClientGuid;
+//        public void AddTransmission(DeJitteredTransmission audio)
+//        {
+//            string guid = audio.OriginalClientGuid;
 
-            if (!_clientAudioBuffers.ContainsKey(guid))
-            {
-                _clientAudioBuffers.Add(guid, new ClientTransmissionBuffer());
-            }
+//            if (!_clientAudioBuffers.ContainsKey(guid))
+//            {
+//                _clientAudioBuffers.Add(guid, new ClientTransmissionBuffer());
+//            }
 
-            _clientAudioBuffers[guid].AddSample(audio);
-        }
+//            _clientAudioBuffers[guid].AddSample(audio);
+//        }
 
-        public short[] GetAssembledSample()
-        {
-            short[] finalShortArray = new short[48000 * 2];
-            _sampleRemainders.CopyTo(finalShortArray, 0);
-            _sampleRemainders = new short[48000 * 2];
+//        public float[] GetAssembledSample()
+//        {
+//            float[] finalFloatArray = new float[48000 * 2];
+//            _sampleRemainders.CopyTo(finalFloatArray, 0);
+//            _sampleRemainders = new float[48000 * 2];
 
-            foreach (var sample in _clientAudioBuffers.Values)
-            {
-                short[] clientPCM = sample.OutputPCM();
-                short[] trimmedClientPCM;
-                if (clientPCM.Length > 96000)
-                {
-                    trimmedClientPCM = SplitRemainder(clientPCM);
-                }
-                else
-                {
-                    trimmedClientPCM = new short[48000 * 2];
-                    clientPCM.CopyTo(trimmedClientPCM, 0);
-                }
+//            foreach (var sample in _clientAudioBuffers.Values)
+//            {
+//                float[] clientPCM = sample.OutputPCM();
+//                float[] trimmedClientPCM;
+//                if (clientPCM.Length > 96000)
+//                {
+//                    trimmedClientPCM = SplitRemainder(clientPCM);
+//                }
+//                else
+//                {
+//                    trimmedClientPCM = new float[48000 * 2];
+//                    clientPCM.CopyTo(trimmedClientPCM, 0);
+//                }
 
-                finalShortArray = AudioManipulationHelper.MixSamplesClipped(finalShortArray, trimmedClientPCM, 48000 * 2);
-            }
+//                finalFloatArray = AudioManipulationHelper.MixSamplesClipped(finalFloatArray, trimmedClientPCM, 48000 * 2);
+//            }
 
 
-            return finalShortArray;
-        }
-    }
-}
+//            return finalFloatArray;
+//        }
+//    }
+//}

--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Recording;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons;
 using Ciribob.DCS.SimpleRadio.Standalone.Client.UI;
@@ -748,8 +749,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
                                     case InputBinding.RadioVolumeDown:
                                         RadioHelper.RadioVolumeDown(dcsPlayerRadioInfo.selected);
                                         break;
-
-
+                                    case InputBinding.RecordingToggle:
+                                        AudioRecordingManager.Instance.Toggle();
+                                        break;
                                     default:
                                         break;
                                 }

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -213,8 +213,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         IntercomPTT = 136,
         ModifierIntercomPTT = 236,
 
-        AwacsOverlayToggle = 137,
-        ModifierAwacsOverlayToggle = 237
+        RecordingToggle = 137,
+        ModifierRecordingToggle = 237,
+
+        AwacsOverlayToggle = 138,
+        ModifierAwacsOverlayToggle = 238
     }
 
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -331,284 +331,285 @@
                 <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Visible">
                         <StackPanel>
                             <Button Width="150px" Content="Rescan Controller Input Devices" Click="RescanInputDevices" />
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition Width="2*" />
-                                    <ColumnDefinition Width="1*" />
-                                    <ColumnDefinition Width="1*" />
-                                    <ColumnDefinition Width="1*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                </Grid.RowDefinitions>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="1*" />
+                                <ColumnDefinition Width="1*" />
+                                <ColumnDefinition Width="1*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
 
 
-                                <Label x:Name="DeviceLabel"
+                            <Label x:Name="DeviceLabel"
                                    Grid.Row="0"
                                    Grid.Column="1"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Device" />
-                                <Label x:Name="ButtonLabel"
+                            <Label x:Name="ButtonLabel"
                                    Grid.Row="0"
                                    Grid.Column="2"
                                    HorizontalContentAlignment="Center"
                                    VerticalContentAlignment="Center"
                                    Content="Button" />
 
-                                <local:InputBindingControl x:Name="Radio1"
+                            <local:InputBindingControl x:Name="Radio1"
                                                        Grid.Row="1"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch1}"
                                                        InputName="Radio 1" />
-                                <local:InputBindingControl x:Name="Radio2"
+                            <local:InputBindingControl x:Name="Radio2"
                                                        Grid.Row="2"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch2}"
                                                        InputName="Radio 2" />
-                                <local:InputBindingControl x:Name="Radio3"
+                            <local:InputBindingControl x:Name="Radio3"
                                                        Grid.Row="3"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch3}"
                                                        InputName="Radio 3" />
-                                <local:InputBindingControl x:Name="PTT"
+                            <local:InputBindingControl x:Name="PTT"
                                                        Grid.Row="4"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Ptt}"
                                                        InputName="Common PTT" />
-                                <local:InputBindingControl x:Name="Intercom"
+                            <local:InputBindingControl x:Name="Intercom"
                                                        Grid.Row="5"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Intercom}"
                                                        InputName="Intercom Select" />
 
-                                <local:InputBindingControl x:Name="IntercomPTT"
+                            <local:InputBindingControl x:Name="IntercomPTT"
                                                        Grid.Row="6"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.IntercomPTT}"
                                                        InputName="Special Intercom Select &amp; PTT" />
 
-                                <local:InputBindingControl x:Name="RadioOverlay"
+                            <local:InputBindingControl x:Name="RadioOverlay"
                                                        Grid.Row="7"
                                                        Grid.ColumnSpan="6"
                                                        ControlInputBinding="{x:Static settings:InputBinding.OverlayToggle}"
                                                        InputName="Overlay Toggle" />
 
-                                <local:InputBindingControl x:Name="Radio4"
+                            <local:InputBindingControl x:Name="Radio4"
                                                        Grid.Row="8"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch4}"
                                                        InputName="Radio 4" />
-                                <local:InputBindingControl x:Name="Radio5"
+                            <local:InputBindingControl x:Name="Radio5"
                                                        Grid.Row="9"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch5}"
                                                        InputName="Radio 5" />
-                                <local:InputBindingControl x:Name="Radio6"
+                            <local:InputBindingControl x:Name="Radio6"
                                                        Grid.Row="10"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch6}"
                                                        InputName="Radio 6" />
 
-                                <local:InputBindingControl x:Name="Radio7"
+                            <local:InputBindingControl x:Name="Radio7"
                                                        Grid.Row="11"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch7}"
                                                        InputName="Radio 7" />
 
-                                <local:InputBindingControl x:Name="Radio8"
+                            <local:InputBindingControl x:Name="Radio8"
                                                        Grid.Row="12"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch8}"
                                                        InputName="Radio 8" />
 
-                                <local:InputBindingControl x:Name="Radio9"
+                            <local:InputBindingControl x:Name="Radio9"
                                                        Grid.Row="13"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch9}"
                                                        InputName="Radio 9" />
 
-                                <local:InputBindingControl x:Name="Radio10"
+                            <local:InputBindingControl x:Name="Radio10"
                                                        Grid.Row="14"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Switch10}"
                                                        InputName="Radio 10" />
 
 
-                                <local:InputBindingControl x:Name="Up100"
+                            <local:InputBindingControl x:Name="Up100"
                                                        Grid.Row="15"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up100}"
                                                        InputName="Up 100MHz" />
 
-                                <local:InputBindingControl x:Name="Up10"
+                            <local:InputBindingControl x:Name="Up10"
                                                        Grid.Row="16"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up10}"
                                                        InputName="Up 10MHz" />
 
-                                <local:InputBindingControl x:Name="Up1"
+                            <local:InputBindingControl x:Name="Up1"
                                                        Grid.Row="17"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up1}"
                                                        InputName="Up 1MHz" />
 
-                                <local:InputBindingControl x:Name="Up01"
+                            <local:InputBindingControl x:Name="Up01"
                                                        Grid.Row="18"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up01}"
                                                        InputName="Up 0.1MHz" />
 
-                                <local:InputBindingControl x:Name="Up001"
+                            <local:InputBindingControl x:Name="Up001"
                                                        Grid.Row="19"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up001}"
                                                        InputName="Up 0.01MHz" />
 
-                                <local:InputBindingControl x:Name="Up0001"
+                            <local:InputBindingControl x:Name="Up0001"
                                                        Grid.Row="20"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Up0001}"
                                                        InputName="Up 0.001MHz" />
 
 
-                                <local:InputBindingControl x:Name="Down100"
+                            <local:InputBindingControl x:Name="Down100"
                                                        Grid.Row="21"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down100}"
                                                        InputName="Down 100MHz" />
 
-                                <local:InputBindingControl x:Name="Down10"
+                            <local:InputBindingControl x:Name="Down10"
                                                        Grid.Row="22"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down10}"
                                                        InputName="Down 10MHz" />
 
-                                <local:InputBindingControl x:Name="Down1"
+                            <local:InputBindingControl x:Name="Down1"
                                                        Grid.Row="23"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down1}"
                                                        InputName="Down 1MHz" />
 
-                                <local:InputBindingControl x:Name="Down01"
+                            <local:InputBindingControl x:Name="Down01"
                                                        Grid.Row="24"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down01}"
                                                        InputName="Down 0.1MHz" />
 
-                                <local:InputBindingControl x:Name="Down001"
+                            <local:InputBindingControl x:Name="Down001"
                                                        Grid.Row="25"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down001}"
                                                        InputName="Down 0.01MHz" />
 
-                                <local:InputBindingControl x:Name="Down0001"
+                            <local:InputBindingControl x:Name="Down0001"
                                                        Grid.Row="26"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.Down0001}"
                                                        InputName="Down 0.001MHz" />
 
-                                <local:InputBindingControl x:Name="ToggleGuard"
+                            <local:InputBindingControl x:Name="ToggleGuard"
                                                        Grid.Row="27"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleGuard}"
                                                        InputName="Toggle Guard" />
 
-                                <local:InputBindingControl x:Name="NextRadio"
+                            <local:InputBindingControl x:Name="NextRadio"
                                                        Grid.Row="28"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.NextRadio}"
                                                        InputName="Next Radio" />
 
 
-                                <local:InputBindingControl x:Name="PreviousRadio"
+                            <local:InputBindingControl x:Name="PreviousRadio"
                                                        Grid.Row="29"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.PreviousRadio}"
                                                        InputName="Previous Radio" />
 
-                                <local:InputBindingControl x:Name="ToggleEncryption"
+                            <local:InputBindingControl x:Name="ToggleEncryption"
                                                        Grid.Row="30"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.ToggleEncryption}"
                                                        InputName="Toggle Encryption" />
 
-                                <local:InputBindingControl x:Name="EncryptionKeyIncrease"
+                            <local:InputBindingControl x:Name="EncryptionKeyIncrease"
                                                        Grid.Row="31"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyIncrease}"
                                                        InputName="Encryption Key Increase" />
 
-                                <local:InputBindingControl x:Name="EncryptionKeyDecrease"
+                            <local:InputBindingControl x:Name="EncryptionKeyDecrease"
                                                        Grid.Row="32"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.EncryptionKeyDecrease}"
                                                        InputName="Encryption Key Decrease" />
 
-                                <local:InputBindingControl x:Name="RadioChannelUp"
+                            <local:InputBindingControl x:Name="RadioChannelUp"
                                                        Grid.Row="33"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelUp}"
                                                        InputName="Radio Channel Up" />
 
-                                <local:InputBindingControl x:Name="RadioChannelDown"
+                            <local:InputBindingControl x:Name="RadioChannelDown"
                                                        Grid.Row="34"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioChannelDown}"
                                                        InputName="Radio Channel Down" />
 
-                                <local:InputBindingControl x:Name="TransponderIDENT"
+                            <local:InputBindingControl x:Name="TransponderIDENT"
                                                        Grid.Row="35"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.TransponderIDENT}"
                                                        InputName="Transponder IDENT" />
 
-                                <local:InputBindingControl x:Name="RadioVolumeUp"
+                            <local:InputBindingControl x:Name="RadioVolumeUp"
                                                        Grid.Row="36"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeUp}"
                                                        InputName="Radio Volume Up" />
 
-                                <local:InputBindingControl x:Name="RadioVolumeDown"
+                            <local:InputBindingControl x:Name="RadioVolumeDown"
                                                        Grid.Row="37"
                                                        Grid.ColumnSpan="5"
                                                        ControlInputBinding="{x:Static settings:InputBinding.RadioVolumeDown}"
@@ -620,10 +621,13 @@
                                                            ControlInputBinding="{x:Static settings:InputBinding.AwacsOverlayToggle}"
                                                            InputName="AWACS Overlay Toggle" />
 
-
+                            <local:InputBindingControl x:Name="RecordingToggle"
+                                                           Grid.Row="39"
+                                                           Grid.ColumnSpan="5"
+                                                           ControlInputBinding="{x:Static settings:InputBinding.RecordingToggle}"
+                                                           InputName="Recording Toggle" />
                         </Grid>
-
-                        </StackPanel>
+                    </StackPanel>
                 </ScrollViewer>
 
                     </GroupBox>

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -501,6 +501,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             RadioVolumeDown.InputName = "Radio Volume Down";
             RadioVolumeDown.ControlInputBinding = InputBinding.RadioVolumeDown;
             RadioVolumeDown.InputDeviceManager = InputManager;
+
+            RecordingToggle.InputName = "Toggle Recording";
+            RecordingToggle.ControlInputBinding = InputBinding.RecordingToggle;
+            RecordingToggle.InputDeviceManager = InputManager;
         }
 
         private void OnProfileDropDownChanged(object sender, SelectionChangedEventArgs e)
@@ -580,6 +584,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             RadioVolumeUp.LoadInputSettings();
             RadioVolumeDown.LoadInputSettings();
             AwacsOverlayToggle.LoadInputSettings();
+            RecordingToggle.LoadInputSettings();
         }
 
         private void ReloadRadioAudioChannelSettings()


### PR DESCRIPTION
…previously.

Fix issue to enable recording of mic capture

Refactor AudioManager to enable capture of user audio captured via microphone

Add assembling with silence being generated between transmissions Refactored AudioRecordingManager to reuse as many buffers as possible Refactor headroom mixing to a simpler implementation, may want to consider removing Refactor SplitSampleByTime to account for floating point reprensentation Refactor ClientTransmission to work with new effects pipeline and floating point representation Update file output name to be more descriptive by including aircraft name Refactor PerRadioLameRecordingWriter to work with new recording implementation

Remove transmission assember temporarily (commented out for now), should either be removed or refactored when the implementation of recording is resolved.

Clean up the temporary debug wavewriter

Add silence and receive time properties to DejitteredTransmission struct - allows insertion of silence between transmissions without requiring CPU use on effects processing 'empty' transmissions