### PR TITLE
Alternative auto ip lookup for dcs autoconnect

### DIFF
--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -9,6 +9,10 @@
 -- User options --
 local SRSAuto = {}
 
+package.path  = package.path..";.\\LuaSocket\\?.lua;"
+require("url") -- defines socket.url, which socket.http looks for
+http = require("http")
+
 SRSAuto.SERVER_SRS_HOST_AUTO = false -- if set to true SRS will set the SERVER_SRS_HOST for you! - Currently disabled
 SRSAuto.SERVER_SRS_PORT = "5002" --  SRS Server default is 5002 TCP & UDP
 SRSAuto.SERVER_SRS_HOST = "127.0.0.1" -- overridden if SRS_HOST_AUTO is true -- set to your PUBLIC ipv4 address
@@ -118,8 +122,9 @@ local _lastSent = 0
 SRSAuto.onMissionLoadBegin = function()
 
 	if SRSAuto.SERVER_SRS_HOST_AUTO then
-		-- SRSAuto.SERVER_SRS_HOST = DcsWeb.get_data('dcs:whatsmyip')
-		-- SRSAuto.log("SET IP automatically to "..SRSAuto.SERVER_SRS_HOST)
+		local T, code, headers, status = socket.http.request("https://ipv4.icanhazip.com")
+		SRSAuto.SERVER_SRS_HOST = T
+		SRSAuto.log("SET IP automatically to "..SRSAuto.SERVER_SRS_HOST)
 	end
 
 end

--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -9,10 +9,6 @@
 -- User options --
 local SRSAuto = {}
 
-package.path  = package.path..";.\\LuaSocket\\?.lua;"
-require("url") -- defines socket.url, which socket.http looks for
-http = require("http")
-
 SRSAuto.SERVER_SRS_HOST_AUTO = false -- if set to true SRS will set the SERVER_SRS_HOST for you! - Currently disabled
 SRSAuto.SERVER_SRS_PORT = "5002" --  SRS Server default is 5002 TCP & UDP
 SRSAuto.SERVER_SRS_HOST = "127.0.0.1" -- overridden if SRS_HOST_AUTO is true -- set to your PUBLIC ipv4 address
@@ -55,6 +51,9 @@ SRSAuto.JSON = JSON
 
 local socket = require("socket")
 -- local DcsWeb = require('DcsWeb')
+
+require("url") -- defines socket.url, which socket.http looks for
+http = require("http") -- socket.http
 
 SRSAuto.UDPSendSocket = socket.udp()
 SRSAuto.UDPSendSocket:settimeout(0)


### PR DESCRIPTION
Hi I've made a small change to DCS-SRS-AutoConnectGameGUI.lua to fix auto IP acquisition when SERVER_SRS_HOST_AUTO == true. Instead of using DCSWeb, we make a call to ipv4.icanhazip.com via socket.http module shipped with DCS (assuming DCSWeb was the original issue).