### PR TITLE
UH-60L ARC-201 RX Detection

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
@@ -83,6 +83,22 @@ srsOverlay.module_specific["M-2000C"] = function(radios)
 	end
 
 
+srsOverlay.module_specific["UH-60L"] = function(radios) -- for ARC-201 scanning feature, detects RX-ing
+		for _i,_radio in pairs(radios) do
+			local _isReceiving,_sentBy = srsOverlay.isReceiving(_i)
+			if _i==2 then -- ARC-201 FM1
+				if _isReceiving>0 then
+					base.Export.GetDevice(2):performClickableAction(20101, 1)
+				end
+			elseif _i==5 then -- ARC-201 FM2
+				if _isReceiving>0 then
+					base.Export.GetDevice(9):performClickableAction(20102, 1)
+				end
+			end
+		end
+	end
+
+
 function srsOverlay.loadConfiguration()
     srsOverlay.log("Loading config file...")
     local tbl = Tools.safeDoFile(lfs.writedir() .. 'Config/SRSConfig.lua', false)


### PR DESCRIPTION
Added code that monitors for reception on the UH-60L's ARC-201 FM1 and FM2 radios. While receiving, a key command is issued. Within the UH-60L mod, the two "ARC201_FMx.lua" scripts look for these key presses to temporarily pause scanning.

At this time, the matching code on the UH-60L mod side is not an official part of the mod yet.