### PR TITLE
SA342: Honor the 'disable hot mic' special option

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -95,6 +95,23 @@ SR.fc3["Su-33"] = true
 SR.fc3["Su-25"] = true
 SR.fc3["Su-25T"] = true
 
+--[[ Reading special options.
+   option: dot separated 'path' to your option under the plugins field,
+   ie 'DCS-SRS.srsAutoLaunchEnabled', or 'SA342.HOT_MIC'
+--]]
+SR.specialOptions = {}
+function SR.getSpecialOption(option)
+    if not SR.specialOptions[option] then
+        local options = require('optionsEditor')
+        -- If the option doesn't exist, a nil value is returned.
+        -- Memoize into a subtable to avoid entering that code again,
+        -- since options.getOption ends up doing a disk access.
+        SR.specialOptions[option] = { value = options.getOption('plugins.'..option) }
+    end
+    
+    return SR.specialOptions[option].value
+end
+
 -- Function to load mods' SRS plugin script
 function SR.LoadModsPlugins()
     local mode, errmsg
@@ -1866,12 +1883,11 @@ function SR.exportRadioSA342(_data)
         _data.control = 0; -- OVERLAY Controls
     end
 
-    _data.intercomHotMic = true
+     -- The option reads 'disable HOT_MIC', true means off.
+     _data.intercomHotMic = not SR.getSpecialOption('SA342.HOT_MIC')
 
-    
     -- HANDLE TRANSPONDER
     _data.iff = {status=0,mode1=0,mode3=0,mode4=false,control=0,expansion=false}
-
 
     local iffPower =  SR.getButtonPosition(246)
 


### PR DESCRIPTION
> Is there a way to disable the intercom hotmic in the Gazelle? The radio capabilities window says that the functionality is "available in cockpit" but try as i might i can't find any switch of the sort

[_Question from the SRS Discord_](https://discord.com/channels/298054423656005632/598575126530752540/1132539780115210260)

Turns out the Gazelle has a special option labeled 'disable intercom hot mic' that we can use.