### PR TITLE
Restore A-10C cockpit PTT support and add it for A-10C II

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -2348,7 +2348,7 @@ end
 --for A10C
 function SR.exportRadioA10C(_data)
 
-    _data.capabilities = { dcsPtt = false, dcsIFF = true, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
+    _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = false, desc = "Using cockpit PTT (HOTAS Mic Switch) requires use of VoIP bindings." }
 
     -- Check if player is in a new aircraft
     if _lastUnitId ~= _data.unitId then
@@ -2449,35 +2449,35 @@ function SR.exportRadioA10C(_data)
     -- Mic Switch Radio Select and Transmit - by Dyram
     -- Check Mic Switch position (UP: 751 1.0, DOWN: 751 -1.0, FWD: 752 1.0, AFT: 752 -1.0)
     -- ED broke this as part of the VoIP work
-    -- if SR.getButtonPosition(752) == 1 then
-    --     -- Mic Switch FWD pressed
-    --     -- Check Intercom panel Rotary Selector Dial (0: INT, 1: FM, 2: VHF, 3: HF, 4: "")
-    --     if SR.getSelectorPosition(239, 0.1) == 2 then
-    --         -- Intercom panel set to VHF
-    --         _data.selected = 1 -- radios[2] VHF AM
-    --         _data.ptt = true
-    --     elseif SR.getSelectorPosition(239, 0.1) == 0 then
-    --         -- Intercom panel set to INT
-    --         -- Intercom not functional, but select it anyway to be proper
-    --         _data.selected = 0 -- radios[1] Intercom
-    --     else
-    --         _data.selected = -1
-    --     end
-    -- elseif SR.getButtonPosition(751) == -1 then
-    --     -- Mic Switch DOWN pressed
-    --     _data.selected = 2 -- radios[3] UHF
-    --     _data.ptt = true
-    -- elseif SR.getButtonPosition(752) == -1 then
-    --     -- Mic Switch AFT pressed
-    --     _data.selected = 3 -- radios[4] VHF FM
-    --     _data.ptt = true
-    -- else
-    --     -- Mic Switch released
-    --     _data.selected = -1
-    --     _data.ptt = false
-    -- end
+    if SR.getButtonPosition(752) == 1 then
+        -- Mic Switch FWD pressed
+        -- Check Intercom panel Rotary Selector Dial (0: INT, 1: FM, 2: VHF, 3: HF, 4: "")
+        if SR.getSelectorPosition(239, 0.1) == 2 then
+            -- Intercom panel set to VHF
+            _data.selected = 1 -- radios[2] VHF AM
+            _data.ptt = true
+        elseif SR.getSelectorPosition(239, 0.1) == 0 then
+            -- Intercom panel set to INT
+            -- Intercom not functional, but select it anyway to be proper
+            _data.selected = 0 -- radios[1] Intercom
+        else
+            _data.selected = -1
+        end
+    elseif SR.getButtonPosition(751) == -1 then
+        -- Mic Switch DOWN pressed
+        _data.selected = 2 -- radios[3] UHF
+        _data.ptt = true
+    elseif SR.getButtonPosition(752) == -1 then
+        -- Mic Switch AFT pressed
+        _data.selected = 3 -- radios[4] VHF FM
+        _data.ptt = true
+    else
+        -- Mic Switch released
+        _data.selected = -1
+        _data.ptt = false
+    end
 
-    _data.control = 0 -- Overlay  
+    _data.control = 1 -- Overlay  
 
     -- Handle transponder
 
@@ -2547,7 +2547,7 @@ _a10c2.encKey = 1
 
 function SR.exportRadioA10C2(_data)
 
-    _data.capabilities = { dcsPtt = false, dcsIFF = true, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
+    _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = false, desc = "Using cockpit PTT (HOTAS Mic Switch) requires use of VoIP bindings." }
 
     -- Check if player is in a new aircraft
     if _lastUnitId ~= _data.unitId then
@@ -2685,7 +2685,38 @@ function SR.exportRadioA10C2(_data)
         end
     end
 
-    _data.control = 0 -- Overlay  
+ -- Mic Switch Radio Select and Transmit - by Dyram
+    -- Check Mic Switch position (UP: 751 1.0, DOWN: 751 -1.0, FWD: 752 1.0, AFT: 752 -1.0)
+    -- ED broke this as part of the VoIP work
+    if SR.getButtonPosition(752) == 1 then
+        -- Mic Switch FWD pressed
+        -- Check Intercom panel Rotary Selector Dial (0: INT, 1: FM, 2: VHF, 3: HF, 4: "")
+        if SR.getSelectorPosition(239, 0.1) == 2 then
+            -- Intercom panel set to VHF
+            _data.selected = 1 -- radios[2] VHF AM
+            _data.ptt = true
+        elseif SR.getSelectorPosition(239, 0.1) == 0 then
+            -- Intercom panel set to INT
+            -- Intercom not functional, but select it anyway to be proper
+            _data.selected = 0 -- radios[1] Intercom
+        else
+            _data.selected = -1
+        end
+    elseif SR.getButtonPosition(751) == -1 then
+        -- Mic Switch DOWN pressed
+        _data.selected = 2 -- radios[3] UHF
+        _data.ptt = true
+    elseif SR.getButtonPosition(752) == -1 then
+        -- Mic Switch AFT pressed
+        _data.selected = 3 -- radios[4] VHF FM
+        _data.ptt = true
+    else
+        -- Mic Switch released
+        _data.selected = -1
+        _data.ptt = false
+    end
+
+    _data.control = 1 -- Overlay  
 
     -- Handle transponder
 


### PR DESCRIPTION
Added back support for in-cockpit PTT (HOTAS Mic Switch). Using it requires using binding VoIP commands for Mic Switch.
Solves issue #584 