### PR TITLE
[FEATURE] F15E hot mic

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1752,7 +1752,8 @@ function SR.exportRadioF15ESE(_data)
     end
 
 
-    _data.control = 0;
+    -- required for hot mic
+    _data.control = 1 -- full radio
     _data.selected = 1
 
     return _data

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1713,6 +1713,7 @@ function SR.exportRadioF15C(_data)
 end
 
 function SR.exportRadioF15ESE(_data)
+    _data.capabilities = { dcsPtt = false, dcsIFF = false, dcsRadioSwitch = true, intercomHotMic = true, desc = "" }
 
     _data.radios[1].name = "Intercom"
     _data.radios[1].freq = 100.0
@@ -1734,13 +1735,22 @@ function SR.exportRadioF15ESE(_data)
     local _seat = SR.lastKnownSeat
 
     if _seat == 0 then
-       
+
         _data.radios[2].volume = SR.getRadioVolume(0, 282, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 283, { 0.1, 1.0 }, false)
+
+        -- https://github.com/DCSSKUNKWORKS/dcs-bios/blob/master/Scripts/DCS-BIOS/lib/F-15E.lua#L657C7-L657C7
+        if SR.getButtonPosition(509) ~= 0.5 then
+            _data.intercomHotMic = true
+        end
     else
         _data.radios[2].volume = SR.getRadioVolume(0, 1307, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 1308, { 0.1, 1.0 }, false)
 
+        -- https://github.com/DCSSKUNKWORKS/dcs-bios/blob/master/Scripts/DCS-BIOS/lib/F-15E.lua#L1040
+        if SR.getButtonPosition(1427) ~= 0.5 then
+            _data.intercomHotMic = true
+        end
     end
 
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1739,14 +1739,14 @@ function SR.exportRadioF15ESE(_data)
         _data.radios[2].volume = SR.getRadioVolume(0, 282, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 283, { 0.1, 1.0 }, false)
 
-        if SR.getButtonPosition(509) ~= 0.5 then
+        if SR.getButtonPosition(509) >= 0.5 then
             _data.intercomHotMic = true
         end
     else
         _data.radios[2].volume = SR.getRadioVolume(0, 1307, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 1308, { 0.1, 1.0 }, false)
 
-        if SR.getButtonPosition(1427) ~= 0.5 then
+        if SR.getButtonPosition(1427) >= 0.5 then
             _data.intercomHotMic = true
         end
     end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1739,7 +1739,6 @@ function SR.exportRadioF15ESE(_data)
         _data.radios[2].volume = SR.getRadioVolume(0, 282, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 283, { 0.1, 1.0 }, false)
 
-        -- https://github.com/DCSSKUNKWORKS/dcs-bios/blob/master/Scripts/DCS-BIOS/lib/F-15E.lua#L657C7-L657C7
         if SR.getButtonPosition(509) ~= 0.5 then
             _data.intercomHotMic = true
         end
@@ -1747,7 +1746,6 @@ function SR.exportRadioF15ESE(_data)
         _data.radios[2].volume = SR.getRadioVolume(0, 1307, { 0.1, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 1308, { 0.1, 1.0 }, false)
 
-        -- https://github.com/DCSSKUNKWORKS/dcs-bios/blob/master/Scripts/DCS-BIOS/lib/F-15E.lua#L1040
         if SR.getButtonPosition(1427) ~= 0.5 then
             _data.intercomHotMic = true
         end


### PR DESCRIPTION
**I could not successfully test this yet! Appreciate any pointers what's missing**

I think the Strike Eagle is missing a hot mic for the intercom. RAZBAMs documentation says:

>Intercom Function Selector Switch. It is spring-loaded to ON position. RAD 
ORIDE overrides the radio comms in favour of the intercom. In ON it provides direct 
communications between crew members. OFF turns off the microphone for intercom 
purposes (but not for radio)
> (Page 78)

I understand from this that setting MIC to ON should have a hot mic for WSO and pilot?

I started working on this and the button is now correctly identified but the Intercom is not switching to hot mic mode like in the Apache. I looked in the Apache code and it should work with these changes. **What am I missing?**

Closes #663
