### PR TITLE
M2000 iff

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -4639,9 +4639,8 @@ function SR.exportRadioM2000C(_data)
         _data.iff.mode3 = 7700
     end
 
-    local mode4On =  SR.round(SR.getButtonPosition(598),0.1)*10
-
-    if mode4On == 2 then
+    local mode4On = SR.getButtonPosition(390)
+    if mode4On == 1 then
         _data.iff.mode4 = true
     else
         _data.iff.mode4 = false

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -4577,8 +4577,11 @@ function SR.exportRadioM2000C(_data)
 
     local iffIdent =  SR.getButtonPosition(383) -- -1 is off 0 or more is on
 
-    -- No power switch - always on
-    _data.iff.status = 1 -- NORMAL
+    -- Power switch
+    local masterIFF = SR.getSelectorPosition(392, 0.25)
+    if masterIFF >= 2 then
+        _data.iff.status = 1 -- NORMAL
+    end
 
     if iffIdent == 1 then
         _data.iff.status = 2 -- IDENT (BLINKY THING)

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -4575,7 +4575,6 @@ function SR.exportRadioM2000C(_data)
     _data.iff = {status=0,mode1=0,mode3=0,mode4=false,control=0,expansion=false}
 
 
-    local iffIdent =  SR.getButtonPosition(383) -- -1 is off 0 or more is on
 
     -- Power switch
     local masterIFF = SR.getSelectorPosition(392, 0.25)
@@ -4583,7 +4582,9 @@ function SR.exportRadioM2000C(_data)
         _data.iff.status = 1 -- NORMAL
     end
 
-    if iffIdent == 1 then
+    --IFF IDENT/MIC blinking
+    local iffIdent =  SR.getButtonPosition(383) -- -1 is MIC, 0 is OUT(OFF), 1 is IDENT
+    if iffIdent == 1 or (iffIdent == -1 and (GREEN_ptt or RED_ptt)) then
         _data.iff.status = 2 -- IDENT (BLINKY THING)
     end
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -4634,7 +4634,7 @@ function SR.exportRadioM2000C(_data)
 
     if mode3On == 0 then
         _data.iff.mode3 = -1
-    elseif iffPower == 4 then
+    elseif masterIFF == 3 then
         -- EMERG SETTING 7770
         _data.iff.mode3 = 7700
     end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -4603,7 +4603,7 @@ function SR.exportRadioM2000C(_data)
 
     _data.iff.mode1 = mode1Digit1+mode1Digit2
 
-    if mode1On ~= 0 then
+    if mode1On == 0 then
         _data.iff.mode1 = -1
     end
 
@@ -4632,7 +4632,7 @@ function SR.exportRadioM2000C(_data)
 
     _data.iff.mode3 = mode3Digit1+mode3Digit2+mode3Digit3+mode3Digit4
 
-    if mode3On ~= 0 then
+    if mode3On == 0 then
         _data.iff.mode3 = -1
     elseif iffPower == 4 then
         -- EMERG SETTING 7770


### PR DESCRIPTION
Fixes : 
 - IFF Switchs mode 1/2/3/C are inverted (down/out should be OFF)
 - MIC ident position to blink contacts when PTT pressed (will be implemented in module in november DCS OB update)

Adds:
 - Master IFF switch (N for normal operation, EMERG for emergency preset)
 - Mode 4 switch
 
