### PR TITLE
Remove seat hardcode that prevents front seat volume controls from working

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -1995,8 +1995,6 @@ function SR.exportRadioF15ESE(_data)
 
     local _seat = SR.lastKnownSeat
 
-    _seat = 1
-
     if _seat == 0 then
         _data.radios[2].volume = SR.getRadioVolume(0, 282, { 0.0, 1.0 }, false)
         _data.radios[3].volume = SR.getRadioVolume(0, 283, { 0.0, 1.0 }, false)


### PR DESCRIPTION
removed seat hardcode that was introduced with mode 2 additions that prevents entry into the if statement for the front seat volume position retrieval.