### PR TITLE
Honor channel set in json for EAM

### DIFF
--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
@@ -486,11 +486,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                             channelModel.Max = clientRadio.freqMax;
                             channelModel.Min = clientRadio.freqMin;
                             channelModel.Reload();
-                            clientRadio.channel = -1; //reset channel
 
                             if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.AutoSelectPresetChannel))
                             {
                                 RadioHelper.RadioChannelUp(i);
+                            }
+                            else if (!_clientStateSingleton.ExternalAWACSModeConnected)
+                            {
+                                // Only reset channels if the user is not using the AWACS panel.
+                                // Otherwise, keep whatever channel they preset in the json.
+                                clientRadio.channel = -1; //reset channel
                             }
                         }
                         else

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
@@ -486,16 +486,23 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
                             channelModel.Max = clientRadio.freqMax;
                             channelModel.Min = clientRadio.freqMin;
                             channelModel.Reload();
+                            var preselectedChannel = clientRadio.channel;
+
+                            clientRadio.channel = -1; //reset channel
 
                             if (_globalSettings.ProfileSettingsStore.GetClientSettingBool(ProfileSettingsKeys.AutoSelectPresetChannel))
                             {
                                 RadioHelper.RadioChannelUp(i);
                             }
-                            else if (!_clientStateSingleton.ExternalAWACSModeConnected)
+                            else if (_clientStateSingleton.ExternalAWACSModeConnected)
                             {
-                                // Only reset channels if the user is not using the AWACS panel.
-                                // Otherwise, keep whatever channel they preset in the json.
-                                clientRadio.channel = -1; //reset channel
+                                if (preselectedChannel != -1)
+                                {
+                                    // Keep whatever channel they preset in the json when in EAM mode.
+                                    channelModel.SelectedPresetChannel = channelModel.PresetChannels[preselectedChannel - 1];
+                                    RadioHelper.SelectRadioChannel(channelModel.SelectedPresetChannel, i);
+                                }
+                                
                             }
                         }
                         else

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
@@ -168,7 +168,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
 
             // Force an immediate update of radio information
             _clientStateSingleton.LastSent = 0;
-
+            _clientStateSingleton.DcsPlayerRadioInfo.LastUpdate = DateTime.Now.Ticks;
             Task.Factory.StartNew(() =>
             {
                 Logger.Debug("Starting external AWACS mode loop");


### PR DESCRIPTION
Note that if the user has _auto select **first** channel_ set, it will still honor than.

When on a plane, it will clear the preselected channel.