### PR TITLE
fix: update uhf trap-137b radio id from 7 to 8

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -5560,7 +5560,7 @@ function SR.exportRadioF1CE(_data)
     end
 
     _data.radios[3].name = "UHF TRAP-137B"
-    _data.radios[3].freq = SR.getRadioFrequency(7)
+    _data.radios[3].freq = SR.getRadioFrequency(8)
     _data.radios[3].modulation = 0
     _data.radios[3].volume = SR.getRadioVolume(0, 314,{0.0,1.0},false)
     _data.radios[3].volMode = 0
@@ -5663,7 +5663,7 @@ function SR.exportRadioF1BE(_data)
 
 
     _data.radios[3].name = "UHF TRAP-137B"
-    _data.radios[3].freq = SR.getRadioFrequency(7)
+    _data.radios[3].freq = SR.getRadioFrequency(8)
     _data.radios[3].modulation = 0
     _data.radios[3].volMode = 0
     _data.radios[3].channel = SR.getNonStandardSpinner(348, {[0.000]= "1", [0.050]= "2",[0.100]= "3",[0.150]= "4",[0.200]= "5",[0.250]= "6",[0.300]= "7",[0.350]= "8",[0.400]= "9",[0.450]= "10",[0.500]= "11",[0.550]= "12",[0.600]= "13",[0.650]= "14",[0.700]= "15",[0.750]= "16",[0.800]= "17",[0.850]= "18",[0.900]= "19",[0.950]= "20"},0.05,3)


### PR DESCRIPTION
After patch [2.9.3.51704](https://www.digitalcombatsimulator.com/en/news/changelog/stable/2.9.3.51704/), it looks like `UHF TRAP-137B`'s device ID was incremented from `7` to `8`.

This small PR updates the Mirage to use the new ID.