### PR TITLE
Radio calculator Unit Tests

### DIFF
--- a/DCS-SR-Common/DCSState/DcsLatLngPosition.cs
+++ b/DCS-SR-Common/DCSState/DcsLatLngPosition.cs
@@ -12,6 +12,19 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState
         public double lng;
         public double alt;
 
+        public DCSLatLngPosition()
+        {
+            // Null constructor. Is dangerous.
+            this.lat = 0; this.lng = 0; this.alt = 0;
+        }
+        
+        public DCSLatLngPosition(double lat, double lng, double alt)
+        {
+            this.lat = lat;
+            this.lng = lng;
+            this.alt = alt;
+        }
+
         public bool isValid()
         {
             return lat != 0 && lng != 0;

--- a/DCS-SR-Common/Helpers/RadioCalculator.cs
+++ b/DCS-SR-Common/Helpers/RadioCalculator.cs
@@ -56,11 +56,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
             return FriisMaximumTransmissionRange(frequency) > distance;
         }
 
-        public static double DegreeToRadian(double angle)
-        {
-            return Math.PI * angle / 180.0;
-        }
-
         public static double CalculateDistanceHaversine(DCSLatLngPosition myLatLng, DCSLatLngPosition clientLatLng)
         {
             if (myLatLng.lat == clientLatLng.lat || myLatLng.lng == clientLatLng.lng)
@@ -84,6 +79,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
             return Math.Abs(PythagDistance(d, myLatLng.alt - clientLatLng.alt));
         }
 
+        private static double DegreeToRadian(double angle)
+        {
+            return Math.PI * angle / 180.0;
+        }
+        
         //we have haversine great circle distance - but as they're aircraft we need to offset for height as that gives the real distance
         private static double PythagDistance(double distance, double height)
         {
@@ -96,8 +96,6 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common
 
             //distance^2 and height^2 
             return Math.Sqrt((distance * distance) + (height * height));
-
         }
-      
     }
 }

--- a/DCS-SR-CommonTests/DCS-SR-CommonTests.csproj
+++ b/DCS-SR-CommonTests/DCS-SR-CommonTests.csproj
@@ -71,6 +71,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Helpers\ConversionHelpersTests.cs" />
+    <Compile Include="Helpers\RadioCalculatorTests.cs" />
     <Compile Include="Network\UDPVoicePacketTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/DCS-SR-CommonTests/Helpers/RadioCalculatorTests.cs
+++ b/DCS-SR-CommonTests/Helpers/RadioCalculatorTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.DCSState;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Tests.RadioCalculatorTests
+{
+    [TestClass()]
+    public class TestFreqencyToWaveLength
+    {
+        //Frequency to Wavelength tests
+        //These are generally for verifying that our constants dont change.
+        [TestMethod()]
+        public void ConstantVerification1Hz()
+        {
+            // 1 hz should return the speed of light constant.
+            double wavelength = RadioCalculator.FrequencyToWaveLength(1);
+        
+            Assert.AreEqual(299792458, wavelength);
+        }
+    
+        [TestMethod()]
+        public void ConstantVerification1MHz()
+        {
+            double wavelength = RadioCalculator.FrequencyToWaveLength(1000000);
+        
+            Assert.AreEqual(299.792458, wavelength);
+        }
+    
+        [TestMethod()]
+        public void ConstantVerification1GHz()
+        {
+            // 1 hz should return the speed of light constant.
+            double wavelength = RadioCalculator.FrequencyToWaveLength(1000000000);
+        
+            Assert.AreEqual(0.299792458, wavelength);
+        }
+    
+        [TestMethod()]
+        public void ConstantVerification123MHz()
+        {
+            // 1 hz should return the speed of light constant.
+            double wavelength = RadioCalculator.FrequencyToWaveLength(123000000);
+        
+            Assert.AreEqual(2.437337056910569, wavelength);
+        }
+    }
+
+    /*
+    [TestClass()]
+    public class TestFriisTransmissionReceivedPower
+    {
+        // Not implemented due to 0 usages at time of writing.
+    }
+    */
+    
+    [TestClass()]
+    public class TestFriisMaximumTransmissionRange
+    {
+        [TestMethod()]
+        public void ConstantVerification1Hz()
+        {
+            // Rounded to 8 decimal places because of Pi being used.
+            double range = Math.Round(RadioCalculator.FriisMaximumTransmissionRange(1), 8);
+            Assert.AreEqual(94975336055448.6, range);
+        }
+        [TestMethod()]
+        public void ConstantVerification1MHz()
+        {
+            // Rounded to 8 decimal places because of Pi being used.
+            double range = Math.Round(RadioCalculator.FriisMaximumTransmissionRange(1000000), 8);
+            Assert.AreEqual(94975336.0554486, range);
+        }
+        [TestMethod()]
+        public void ConstantVerification1GHz()
+        {
+            // Rounded to 8 decimal places because of Pi being used.
+            double range = Math.Round(RadioCalculator.FriisMaximumTransmissionRange(1000000000), 8);
+            Assert.AreEqual(94975.33605545, range);
+        }
+        [TestMethod()]
+        public void ConstantVerification123MHz()
+        {
+            // Rounded to 8 decimal places because of Pi being used.
+            double range = Math.Round(RadioCalculator.FriisMaximumTransmissionRange(123000000), 8);
+            Assert.AreEqual(772157.20370283, range);
+        }
+    }
+
+    [TestClass()]
+    public class TestCanHearTransmission
+    {
+        [TestMethod()]
+        public void OneKilometerAt1MHz()
+        {
+            bool canHear = RadioCalculator.CanHearTransmission(1000, 1000000);
+            
+            Assert.IsTrue(canHear);
+        }
+        [TestMethod()]
+        public void OneHundredKilometersAt1MHz()
+        {
+            bool canHear = RadioCalculator.CanHearTransmission(100000, 1000000);
+            
+            Assert.IsTrue(canHear);
+        }
+        
+        [TestMethod()]
+        public void OneMillionKilometersAt123MHz()
+        {
+            bool canHear = RadioCalculator.CanHearTransmission(1000000, 1000000);
+            
+            Assert.IsTrue(canHear);
+        }
+        
+        [TestMethod()]
+        public void ExactCheckAt123MHz()
+        {
+            bool canHear = RadioCalculator.CanHearTransmission(772158, 123000000);
+            
+            Assert.IsFalse(canHear);
+        }
+    }
+
+
+    [TestClass()]
+    public class TestCalculateDistanceHaversine
+    {
+        [TestMethod()]
+        public void DoubleInstantiatedButNeverDefined()
+        {
+            var position = new DCSLatLngPosition();
+            double distance = RadioCalculator.CalculateDistanceHaversine(position, position);
+
+            Assert.AreEqual(0, distance);
+        }
+        
+        [TestMethod()]
+        public void SingleInstantiatedButNeverDefined()
+        {
+            var positionA = new DCSLatLngPosition();
+            var positionB = new DCSLatLngPosition(100, 100, 100);
+            double distance = RadioCalculator.CalculateDistanceHaversine(positionA, positionB);
+
+            // Really not sure how it should handle this.
+            Assert.Inconclusive("Possibly needs error handling");
+        }
+
+        [TestMethod()]
+        public void SameLocationCheck()
+        {
+            // The transmission is coming from inside the jet... *horror movie sting*
+            var position = new DCSLatLngPosition(100, 100, 100);
+            double roundedDistance = RadioCalculator.CalculateDistanceHaversine(position, position);
+
+            Assert.AreEqual(0, roundedDistance);
+        }
+        
+        [TestMethod()]
+        public void KnownDistanceCheck()
+        {
+            // The transmission is coming from inside the jet... *horror movie sting*
+            var positionA = new DCSLatLngPosition(100, 100, 100);
+            var positionB = new DCSLatLngPosition(101, 101, 101);
+            double distance = Math.Round(RadioCalculator.CalculateDistanceHaversine(positionA, positionB), 8);
+
+            Assert.AreEqual(113022.10863318, distance);
+        }
+    }
+}


### PR DESCRIPTION
Added unit tests for DCS-SR-Common -> RadioCalculator.cs
A method was made private in RadioCalculator.cs as it was only internally referenced.
A constructor was added to DcsLatLngPosition.cs to facilitate testing.