### PR TITLE
Fix SERVER_SRS_HOST_AUTO (Attempt 2)

### DIFF
--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -42,6 +42,7 @@ SRSAuto.unicast = true
 local HOST_PLAYER_ID = 1
 
 SRSAuto.MESSAGE_PREFIX = "SRS Running @ " -- DO NOT MODIFY!!!
+SRSAuto.MESSAGE_PREFIX_PORT = "SRS Running on " -- DO NOT MODIFY!!!
 
 package.path  = package.path..";.\\LuaSocket\\?.lua;"
 package.cpath = package.cpath..";.\\LuaSocket\\?.dll;"
@@ -67,16 +68,24 @@ function SRSAuto.log(str)
     end
 end
 
+function SRSAuto.sendAutoConnectMessage(id)
+    SRSAuto.log(string.format("Sending auto connect message to player %d on connect ", id))
+    if SRSAuto.SERVER_SRS_HOST_AUTO then
+        net.send_chat_to(SRSAuto.MESSAGE_PREFIX_PORT .. SRSAuto.SERVER_SRS_PORT, id)
+    else    
+        net.send_chat_to(SRSAuto.MESSAGE_PREFIX .. SRSAuto.SERVER_SRS_HOST .. ":" .. SRSAuto.SERVER_SRS_PORT, id)
+    end
+end
+
 -- Register callbacks --
 
 SRSAuto.onPlayerConnect = function(id)
 	if not DCS.isServer() then
         return
     end
-	if SRSAuto.SERVER_SEND_AUTO_CONNECT and id ~= HOST_PLAYER_ID then
-        SRSAuto.log(string.format("Sending auto connect message to player %d on connect ", id))
-		net.send_chat_to(string.format(SRSAuto.MESSAGE_PREFIX .. "%s", SRSAuto.SERVER_SRS_HOST..":"..SRSAuto.SERVER_SRS_PORT), id)
-	end
+    if SRSAuto.SERVER_SEND_AUTO_CONNECT and id ~= HOST_PLAYER_ID then
+        sendAutoConnectMessage(id)
+    end
 end
 
 SRSAuto.onPlayerChangeSlot = function(id)
@@ -84,9 +93,8 @@ SRSAuto.onPlayerChangeSlot = function(id)
         return
     end
     if SRSAuto.SERVER_SEND_AUTO_CONNECT and id ~= HOST_PLAYER_ID then
-        SRSAuto.log(string.format("Sending auto connect message to player %d on switch ", id))
-        net.send_chat_to(string.format(SRSAuto.MESSAGE_PREFIX .. "%s", SRSAuto.SERVER_SRS_HOST..":"..SRSAuto.SERVER_SRS_PORT), id)
-   end
+        sendAutoConnectMessage(id)
+    end
 end
 
 SRSAuto.trimStr = function(_str)
@@ -119,24 +127,6 @@ end
 local _lastSent = 0
 
 SRSAuto.onMissionLoadBegin = function()
-	local _status, _result = pcall( function()
-		if SRSAuto.SERVER_SRS_HOST_AUTO then
-			local ipLookupUrl = "https://ipv4.icanhazip.com"
-			local T, code, headers, status = socket.http.request(ipLookupUrl)
-
-			if T == nil or code == nil or code < 200 or code >= 300 then
-			   if code == nil then code = "??" end
-			   SRSAuto.log("Failed to lookup IP from "..ipLookupUrl..". Http Status: " .. code)
-			else
-				SRSAuto.SERVER_SRS_HOST = T
-				SRSAuto.log("SET IP automatically to "..SRSAuto.SERVER_SRS_HOST)
-			end
-		end
-	end)
-	
-	if not _status then
-		SRSAuto.log('ERROR: ' .. _result)
-	end
 end
 
 SRSAuto.onSimulationFrame = function()

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -101,9 +101,9 @@ SRS.sendUpdate = function(playerID)
 	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 9087))
 end
 
-SRS.MESSAGE_PATTERN_OLDER = "This server is running SRS on - (%d+%.%d+%.%d+%.%d+:%d+)" -- DO NOT MODIFY!!!
-SRS.MESSAGE_PATTERN_OLD = "SRS Running @ (%d+%.%d+%.%d+%.%d+:%d+)"                     -- DO NOT MODIFY!!!
-SRS.MESSAGE_PATTERN = "SRS Running on (%d+)"                                           -- DO NOT MODIFY!!!
+SRS.MESSAGE_PATTERN_OLDER = "This server is running SRS on - (%d+%.%d+%.%d+%.%d+:?%d*)" -- DO NOT MODIFY!!!
+SRS.MESSAGE_PATTERN_OLD = "SRS Running @ (%d+%.%d+%.%d+%.%d+:?%d*)"                     -- DO NOT MODIFY!!!
+SRS.MESSAGE_PATTERN = "SRS Running on (%d+)"                                            -- DO NOT MODIFY!!!
 
 function string.startsWith(string, prefix)
     return string.sub(string, 1, string.len(prefix)) == prefix


### PR DESCRIPTION
Original PR: #676 This fixes the SERVER_SRS_HOST_AUTO by making use of net.get_server_host() on the client-side.

@ciribob  MESSAGE_PATTERN_OLD & MESSAGE_PATTERN_OLDER should now match to obtain the host where no `:PORT` has been specified.

I've updated the auto-connect message to only send the port if SERVER_SRS_HOST_AUTO is enabled, otherwise it uses the original message with SERVER_SRS_HOST and SERVER_SRS_PORT.

I've removed the isAutoConnectMessage function in favour of regex matching. We try to get the port from the message, if this fails, fallback to matching on IP and Port.