### PR TITLE
Update DCS-SimpleRadioStandalone.lua to support Customer Radios

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -292,6 +292,12 @@ function SR.exporter()
             iff = {status=0,mode1=0,mode2=-1,mode3=0,mode4=0,control=0,expansion=false,mic=-1}
         }
 
+        -- Allows for custom radio's using the DCS-Plugin scheme.
+        local aircraftExporter = SR.exporters["CA"]
+        if aircraftExporter then
+            _update = aircraftExporter(_update)
+        end
+        
         local _latLng,_point = SR.exportCameraLocation()
 
         _update.latLng = _latLng


### PR DESCRIPTION
Summary: Change leverages the existing plugin system to allow for over writing the Combined Arms radio data set.

Reason for change: Game Master radio configurations currently rely on modifying the whole DCS-SimpleRadioStandalone.lua file. This means that every SRS patch for a new aircraft, the radios are reverted until manual file updates are done. With this change, a Combined Arms Autoload.lua would be unaffected by changes to the main lua file.