### PR TITLE
TX Inhibit keybind

### DIFF
--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -918,9 +918,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             var bindStates = new List<InputBindState>();
             var currentInputProfile = _globalSettings.ProfileSettingsStore.GetCurrentInputProfile();
 
-            //REMEMBER TO UPDATE THIS WHEN NEW BINDINGS ARE ADDED
-            //MIN + MAX bind numbers
-            for (int i = (int)InputBinding.Intercom; i <= (int)InputBinding.AwacsOverlayToggle; i++)
+            
+            for (int i = InputBindings.FirstIndex; i <= InputBindings.LastIndex; i++)
             {
                 if (!currentInputProfile.ContainsKey((InputBinding)i))
                 {

--- a/DCS-SR-Client/Properties/Resources.Designer.cs
+++ b/DCS-SR-Client/Properties/Resources.Designer.cs
@@ -3082,6 +3082,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TX Inhibit.
+        /// </summary>
+        public static string TXInhibit {
+            get {
+                return ResourceManager.GetString("TXInhibit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UHF Effect Volume.
         /// </summary>
         public static string UHFEffectVolume {

--- a/DCS-SR-Client/Properties/Resources.resx
+++ b/DCS-SR-Client/Properties/Resources.resx
@@ -1091,6 +1091,9 @@ Requires Tx or Rx Effects On</value>
   <data name="ToolTipTransponderMode4" xml:space="preserve">
     <value>Mode 4</value>
   </data>
+  <data name="TXInhibit" xml:space="preserve">
+    <value>TX Inhibit</value>
+  </data>
   <data name="UHFEffectVolume" xml:space="preserve">
     <value>UHF Effect Volume</value>
   </data>

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -216,7 +216,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         ModifierIntercomPTT = 236,
 
         AwacsOverlayToggle = 137,
-        ModifierAwacsOverlayToggle = 237
+        ModifierAwacsOverlayToggle = 237,
+
+        TXInhibit = 138,
+        ModifierTXInhibit = 238,
     }
 
 

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -222,6 +222,15 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         ModifierTXInhibit = 238,
     }
 
+    //REMEMBER TO UPDATE THIS WHEN NEW BINDINGS ARE ADDED
+    //MIN + MAX bind numbers
+    public class InputBindings
+    {
+        public static int FirstIndex { get { return (int)InputBinding.Intercom; } }
+        public static int LastIndex { get { return (int)InputBinding.TXInhibit; } }
+    }
+    
+
 
     public class GlobalSettingsStore
     {

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -384,6 +384,7 @@
                                 <RowDefinition />
                                 <RowDefinition />
                                 <RowDefinition />
+                                <RowDefinition />
                             </Grid.RowDefinitions>
 
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml
@@ -624,8 +624,11 @@
                                                            Grid.ColumnSpan="5"
                                                            ControlInputBinding="{x:Static settings:InputBinding.AwacsOverlayToggle}"
                                                            InputName="AWACS Overlay Toggle" />
-
-
+                            <local:InputBindingControl x:Name="TXInhibit"
+                                                           Grid.Row="39"
+                                                           Grid.ColumnSpan="5"
+                                                           ControlInputBinding="{x:Static settings:InputBinding.TXInhibit}"
+                                                           InputName="TX Inhibit" />
                         </Grid>
 
                     </StackPanel>

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -585,6 +585,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             RadioVolumeUp.LoadInputSettings();
             RadioVolumeDown.LoadInputSettings();
             AwacsOverlayToggle.LoadInputSettings();
+            TXInhibit.LoadInputSettings();
         }
 
         private void ReloadRadioAudioChannelSettings()

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -502,6 +502,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             RadioVolumeDown.InputName = Properties.Resources.InputRadioVolumeDown;
             RadioVolumeDown.ControlInputBinding = InputBinding.RadioVolumeDown;
             RadioVolumeDown.InputDeviceManager = InputManager;
+
+            TXInhibit.InputName = Properties.Resources.TXInhibit;
+            TXInhibit.ControlInputBinding = InputBinding.TXInhibit;
+            TXInhibit.InputDeviceManager = InputManager;
         }
 
         private void OnProfileDropDownChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
Use case: my setup is to have my regular PTT binds for radios (4-way switch) for SRS, and modifier + PTT for the in-game radio menu.

This creates a conflict of sorts where I will "click" the radio every time I bring up the in-game radio menu.

This bind allows me to make SRS aware of this in-game modifier, and will prevent PTT for as long as it's pressed.