### PR TITLE
Better Combined Arms detection and fix for controlled vehicles getting FC3 Radios

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -73,7 +73,7 @@ SRS.sendUpdate = function(playerID)
         side = 0,
         seat = 0,
 		slotNum = 0,
-		slotString = "?",
+		slotName = "?",
     }
 
     _update.name = net.get_player_info(playerID, "name" )
@@ -101,15 +101,15 @@ SRS.sendUpdate = function(playerID)
 		
 		-- Deal with the special slots added by Combined Arms and Spectators
 		if string.find(rawSlot, 'artillery_commander') then
-			_update.slotString = "artillery_commander"
+			_update.slotName = "Ground Commander"
 		elseif string.find(rawSlot, 'instructor') then
-			_update.slotString = "Game Master" --"Game Master"
+			_update.slotName = "Game Master" --"Game Master"
 		elseif string.find(rawSlot, 'forward_observer') then
-			_update.slotString = "JTAC" -- "JTAC"
+			_update.slotName = "JTAC" -- "JTAC"
 		elseif string.find(rawSlot, 'observer') then
-			_update.slotString = "observer"
+			_update.slotName = "Observer"
 		else
-			_update.slotString = "??"
+			_update.slotName = "Spectator"
 		end
 
 	end

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -66,6 +66,16 @@ SRS.onSimulationFrame = function()
 
 end
 
+-- Slot Data Examples:
+-- 3271
+-- 12122
+-- 13312_2
+-- 13312_3
+-- forward_observer_blue_6
+-- artillery_commander_blue_1
+-- instructor_red_1
+-- Spectators are Null
+
 SRS.sendUpdate = function(playerID)
   
     local _update = {

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -141,7 +141,7 @@ SRS.sendUpdate = function(playerID)
 	end
 
 	local _jsonUpdate = SRS.JSON:encode(_update).." \n"
-    --SRS.log("Update -  Slot  ID:"..playerID.." Name: ".._update.name.." Side: ".._update.side.." Seat: ".._update.seat.." slot #: ".._update.slotNum.." slot string: ".._update.slotString)
+    --SRS.log("Update -  Slot  ID:"..playerID.." Name: ".._update.name.." Side: ".._update.side.." Seat: ".._update.seat.." slot #: ".._update.slotNum.." slotName: ".._update.slotName)
 	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 5068))
 	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 9087))
 end

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -108,6 +108,8 @@ SRS.sendUpdate = function(playerID)
 			_update.slotString = "forward_observer" -- "JTAC"
 		elseif string.find(rawSlot, 'observer') then
 			_update.slotString = "observer"
+		else
+			_update.slotString = "??"
 		end
 
 	end

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -87,11 +87,11 @@ SRS.sendUpdate = function(playerID)
     }
 
     _update.name = net.get_player_info(playerID, "name" )
-	_update.side = net.get_player_info(playerID,"side")
+	_update.side = net.get_player_info(playerID, "side")
 
-	local rawSlot =  net.get_player_info(playerID,"slot")
+	local rawSlot =  net.get_player_info(playerID, "slot")
 
-	if rawSlot and rawSlot ~= '' then 
+	if rawSlot and rawSlot ~= '' then
 		slot = tostring(rawSlot)
 	    
 	    -- Slot 2744_2 -- backseat slot is Unit ID  _2 

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -96,7 +96,7 @@ SRS.sendUpdate = function(playerID)
 	end
 
 	local _jsonUpdate = SRS.JSON:encode(_update).." \n"
-    --SRS.log("Update -  Slot  ID:"..playerID.." Name: ".._update.name.." Side: ".._update.side)
+    --SRS.log("Update -  Slot  ID:"..playerID.." Name: ".._update.name.." Side: ".._update.side.." Seat: ".._update.seat)
 	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 5068))
 	socket.try(SRS.UDPSendSocket:sendto(_jsonUpdate, "127.0.0.1", 9087))
 end

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -103,9 +103,9 @@ SRS.sendUpdate = function(playerID)
 		if string.find(rawSlot, 'artillery_commander') then
 			_update.slotString = "artillery_commander"
 		elseif string.find(rawSlot, 'instructor') then
-			_update.slotString = "instructor" --"Game Master"
+			_update.slotString = "Game Master" --"Game Master"
 		elseif string.find(rawSlot, 'forward_observer') then
-			_update.slotString = "forward_observer" -- "JTAC"
+			_update.slotString = "JTAC" -- "JTAC"
 		elseif string.find(rawSlot, 'observer') then
 			_update.slotString = "observer"
 		else

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -19,7 +19,7 @@ SR.unicast = true --DONT CHANGE THIS
 SR.lastKnownPos = { x = 0, y = 0, z = 0 }
 SR.lastKnownSeat = 0
 SR.lastKnownSlotNum = 0
-SR.lastKnownSlotString = "?"
+SR.lastKnownSlotName = "?"
 
 SR.MIDS_FREQ = 1030.0 * 1000000 -- Start at UHF 300
 SR.MIDS_FREQ_SEPARATION = 1.0 * 100000 -- 0.1 MHZ between MIDS channels
@@ -308,13 +308,12 @@ function SR.exporter()
             iff = {status=0,mode1=0,mode2=-1,mode3=0,mode4=0,control=0,expansion=false,mic=-1}
         }
 
-        _update.unit = SR.lastKnownSlotString
-
         -- Allows for custom radio's using the DCS-Plugin scheme.
         -- Combined Arms Overrides spectators.
         local aircraftExporter = SR.exporters["CA"]
         if aircraftExporter then
             _update = aircraftExporter(_update)
+            _update.unit = SR.lastKnownSlotName
         end
         
         local _latLng,_point = SR.exportCameraLocation()
@@ -370,9 +369,9 @@ function SR.readSeatSocket()
         if _decoded then
             SR.lastKnownSeat = _decoded.seat
             SR.lastKnownSlotNum = _decoded.slotNum
-            SR.lastKnownSlotString = _decoded.slotString       
+            SR.lastKnownSlotName = _decoded.slotString       
 
-            --SR.log("lastKnownSeat: "..SR.lastKnownSeat.." lastKnownSlotNum: "..SR.lastKnownSlotNum.." lastKnownSlotString: "..SR.lastKnownSlotString)
+            --SR.log("lastKnownSeat: "..SR.lastKnownSeat.." lastKnownSlotNum: "..SR.lastKnownSlotNum.." lastKnownSlotName: "..SR.lastKnownSlotName)
         end
 
     end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -176,8 +176,7 @@ function SR.exporter()
         end
     end
 
-    -- TODO: Validate the Slot Check Here works as predicted.
-    if _data ~= nil and (SR.lastKnownSlotNum > -1) then
+    if _data ~= nil and SR.lastKnownSlotNum ~=0 then
 
         _update = {
             name = "",
@@ -220,7 +219,7 @@ function SR.exporter()
 
         _update.iff = {status=0,mode1=0,mode2=-1,mode3=0,mode4=0,control=1,expansion=false,mic=-1}
 
-     --   SR.log(_update.unit.."\n\n")
+        --SR.log(_update.unit.."\n")
 
         local aircraftExporter = SR.exporters[_update.unit]
 
@@ -369,7 +368,7 @@ function SR.readSeatSocket()
         if _decoded then
             SR.lastKnownSeat = _decoded.seat
             SR.lastKnownSlotNum = _decoded.slotNum
-            SR.lastKnownSlotName = _decoded.slotName       
+            SR.lastKnownSlotName = _decoded.slotName
 
             --SR.log("lastKnownSeat: "..SR.lastKnownSeat.." lastKnownSlotNum: "..SR.lastKnownSlotNum.." lastKnownSlotName: "..SR.lastKnownSlotName)
         end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -369,7 +369,7 @@ function SR.readSeatSocket()
         if _decoded then
             SR.lastKnownSeat = _decoded.seat
             SR.lastKnownSlotNum = _decoded.slotNum
-            SR.lastKnownSlotName = _decoded.slotString       
+            SR.lastKnownSlotName = _decoded.slotName       
 
             --SR.log("lastKnownSeat: "..SR.lastKnownSeat.." lastKnownSlotNum: "..SR.lastKnownSlotNum.." lastKnownSlotName: "..SR.lastKnownSlotName)
         end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -18,6 +18,8 @@ SR.unicast = true --DONT CHANGE THIS
 
 SR.lastKnownPos = { x = 0, y = 0, z = 0 }
 SR.lastKnownSeat = 0
+SR.lastKnownSlotNum = 0
+SR.lastKnownSlotString = "?"
 
 SR.MIDS_FREQ = 1030.0 * 1000000 -- Start at UHF 300
 SR.MIDS_FREQ_SEPARATION = 1.0 * 100000 -- 0.1 MHZ between MIDS channels
@@ -174,7 +176,8 @@ function SR.exporter()
         end
     end
 
-    if _data ~= nil then
+    -- TODO: Validate the Slot Check Here works as predicted.
+    if _data ~= nil and (SR.lastKnownSlotNum > -1) then
 
         _update = {
             name = "",
@@ -276,11 +279,11 @@ function SR.exporter()
         _lastUnitId = _update.unitId
         _lastUnitType = _data.Name
     else
-        --Ground Commander or spectator
+        -- spectator
         _update = {
             name = "Unknown",
             ambient = {vol = 0.0, abType = ''},
-            unit = "CA",
+            unit = "Spectator",
             selected = 1,
             ptt = false,
             capabilities = { dcsPtt = false, dcsIFF = false, dcsRadioSwitch = false, intercomHotMic = false, desc = "" },
@@ -305,7 +308,10 @@ function SR.exporter()
             iff = {status=0,mode1=0,mode2=-1,mode3=0,mode4=0,control=0,expansion=false,mic=-1}
         }
 
+        _update.unit = SR.lastKnownSlotString
+
         -- Allows for custom radio's using the DCS-Plugin scheme.
+        -- Combined Arms Overrides spectators.
         local aircraftExporter = SR.exporters["CA"]
         if aircraftExporter then
             _update = aircraftExporter(_update)
@@ -363,7 +369,10 @@ function SR.readSeatSocket()
 
         if _decoded then
             SR.lastKnownSeat = _decoded.seat
-            --SR.log("lastKnownSeat "..SR.lastKnownSeat)
+            SR.lastKnownSlotNum = _decoded.slotNum
+            SR.lastKnownSlotString = _decoded.slotString       
+
+            --SR.log("lastKnownSeat: "..SR.lastKnownSeat.." lastKnownSlotNum: "..SR.lastKnownSlotNum.." lastKnownSlotString: "..SR.lastKnownSlotString)
         end
 
     end


### PR DESCRIPTION
Slot detection is achieved using the changes in `SRSGameGUI.lua`. The get_player_info call was already being done there and returns a string with the data needed to determine more complex slot types. We parse that and send it.

The export lua, `DCS-SimpleRadioStandalone.lua`, decodes the Slot data using the existing mechanism used for determining Seats in multi-crew vehicles. It then uses the `LastKnownSlotID` to check if our unit data is valid Unit Data. The Slot name is then used to override the Vehicle name. The Default non-aircraft name has been amended to being Spectator.