### PR TITLE
Client settings as properties

### DIFF
--- a/DCS-SR-Client/App.xaml.cs
+++ b/DCS-SR-Client/App.xaml.cs
@@ -79,7 +79,7 @@ namespace DCS_SR_Client
                     }
                 }
 
-                if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.AllowMultipleInstances) || allowMultiple)
+                if (GlobalSettingsStore.Instance.AllowMultipleInstances || allowMultiple)
                 {
                     Logger.Warn("Another SRS instance is already running, allowing multiple instances due to config setting");
                 }
@@ -118,7 +118,7 @@ namespace DCS_SR_Client
 
         private void RequireAdmin()
         {
-            if (!GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RequireAdmin))
+            if (!GlobalSettingsStore.Instance.RequireAdmin)
             {
                 return;
             }
@@ -126,7 +126,7 @@ namespace DCS_SR_Client
             WindowsPrincipal principal = new WindowsPrincipal(WindowsIdentity.GetCurrent());
             bool hasAdministrativeRight = principal.IsInRole(WindowsBuiltInRole.Administrator);
 
-            if (!hasAdministrativeRight && GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RequireAdmin))
+            if (!hasAdministrativeRight && GlobalSettingsStore.Instance.RequireAdmin)
             {
                 Task.Factory.StartNew(() =>
                 {

--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -345,7 +345,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                         //check for voice before any pre-processing
                         bool voice = true;
 
-                        if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOX))
+                        if (_globalSettings.VOX)
                         {
                             Buffer.BlockCopy(_pcmShort, 0, _pcmBytes, 0, _pcmBytes.Length);
                             voice = DoesFrameContainSpeech(_pcmBytes, _pcmShort);
@@ -386,8 +386,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
 
                             // _beforeWaveFile.Write(pcmBytes, 0, pcmBytes.Length);
 
-                            if (clientAudio != null && (_micWaveOutBuffer != null 
-                                                        || GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio)))
+                            if (clientAudio != null && (_micWaveOutBuffer != null || GlobalSettingsStore.Instance.RecordAudio))
                             {
 
                                 //todo see if we can fix the resample / opus decode
@@ -430,8 +429,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                                         _micWaveOutBuffer.AddSamples(_tempMicOutputBuffer, 0, tempFloat.Length * 4);
                                     }
 
-                                    if (GlobalSettingsStore.Instance.GetClientSettingBool(
-                                        GlobalSettingsKeys.RecordAudio))
+                                    if (GlobalSettingsStore.Instance.RecordAudio)
                                     {
                                         ///TODO cache this to avoid the contant lookup
                                         _audioRecordingManager.AppendPlayerAudio(tempFloat, jitterBufferAudio.ReceivedRadio);
@@ -546,7 +544,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             {
                 SampleRate = SampleRate.Is16kHz,
                 FrameLength = FrameLength.Is20ms,
-                OperatingMode = (OperatingMode)_globalSettings.GetClientSettingInt(GlobalSettingsKeys.VOXMode)
+                OperatingMode = (OperatingMode)_globalSettings.VOXMode
             };
         }
 
@@ -678,7 +676,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             Buffer.BlockCopy(audioFrame,0,tempBuffferFirst20ms,0, MIC_SEGMENT_FRAMES);
             Buffer.BlockCopy(audioFrame, MIC_SEGMENT_FRAMES, tempBuffferSecond20ms, 0, MIC_SEGMENT_FRAMES);
 
-            OperatingMode mode = (OperatingMode)_globalSettings.GetClientSettingInt(GlobalSettingsKeys.VOXMode);
+            OperatingMode mode = (OperatingMode)_globalSettings.VOXMode;
 
             if (_voxDectection.OperatingMode != mode)
             {
@@ -693,7 +691,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
                 //calculate the RMS and see if we're over it
                 //voice run first as it ignores background hums very well
                 double rms = VolumeConversionHelper.CalculateRMS(pcmShort);
-                double min = _globalSettings.GetClientSettingDouble(GlobalSettingsKeys.VOXMinimumDB);
+                double min = _globalSettings.VOXMinimumDB;
 
                 return rms > min;
             }

--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -544,7 +544,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Managers
             {
                 SampleRate = SampleRate.Is16kHz,
                 FrameLength = FrameLength.Is20ms,
-                OperatingMode = (OperatingMode)_globalSettings.VOXMode
+                OperatingMode = _globalSettings.VOXMode
             };
         }
 

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriter.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriter.cs
@@ -80,7 +80,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
             string sanitisedTime = String.Join("-", DateTime.Now.ToLongTimeString().Split(Path.GetInvalidFileNameChars()));
             string filePathBase = $"Recordings\\{sanitisedDate}-{sanitisedTime}";
 
-            var lamePreset = (LAMEPreset)Enum.Parse(typeof(LAMEPreset), GlobalSettingsStore.Instance.RecordingQuality);
+            var lamePreset = GlobalSettingsStore.Instance.RecordingQuality;
 
             for (int i = 0; i < _streams.Count; i++)
             {

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriter.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingLameWriter.cs
@@ -80,8 +80,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
             string sanitisedTime = String.Join("-", DateTime.Now.ToLongTimeString().Split(Path.GetInvalidFileNameChars()));
             string filePathBase = $"Recordings\\{sanitisedDate}-{sanitisedTime}";
 
-            var lamePreset = (LAMEPreset)Enum.Parse(typeof(LAMEPreset),
-                    GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.RecordingQuality).RawValue);
+            var lamePreset = (LAMEPreset)Enum.Parse(typeof(LAMEPreset), GlobalSettingsStore.Instance.RecordingQuality);
 
             for (int i = 0; i < _streams.Count; i++)
             {

--- a/DCS-SR-Client/Audio/Recording/AudioRecordingManager.cs
+++ b/DCS-SR-Client/Audio/Recording/AudioRecordingManager.cs
@@ -235,7 +235,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
 
         public void Start()
         {
-            if (!GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio))
+            if (!GlobalSettingsStore.Instance.RecordAudio)
             {
                 _processThreadDone = true;
                 _logger.Info("Transmission recording disabled");
@@ -276,7 +276,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
  
             _audioRecordingWriter?.Stop();
 
-            if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown))
+            if (GlobalSettingsStore.Instance.SingleFileMixdown)
             {
                 // write single mixed file. create a writer with a single stream source: a mixer
                 // that combines all per-radio streams.
@@ -318,7 +318,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
         public void AppendPlayerAudio(float[] transmission, int radioId)
         {
             //only record if we need too
-            if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio) && !_stop)
+            if (GlobalSettingsStore.Instance.RecordAudio && !_stop)
             {
                 _playerRawQueues[radioId]?.Write(transmission, 0, transmission.Length);
             }
@@ -327,7 +327,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
         public void AppendClientAudio(List<DeJitteredTransmission> mainAudio, List<DeJitteredTransmission> secondaryAudio, int radioId)
         {
             //only record if we need too
-            if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.RecordAudio) && !_stop)
+            if (GlobalSettingsStore.Instance.RecordAudio && !_stop)
             {
                 mainAudio = FilterTransmisions(mainAudio);
                 secondaryAudio = FilterTransmisions(secondaryAudio);
@@ -358,7 +358,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Recording
                     {
                         filteredTransmisions.Add(transmission);
                     }
-                    else if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.DisallowedAudioTone))
+                    else if (GlobalSettingsStore.Instance.DisallowedAudioTone)
                     {
                         DeJitteredTransmission toneTransmission = new DeJitteredTransmission
                         {

--- a/DCS-SR-Client/Audio/Utility/SpeexWrapper.cs
+++ b/DCS-SR-Client/Audio/Utility/SpeexWrapper.cs
@@ -327,13 +327,13 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Audio.Utility
                     //only check settings store every 5 seconds
                     var settingsStore = GlobalSettingsStore.Instance;
 
-                    var agc = settingsStore.GetClientSettingBool(GlobalSettingsKeys.AGC);
-                    var agcTarget = settingsStore.GetClientSetting(GlobalSettingsKeys.AGCTarget).IntValue;
-                    var agcDecrement = settingsStore.GetClientSetting(GlobalSettingsKeys.AGCDecrement).IntValue;
-                    var agcLevelMax = settingsStore.GetClientSetting(GlobalSettingsKeys.AGCLevelMax).IntValue;
+                    bool agc = settingsStore.AGC;
+                    int agcTarget = settingsStore.AGCTarget;
+                    int agcDecrement = settingsStore.AGCDecrement;
+                    int agcLevelMax = settingsStore.AGCLevelMax;
 
-                    var denoise = settingsStore.GetClientSettingBool(GlobalSettingsKeys.Denoise);
-                    var denoiseAttenuation = settingsStore.GetClientSetting(GlobalSettingsKeys.DenoiseAttenuation).IntValue;
+                    bool denoise = settingsStore.Denoise;
+                    int denoiseAttenuation = settingsStore.DenoiseAttenuation;
 
                     //From https://github.com/mumble-voip/mumble/blob/a189969521081565b8bda93d253670370778d471/src/mumble/Settings.cpp
                     //and  https://github.com/mumble-voip/mumble/blob/3ffd9ad3ed18176774d8e1c64a96dffe0de69655/src/mumble/AudioInput.cpp#L605

--- a/DCS-SR-Client/Input/InputDeviceManager.cs
+++ b/DCS-SR-Client/Input/InputDeviceManager.cs
@@ -96,9 +96,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         public void InitDevices()
         {
-            var allowXInput = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AllowXInputController);
+            var allowXInput = _globalSettings.AllowXInputController;
             Logger.Info("Starting Device Search. Expand Search: " +
-            (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.ExpandControls)) +
+            (_globalSettings.ExpandControls) +
             ". Use XInput (for Xbox controllers): " + allowXInput);
 
 
@@ -178,7 +178,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
                     _inputDevices.Add(deviceInstance.InstanceGuid, device);
                 }
-                else if (GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.ExpandControls))
+                else if (GlobalSettingsStore.Instance.ExpandControls)
                 {
                     Logger.Info("Adding (Expanded Devices) ID:" + deviceInstance.ProductGuid + " " +
                                 deviceInstance.ProductName.Trim().Replace("\0", ""));

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncHandler.cs
@@ -277,7 +277,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
 
             if (newAircraft)
             {
-                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoSelectSettingsProfile))
+                if (_globalSettings.AutoSelectSettingsProfile)
                 {
                     _newAircraftCallback(message.unit, message.seat);
                 }

--- a/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
+++ b/DCS-SR-Client/Network/DCS/DCSRadioSyncManager.cs
@@ -46,7 +46,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.DCS
 
         public bool IsListening { get; private set; }
 
-        private string PresetsFolder { get { return _globalSettings.GetClientSetting(GlobalSettingsKeys.LastPresetsFolder).RawValue; } }
+        private string PresetsFolder { get { return _globalSettings.LastPresetsFolder; } }
 
         public DCSRadioSyncManager(SendRadioUpdate clientRadioUpdate, ClientSideUpdate clientSideUpdate,
            string guid, DCSRadioSyncHandler.NewAircraft _newAircraftCallback)

--- a/DCS-SR-Client/Network/LotATC/LotATCSyncHandler.cs
+++ b/DCS-SR-Client/Network/LotATC/LotATCSyncHandler.cs
@@ -43,7 +43,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.LotATC
             _guid = guid;
             _clientStateSingleton = ClientStateSingleton.Instance;
 
-            _heightOffset = _globalSettings.GetClientSetting(GlobalSettingsKeys.LotATCHeightOffset).DoubleValue;
+            _heightOffset = _globalSettings.LotATCHeightOffset;
         }
 
         public void Start()

--- a/DCS-SR-Client/Network/SRSClientSyncHandler.cs
+++ b/DCS-SR-Client/Network/SRSClientSyncHandler.cs
@@ -70,7 +70,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
 
         private void CheckIfIdleTimeOut(object sender, EventArgs e)
         {
-            var timeout = GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.IdleTimeOut).IntValue;
+            var timeout = GlobalSettingsStore.Instance.IdleTimeOut;
             if (_lastSent != -1 && TimeSpan.FromTicks(DateTime.Now.Ticks - _lastSent).TotalSeconds > timeout)
             {
                 Logger.Warn("Disconnecting - Idle Time out");
@@ -109,7 +109,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     Name = sideInfo.name,
                     LatLngPosition = sideInfo.LngLngPosition,
                     ClientGuid = _guid,
-                    AllowRecord = GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.AllowRecording)
+                    AllowRecord = GlobalSettingsStore.Instance.AllowRecording
                 },
                 ExternalAWACSModePassword = password,
                 MsgType = NetworkMessage.MessageType.EXTERNAL_AWACS_MODE_PASSWORD
@@ -222,7 +222,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     Seat = sideInfo.seat,
                     ClientGuid = _guid,
                     RadioInfo = _clientStateSingleton.DcsPlayerRadioInfo,
-                    AllowRecord = GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.AllowRecording)
+                    AllowRecord = GlobalSettingsStore.Instance.AllowRecording
                 },
                 MsgType = NetworkMessage.MessageType.RADIO_UPDATE
             };
@@ -253,7 +253,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     Name = sideInfo.name,
                     Seat = sideInfo.seat,
                     ClientGuid = _guid,
-                    AllowRecord = GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.AllowRecording)
+                    AllowRecord = GlobalSettingsStore.Instance.AllowRecording
                 },
                 MsgType = NetworkMessage.MessageType.UPDATE
             };
@@ -331,7 +331,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                             LatLngPosition = sideInfo.LngLngPosition,
                             ClientGuid = _guid,
                             RadioInfo = _clientStateSingleton.DcsPlayerRadioInfo,
-                            AllowRecord = GlobalSettingsStore.Instance.GetClientSettingBool(GlobalSettingsKeys.AllowRecording)
+                            AllowRecord = GlobalSettingsStore.Instance.AllowRecording
                         },
                         MsgType = NetworkMessage.MessageType.SYNC,
                     });

--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -483,8 +483,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                             {
                                                 if (_serverSettings.GetSettingAsBool(ServerSettingsKeys
                                                         .SHOW_TRANSMITTER_NAME)
-                                                    && _globalSettings.GetClientSettingBool(GlobalSettingsKeys
-                                                        .ShowTransmitterName))
+                                                    && _globalSettings.ShowTransmitterName)
                                                 {
                                                     transmitterName = transmittingClient.Name;
                                                 }
@@ -856,7 +855,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                     else if (radioInfo.intercomHotMic && !voice)
                     {
                         TimeSpan lastVOXSendDiff = new TimeSpan(DateTime.Now.Ticks - _lastVOXSend);
-                        if (lastVOXSendDiff.TotalMilliseconds < _globalSettings.GetClientSettingInt(GlobalSettingsKeys.VOXMinimumTime))
+                        if (lastVOXSendDiff.TotalMilliseconds < _globalSettings.VOXMinimumTime)
                         {
                             return intercom;
                         }

--- a/DCS-SR-Client/Network/VAICOM/VAICOMSyncHandler.cs
+++ b/DCS-SR-Client/Network/VAICOM/VAICOMSyncHandler.cs
@@ -71,7 +71,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network.VAICOM
                             {
                                 if (vaicomMessageWrapper.MessageType == 1)
                                 {
-                                    if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VAICOMTXInhibitEnabled))
+                                    if (_globalSettings.VAICOMTXInhibitEnabled)
                                     {
                                         vaicomMessageWrapper.LastReceivedAt = DateTime.Now.Ticks;
                                         _clientStateSingleton.InhibitTX = vaicomMessageWrapper;

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Windows;
 using NLog;
 using SharpConfig;
+using WebRtcVadSharp;
 
 namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 {
@@ -999,9 +1000,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             get => GetClientSettingBool(GlobalSettingsKeys.VOX);
             set => SetClientSetting(GlobalSettingsKeys.VOX, value.ToString());
         }
-        public int VOXMode
+        public OperatingMode VOXMode
         {
-            get => GetClientSettingInt(GlobalSettingsKeys.VOXMode);
+            get => (OperatingMode)GetClientSettingInt(GlobalSettingsKeys.VOXMode);
             set => SetClientSetting(GlobalSettingsKeys.VOXMode, value.ToString());
         }
         public int VOXMinimumTime

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Windows;
+using NAudio.Lame;
 using NLog;
 using SharpConfig;
 using WebRtcVadSharp;
@@ -985,10 +986,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             get => GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown);
             set => SetClientSetting(GlobalSettingsKeys.SingleFileMixdown, value.ToString());
         }
-        public string RecordingQuality
+        public LAMEPreset RecordingQuality
         {
-            get => GetClientSetting(GlobalSettingsKeys.RecordingQuality).RawValue;
-            set => SetClientSetting(GlobalSettingsKeys.RecordingQuality, value.ToString());
+            get => (LAMEPreset)GetClientSettingInt(GlobalSettingsKeys.RecordingQuality);
+            set => SetClientSetting(GlobalSettingsKeys.RecordingQuality, (int)value);
         }
         public bool DisallowedAudioTone
         {

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -5,8 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Windows;
-using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
-using Ciribob.DCS.SimpleRadio.Standalone.Common.Network;
 using NLog;
 using SharpConfig;
 

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -1003,7 +1003,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
         public OperatingMode VOXMode
         {
             get => (OperatingMode)GetClientSettingInt(GlobalSettingsKeys.VOXMode);
-            set => SetClientSetting(GlobalSettingsKeys.VOXMode, value.ToString());
+            set => SetClientSetting(GlobalSettingsKeys.VOXMode, (int)value);
         }
         public int VOXMinimumTime
         {

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -691,5 +691,341 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             }
         }
 
+        
+        #region Bulk Properties
+        public bool MinimiseToTray
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.MinimiseToTray);
+            set => SetClientSetting(GlobalSettingsKeys.MinimiseToTray, value.ToString());
+        }
+        public bool StartMinimised
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.StartMinimised);
+            set => SetClientSetting(GlobalSettingsKeys.StartMinimised, value.ToString());
+        }
+        public bool RefocusDCS
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.RefocusDCS);
+            set => SetClientSetting(GlobalSettingsKeys.RefocusDCS, value.ToString());
+        }
+        public bool ExpandControls
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.ExpandControls);
+            set => SetClientSetting(GlobalSettingsKeys.ExpandControls, value.ToString());
+        }
+        public bool AutoConnectPrompt
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AutoConnectPrompt);
+            set => SetClientSetting(GlobalSettingsKeys.AutoConnectPrompt, value.ToString());
+        }
+        public bool RadioOverlayTaskbarHide
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
+            set => SetClientSetting(GlobalSettingsKeys.RadioOverlayTaskbarHide, value.ToString());
+        }
+        public string AudioInputDeviceId
+        {
+            get => GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, value.ToString());
+        }
+        public string AudioOutputDeviceId
+        {
+            get => GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, value.ToString());
+        }
+        public string LastServer
+        {
+            get => GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, value.ToString());
+        }
+        public float MicBoost 
+        {
+            get => GetClientSetting(GlobalSettingsKeys.MicBoost).FloatValue;
+            set => SetClientSetting(GlobalSettingsKeys.MicBoost, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public float  SpeakerBoost
+        {
+            get => GetClientSetting(GlobalSettingsKeys.SpeakerBoost).FloatValue;
+            set => SetClientSetting(GlobalSettingsKeys.SpeakerBoost, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioX 
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.SpeakerBoost);
+            set => SetClientSetting(GlobalSettingsKeys.SpeakerBoost, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioY 
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.SpeakerBoost);
+            set => SetClientSetting(GlobalSettingsKeys.SpeakerBoost, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioSize
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.RadioSize);
+            set => SetClientSetting(GlobalSettingsKeys.RadioSize, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioOpacity
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.RadioOpacity);
+            set => SetClientSetting(GlobalSettingsKeys.RadioOpacity, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioWidth 
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.RadioWidth);
+            set => SetClientSetting(GlobalSettingsKeys.RadioWidth, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double RadioHeight
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.RadioHeight);
+            set => SetClientSetting(GlobalSettingsKeys.RadioHeight, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double ClientX
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.ClientX);
+            set => SetClientSetting(GlobalSettingsKeys.ClientX, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double ClientY
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.ClientY);
+            set => SetClientSetting(GlobalSettingsKeys.ClientY, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double AwacsX
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.AwacsX);
+            set => SetClientSetting(GlobalSettingsKeys.AwacsX, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public double AwacsY
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.AwacsY);
+            set => SetClientSetting(GlobalSettingsKeys.AwacsY, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public string MicAudioOutputDeviceId
+        {
+            get => GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId, value.ToString());
+        }
+        public string ClientIdLong
+        {
+            get => GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, value.ToString());
+        }
+        public int DCSLOSOutgoingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DCSLOSOutgoingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.DCSLOSOutgoingUDP, value.ToString());
+        }
+        public int DCSIncomingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DCSIncomingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.DCSIncomingUDP, value.ToString());
+        }
+        public int CommandListenerUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.CommandListenerUDP);
+            set => SetClientSetting(GlobalSettingsKeys.CommandListenerUDP, value.ToString());
+        }
+        public int OutgoingDCSUDPInfo
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.OutgoingDCSUDPInfo);
+            set => SetClientSetting(GlobalSettingsKeys.OutgoingDCSUDPInfo, value.ToString());
+        }
+        public int OutgoingDCSUDPOther
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.OutgoingDCSUDPOther);
+            set => SetClientSetting(GlobalSettingsKeys.OutgoingDCSUDPOther, value.ToString());
+        }
+        public int DCSIncomingGameGUIUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DCSIncomingGameGUIUDP);
+            set => SetClientSetting(GlobalSettingsKeys.DCSIncomingGameGUIUDP, value.ToString());
+        }
+        public int DCSLOSIncomingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DCSLOSIncomingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.DCSLOSIncomingUDP, value.ToString());
+        }
+        public bool AGC
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AGC);
+            set => SetClientSetting(GlobalSettingsKeys.AGC, value.ToString());
+        }
+        public int AGCTarget
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.AGCTarget);
+            set => SetClientSetting(GlobalSettingsKeys.AGCTarget, value.ToString());
+        }
+        public int AGCDecrement
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.AGCDecrement);
+            set => SetClientSetting(GlobalSettingsKeys.AGCDecrement, value.ToString());
+        }
+        public int AGCLevelMax
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.AGCLevelMax);
+            set => SetClientSetting(GlobalSettingsKeys.AGCLevelMax, value.ToString());
+        }
+        public bool Denoise
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.Denoise);
+            set => SetClientSetting(GlobalSettingsKeys.Denoise, value.ToString());
+        }
+        public int DenoiseAttenuation
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DenoiseAttenuation);
+            set => SetClientSetting(GlobalSettingsKeys.DenoiseAttenuation, value.ToString());
+        }
+        public string LastSeenName
+        {
+            get => GetClientSetting(GlobalSettingsKeys.LastPresetsFolder).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.LastPresetsFolder, value.ToString());
+        }
+        public bool CheckForBetaUpdates
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.CheckForBetaUpdates);
+            set => SetClientSetting(GlobalSettingsKeys.CheckForBetaUpdates, value.ToString());
+        }
+        public bool AllowMultipleInstances
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AllowMultipleInstances);
+            set => SetClientSetting(GlobalSettingsKeys.AllowMultipleInstances, value.ToString());
+        }
+        public bool AutoConnectMismatchPrompt
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AutoConnectMismatchPrompt);
+            set => SetClientSetting(GlobalSettingsKeys.AutoConnectMismatchPrompt, value.ToString());
+        }
+        public bool DisableWindowVisibilityCheck 
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.DisableWindowVisibilityCheck);
+            set => SetClientSetting(GlobalSettingsKeys.DisableWindowVisibilityCheck, value.ToString());
+        }
+        public bool PlayConnectionSounds
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.PlayConnectionSounds);
+            set => SetClientSetting(GlobalSettingsKeys.PlayConnectionSounds, value.ToString());
+        }
+        public bool RequireAdmin
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.RequireAdmin);
+            set => SetClientSetting(GlobalSettingsKeys.RequireAdmin, value.ToString());
+        }
+        public int LotATCIncomingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.LotATCIncomingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.LotATCIncomingUDP, value.ToString());
+        }
+        public int LotATCOutgoingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.LotATCOutgoingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.LotATCOutgoingUDP, value.ToString());
+        }
+
+        
+        /// <summary>
+        /// This is a dangerous property to use.
+        /// Ensure it is being used properly.
+        /// </summary>
+        public string[] SettingsProfiles
+        {
+            get => GetClientSetting(GlobalSettingsKeys.SettingsProfiles).StringValueArray;
+            set => SetClientSetting(GlobalSettingsKeys.SettingsProfiles, value.ToString());
+        }
+        
+        
+        public bool AutoSelectSettingsProfile
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.VAICOMTXInhibitEnabled);
+            set => SetClientSetting(GlobalSettingsKeys.VAICOMTXInhibitEnabled, value.ToString());
+        }
+        public int VAICOMIncomingUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.LotATCOutgoingUDP);
+            set => SetClientSetting(GlobalSettingsKeys.LotATCOutgoingUDP, value.ToString());
+        }
+        public bool VAICOMTXInhibitEnabled
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.VAICOMTXInhibitEnabled);
+            set => SetClientSetting(GlobalSettingsKeys.VAICOMTXInhibitEnabled, value.ToString());
+        }
+        public double LotATCHeightOffset
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.LotATCHeightOffset);
+            set => SetClientSetting(GlobalSettingsKeys.LotATCHeightOffset, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public int DCSAutoConnectUDP
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.DCSAutoConnectUDP);
+            set => SetClientSetting(GlobalSettingsKeys.DCSAutoConnectUDP, value.ToString());
+        }
+        public bool ShowTransmitterName
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.ShowTransmitterName);
+            set => SetClientSetting(GlobalSettingsKeys.ShowTransmitterName, value.ToString());
+        }
+        public int  IdleTimeOut
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.IdleTimeOut);
+            set => SetClientSetting(GlobalSettingsKeys.IdleTimeOut, value.ToString());
+        }
+        public bool AutoConnect
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AutoConnect);
+            set => SetClientSetting(GlobalSettingsKeys.AutoConnect, value.ToString());
+        }
+        public bool AllowRecording
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AllowRecording);
+            set => SetClientSetting(GlobalSettingsKeys.AllowRecording, value.ToString());
+        }
+        public bool RecordAudio
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.RecordAudio);
+            set => SetClientSetting(GlobalSettingsKeys.RecordAudio, value.ToString());
+        }
+        public bool SingleFileMixdown
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown);
+            set => SetClientSetting(GlobalSettingsKeys.SingleFileMixdown, value.ToString());
+        }
+        public string RecordingQuality
+        {
+            get => GetClientSetting(GlobalSettingsKeys.RecordingQuality).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.RecordingQuality, value.ToString());
+        }
+        public bool DisallowedAudioTone
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.DisallowedAudioTone);
+            set => SetClientSetting(GlobalSettingsKeys.DisallowedAudioTone, value.ToString());
+        }
+        public bool VOX
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.VOX);
+            set => SetClientSetting(GlobalSettingsKeys.VOX, value.ToString());
+        }
+        public int VOXMode
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.VOXMode);
+            set => SetClientSetting(GlobalSettingsKeys.VOXMode, value.ToString());
+        }
+        public int VOXMinimumTime
+        {
+            get => GetClientSettingInt(GlobalSettingsKeys.VOXMinimumTime);
+            set => SetClientSetting(GlobalSettingsKeys.VOXMinimumTime, value.ToString());
+        }
+        public double VOXMinimumDB
+        {
+            get => GetClientSettingDouble(GlobalSettingsKeys.VOXMinimumDB);
+            set => SetClientSetting(GlobalSettingsKeys.VOXMinimumDB, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public bool AllowXInputController
+        {
+            get => GetClientSettingBool(GlobalSettingsKeys.AllowXInputController);
+            set => SetClientSetting(GlobalSettingsKeys.AllowXInputController, value.ToString());
+        }
+        public string LastPresetsFolder
+        {
+            get => GetClientSetting(GlobalSettingsKeys.LastPresetsFolder).RawValue;
+            set => SetClientSetting(GlobalSettingsKeys.LastPresetsFolder, value.ToString());
+        }
+        #endregion
     }
 }

--- a/DCS-SR-Client/Settings/GlobalSettingsStore.cs
+++ b/DCS-SR-Client/Settings/GlobalSettingsStore.cs
@@ -496,7 +496,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             SetSetting("Position Settings", key.ToString(), value.ToString(CultureInfo.InvariantCulture));
         }
 
-        public int GetClientSettingInt(GlobalSettingsKeys key)
+        private int GetClientSettingInt(GlobalSettingsKeys key)
         {
             if (_settingsCache.TryGetValue(key.ToString(), out var val))
             {
@@ -512,7 +512,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             return setting.IntValue;
         }
 
-        public double GetClientSettingDouble(GlobalSettingsKeys key)
+        private double GetClientSettingDouble(GlobalSettingsKeys key)
         {
             if (_settingsCache.TryGetValue(key.ToString(), out var val))
             {
@@ -527,7 +527,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             _settingsCache[key.ToString()] = setting.DoubleValue;
             return setting.DoubleValue;
         }
-        public bool GetClientSettingBool(GlobalSettingsKeys key)
+        private bool GetClientSettingBool(GlobalSettingsKeys key)
         {
             if (_settingsCache.TryGetValue(key.ToString(), out var val))
             {
@@ -543,30 +543,30 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
             return setting.BoolValue;
         }
 
-        public Setting GetClientSetting(GlobalSettingsKeys key)
+        private Setting GetClientSetting(GlobalSettingsKeys key)
         {
             return GetSetting("Client Settings", key.ToString());
         }
 
-        public void SetClientSetting(GlobalSettingsKeys key, string value)
+        private void SetClientSetting(GlobalSettingsKeys key, string value)
         {
             _settingsCache.TryRemove(key.ToString(), out _);
             SetSetting("Client Settings", key.ToString(), value);
         }
 
-        public void SetClientSetting(GlobalSettingsKeys key, bool value)
+        private void SetClientSetting(GlobalSettingsKeys key, bool value)
         {
             _settingsCache.TryRemove(key.ToString(), out _);
             SetSetting("Client Settings", key.ToString(), value);
         }
 
-        public void SetClientSetting(GlobalSettingsKeys key, int value)
+        private void SetClientSetting(GlobalSettingsKeys key, int value)
         {
             _settingsCache.TryRemove(key.ToString(), out _);
             SetSetting("Client Settings", key.ToString(), value);
         }
 
-        public void SetClientSetting(GlobalSettingsKeys key, double value)
+        private void SetClientSetting(GlobalSettingsKeys key, double value)
         {
             _settingsCache.TryRemove(key.ToString(), out _);
             SetSetting("Client Settings", key.ToString(), value);

--- a/DCS-SR-Client/Settings/ProfileSettingsStore.cs
+++ b/DCS-SR-Client/Settings/ProfileSettingsStore.cs
@@ -277,7 +277,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings
 
         public List<string> GetProfiles()
         {
-            var profiles = _globalSettings.GetClientSetting(GlobalSettingsKeys.SettingsProfiles).StringValueArray;
+            var profiles = _globalSettings.SettingsProfiles;
 
             if (profiles == null || profiles.Length == 0 || !profiles.Contains("default"))
             {

--- a/DCS-SR-Client/Settings/RadioChannels/FilePresetChannelsStore.cs
+++ b/DCS-SR-Client/Settings/RadioChannels/FilePresetChannelsStore.cs
@@ -19,7 +19,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Settings.RadioChannels
 
         private string PresetsFolder { get
             {
-                var folder = _globalSettings.GetClientSetting(GlobalSettingsKeys.LastPresetsFolder).RawValue;
+                var folder = _globalSettings.LastPresetsFolder;
                 if (string.IsNullOrWhiteSpace(folder))
                 {
                     folder = Directory.GetCurrentDirectory();

--- a/DCS-SR-Client/Singletons/AudioInputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioInputSingleton.cs
@@ -51,8 +51,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
 
         private List<AudioDeviceListItem> BuildAudioInputs()
         {
-            Logger.Info("Audio Input - Saved ID " +
-                        GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue);
+            Logger.Info("Audio Input - Saved ID " + GlobalSettingsStore.Instance.AudioInputDeviceId);
 
             var inputs = new List<AudioDeviceListItem>();
 
@@ -96,7 +95,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
 
                     inputs.Add(input);
 
-                    if (item.ID.Trim().Equals(GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioInputDeviceId).RawValue.Trim()))
+                    if (item.ID.Trim().Equals(GlobalSettingsStore.Instance.AudioInputDeviceId.Trim()))
                     {
                         SelectedAudioInput = input;
                         Logger.Info("Audio Input - Found Saved ");

--- a/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
+++ b/DCS-SR-Client/Singletons/AudioOutputSingleton.cs
@@ -60,8 +60,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         private List<AudioDeviceListItem> BuildNormalAudioOutputs()
         {
             Logger.Info("Building Normal Audio Outputs");
-            Logger.Info("Audio Output - Saved ID " +
-                         GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId).RawValue);
+            Logger.Info("Audio Output - Saved ID " + GlobalSettingsStore.Instance.AudioOutputDeviceId);
 
             return BuildAudioOutputs(Properties.Resources.DefaultSpeakers, false);
         }
@@ -69,8 +68,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
         private List<AudioDeviceListItem> BuildMicAudioOutputs()
         {
             Logger.Info("Building Microphone Audio Outputs");
-            Logger.Info("Mic Audio Output - Saved ID " +
-                                   GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue);
+            Logger.Info("Mic Audio Output - Saved ID " + GlobalSettingsStore.Instance.MicAudioOutputDeviceId);
 
             return BuildAudioOutputs(Properties.Resources.DefaultNoPassthru, true);
         }
@@ -89,11 +87,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             string savedDeviceId;
             if (micOutput)
             {
-                savedDeviceId = GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue;
+                savedDeviceId = GlobalSettingsStore.Instance.MicAudioOutputDeviceId;
                 SelectedMicAudioOutput = outputs[0];
             } else
             {
-                savedDeviceId = GlobalSettingsStore.Instance.GetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId).RawValue;
+                savedDeviceId = GlobalSettingsStore.Instance.AudioOutputDeviceId;
                 SelectedAudioOutput = outputs[0];
             }
 

--- a/DCS-SR-Client/Singletons/ClientStateSingleton.cs
+++ b/DCS-SR-Client/Singletons/ClientStateSingleton.cs
@@ -150,7 +150,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons
             IsConnected = false;
             ExternalAWACSModelSelected = false;
 
-            LastSeenName = Settings.GlobalSettingsStore.Instance.GetClientSetting(Settings.GlobalSettingsKeys.LastSeenName).RawValue;
+            LastSeenName = Settings.GlobalSettingsStore.Instance.LastSeenName;
         }
 
         public static ClientStateSingleton Instance

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsOverlay.xaml.cs
@@ -148,7 +148,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
         {
             // Minimising a window without a taskbar icon leads to the window's menu bar still showing up in the bottom of screen
             // Since controls are unusable, but a very small portion of the always-on-top window still showing, we're closing it instead, similar to toggling the overlay
-            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide))
+            if (_globalSettings.RadioOverlayTaskbarHide)
             {
                 Close();
             }

--- a/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
+++ b/DCS-SR-Client/UI/ClientWindow/Favourites/FavouriteServersViewModel.cs
@@ -80,10 +80,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.Favourites
 
             _addresses.Remove(SelectedItem);
 
-            if (_addresses.Count == 0 && !string.IsNullOrEmpty(_globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue))
+            if (_addresses.Count == 0 && !string.IsNullOrEmpty(_globalSettings.LastServer))
             {
-                var oldAddress = new ServerAddress(_globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue,
-                    _globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue, null, true);
+                var oldAddress = new ServerAddress(_globalSettings.LastServer,
+                    _globalSettings.LastServer, null, true);
                 _addresses.Add(oldAddress);
             }
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -39,6 +39,7 @@ using MahApps.Metro.Controls;
 using Microsoft.Win32;
 using NAudio.CoreAudioApi;
 using NAudio.Dmo;
+using NAudio.Lame;
 using NAudio.Wave;
 using NLog;
 using WebRtcVadSharp;
@@ -702,8 +703,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             RecordingQuality.IsEnabled = false;
             RecordingQuality.ValueChanged += RecordingQuality_ValueChanged;
-            RecordingQuality.Value = double.Parse(
-                _globalSettings.RecordingQuality[1].ToString());
+            RecordingQuality.Value = (int)_globalSettings.RecordingQuality;
             RecordingQuality.IsEnabled = true;
 
             var objValue = Registry.GetValue("HKEY_CURRENT_USER\\SOFTWARE\\DCS-SR-Standalone", "SRSAnalyticsOptOut", "FALSE");
@@ -2116,7 +2116,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void RecordingQuality_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            _globalSettings.RecordingQuality = $"V{(int)e.NewValue}";
+            _globalSettings.RecordingQuality = (LAMEPreset)e.NewValue;
         }
 
         private void DisallowedAudioTone_OnClick(object sender, RoutedEventArgs e)

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -41,6 +41,7 @@ using NAudio.CoreAudioApi;
 using NAudio.Dmo;
 using NAudio.Wave;
 using NLog;
+using WebRtcVadSharp;
 using WPFCustomMessageBox;
 using InputBinding = Ciribob.DCS.SimpleRadio.Standalone.Client.Settings.InputBinding;
 
@@ -718,7 +719,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             VOXEnabled.IsChecked = _globalSettings.VOX;
 
             VOXMode.IsEnabled = false;
-            VOXMode.Value = _globalSettings.VOXMode;
+            VOXMode.Value = (int)_globalSettings.VOXMode;
             VOXMode.ValueChanged += VOXMode_ValueChanged;
             VOXMode.IsEnabled = true;
 
@@ -2131,7 +2132,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private void VOXMode_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if(VOXMode.IsEnabled)
-                _globalSettings.VOXMode = (int)e.NewValue;
+                _globalSettings.VOXMode = (OperatingMode)e.NewValue;
         }
 
         private void VOXMinimumTime_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -125,7 +125,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             CheckWindowVisibility();
 
-            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.StartMinimised))
+            if (_globalSettings.StartMinimised)
             {
                 Hide();
                 WindowState = WindowState.Minimized;
@@ -138,7 +138,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             }
 
             _guid = ClientStateSingleton.Instance.ShortGUID;
-            Analytics.Log("Client", "Startup", _globalSettings.GetClientSetting(GlobalSettingsKeys.ClientIdLong).RawValue);
+            Analytics.Log("Client", "Startup", _globalSettings.ClientIdLong);
 
             InitSettingsScreen();
 
@@ -152,12 +152,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             InitDefaultAddress();
 
-            SpeakerBoost.Value = _globalSettings.GetClientSetting(GlobalSettingsKeys.SpeakerBoost).DoubleValue;
+            SpeakerBoost.Value = _globalSettings.SpeakerBoost;
 
             Speaker_VU.Value = -100;
             Mic_VU.Value = -100;
 
-            ExternalAWACSModeName.Text = _globalSettings.GetClientSetting(GlobalSettingsKeys.LastSeenName).RawValue;
+            ExternalAWACSModeName.Text = _globalSettings.LastSeenName;
             UpdatePresetsFolderLabel();
 
             _audioManager = new AudioManager(AudioOutput.WindowsN);
@@ -168,7 +168,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 SpeakerBoostLabel.Content = VolumeConversionHelper.ConvertLinearDiffToDB(_audioManager.SpeakerBoost);
             }
 
-            UpdaterChecker.CheckForUpdate(_globalSettings.GetClientSettingBool(GlobalSettingsKeys.CheckForBetaUpdates));
+            UpdaterChecker.CheckForUpdate(_globalSettings.CheckForBetaUpdates);
 
             InitFlowDocument();
 
@@ -182,7 +182,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void CheckWindowVisibility()
         {
-            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.DisableWindowVisibilityCheck))
+            if (_globalSettings.DisableWindowVisibilityCheck)
             {
                 Logger.Info("Window visibility check is disabled, skipping");
                 return;
@@ -297,11 +297,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private void InitDefaultAddress()
         {
             // legacy setting migration
-            if (!string.IsNullOrEmpty(_globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue) &&
+            if (!string.IsNullOrEmpty(_globalSettings.LastServer) &&
                 FavouriteServersViewModel.Addresses.Count == 0)
             {
-                var oldAddress = new ServerAddress(_globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue,
-                    _globalSettings.GetClientSetting(GlobalSettingsKeys.LastServer).StringValue, null, true);
+                var oldAddress = new ServerAddress(_globalSettings.LastServer,
+                    _globalSettings.LastServer, null, true);
                 FavouriteServersViewModel.Addresses.Add(oldAddress);
             }
 
@@ -668,41 +668,41 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void InitSettingsScreen()
         {
-            AutoConnectEnabledToggle.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnect);
-            AutoConnectPromptToggle.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnectPrompt);
-            AutoConnectMismatchPromptToggle.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnectMismatchPrompt);
+            AutoConnectEnabledToggle.IsChecked = _globalSettings.AutoConnect;
+            AutoConnectPromptToggle.IsChecked = _globalSettings.AutoConnectPrompt;
+            AutoConnectMismatchPromptToggle.IsChecked = _globalSettings.AutoConnectMismatchPrompt;
             RadioOverlayTaskbarItem.IsChecked =
-                _globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
-            RefocusDCS.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.RefocusDCS);
-            ExpandInputDevices.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.ExpandControls);
+                _globalSettings.RadioOverlayTaskbarHide;
+            RefocusDCS.IsChecked = _globalSettings.RefocusDCS;
+            ExpandInputDevices.IsChecked = _globalSettings.ExpandControls;
 
-            MinimiseToTray.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.MinimiseToTray);
-            StartMinimised.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.StartMinimised);
+            MinimiseToTray.IsChecked = _globalSettings.MinimiseToTray;
+            StartMinimised.IsChecked = _globalSettings.StartMinimised;
 
-            MicAGC.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AGC);
-            MicDenoise.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.Denoise);
+            MicAGC.IsChecked = _globalSettings.AGC;
+            MicDenoise.IsChecked = _globalSettings.Denoise;
 
-            CheckForBetaUpdates.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.CheckForBetaUpdates);
-            PlayConnectionSounds.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.PlayConnectionSounds);
+            CheckForBetaUpdates.IsChecked = _globalSettings.CheckForBetaUpdates;
+            PlayConnectionSounds.IsChecked = _globalSettings.PlayConnectionSounds;
 
-            RequireAdminToggle.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.RequireAdmin);
+            RequireAdminToggle.IsChecked = _globalSettings.RequireAdmin;
 
-            AutoSelectInputProfile.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoSelectSettingsProfile);
+            AutoSelectInputProfile.IsChecked = _globalSettings.AutoSelectSettingsProfile;
 
-            VAICOMTXInhibitEnabled.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VAICOMTXInhibitEnabled);
+            VAICOMTXInhibitEnabled.IsChecked = _globalSettings.VAICOMTXInhibitEnabled;
 
-            ShowTransmitterName.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.ShowTransmitterName);
+            ShowTransmitterName.IsChecked = _globalSettings.ShowTransmitterName;
 
-            AllowTransmissionsRecord.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AllowRecording);
-            RecordTransmissions.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.RecordAudio);
-            SingleFileMixdown.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.SingleFileMixdown);
-            DisallowedAudioTone.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.DisallowedAudioTone);
+            AllowTransmissionsRecord.IsChecked = _globalSettings.AllowRecording;
+            RecordTransmissions.IsChecked = _globalSettings.RecordAudio;
+            SingleFileMixdown.IsChecked = _globalSettings.SingleFileMixdown;
+            DisallowedAudioTone.IsChecked = _globalSettings.DisallowedAudioTone;
             RecordTransmissions_IsEnabled();
 
             RecordingQuality.IsEnabled = false;
             RecordingQuality.ValueChanged += RecordingQuality_ValueChanged;
             RecordingQuality.Value = double.Parse(
-                _globalSettings.GetClientSetting(GlobalSettingsKeys.RecordingQuality).StringValue[1].ToString());
+                _globalSettings.RecordingQuality[1].ToString());
             RecordingQuality.IsEnabled = true;
 
             var objValue = Registry.GetValue("HKEY_CURRENT_USER\\SOFTWARE\\DCS-SR-Standalone", "SRSAnalyticsOptOut", "FALSE");
@@ -715,27 +715,24 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 AllowAnonymousUsage.IsChecked = true;
             }
 
-            VOXEnabled.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOX);
+            VOXEnabled.IsChecked = _globalSettings.VOX;
 
             VOXMode.IsEnabled = false;
-            VOXMode.Value =
-                _globalSettings.GetClientSettingInt(GlobalSettingsKeys.VOXMode);
+            VOXMode.Value = _globalSettings.VOXMode;
             VOXMode.ValueChanged += VOXMode_ValueChanged;
             VOXMode.IsEnabled = true;
 
             VOXMinimimumTXTime.IsEnabled = false;
-            VOXMinimimumTXTime.Value =
-                _globalSettings.GetClientSettingInt(GlobalSettingsKeys.VOXMinimumTime);
+            VOXMinimimumTXTime.Value = _globalSettings.VOXMinimumTime;
             VOXMinimimumTXTime.ValueChanged += VOXMinimumTime_ValueChanged;
             VOXMinimimumTXTime.IsEnabled = true;
 
             VOXMinimumRMS.IsEnabled = false;
-            VOXMinimumRMS.Value =
-                _globalSettings.GetClientSettingDouble(GlobalSettingsKeys.VOXMinimumDB);
+            VOXMinimumRMS.Value = _globalSettings.VOXMinimumDB;
             VOXMinimumRMS.ValueChanged += VOXMinimumRMS_ValueChanged;
             VOXMinimumRMS.IsEnabled = true;
 
-            AllowXInputController.IsChecked = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AllowXInputController);
+            AllowXInputController.IsChecked = _globalSettings.AllowXInputController;
         }
 
         private void ReloadProfileSettings()
@@ -1077,7 +1074,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void Stop(bool connectionError = false)
         {
-            if (ClientState.IsConnected && _globalSettings.GetClientSettingBool(GlobalSettingsKeys.PlayConnectionSounds))
+            if (ClientState.IsConnected && _globalSettings.PlayConnectionSounds)
             {
                 try
                 {
@@ -1103,10 +1100,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             ConnectExternalAWACSMode.IsEnabled = false;
             ConnectExternalAWACSMode.Content = Properties.Resources.ConnectExternalAWACSMode;
 
-            if (!string.IsNullOrWhiteSpace(ClientState.LastSeenName) &&
-                _globalSettings.GetClientSetting(GlobalSettingsKeys.LastSeenName).StringValue != ClientState.LastSeenName)
+            if (!string.IsNullOrWhiteSpace(ClientState.LastSeenName) && _globalSettings.LastSeenName != ClientState.LastSeenName)
             {
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.LastSeenName, ClientState.LastSeenName);
+                _globalSettings.LastSeenName = ClientState.LastSeenName;
             }
 
             try
@@ -1131,35 +1127,35 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             {
                 if (AudioInput.SelectedAudioInput.Value == null)
                 {
-                    _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, "default");
+                    _globalSettings.AudioInputDeviceId = "default";
 
                 }
                 else
                 {
                     var input = ((MMDevice)AudioInput.SelectedAudioInput.Value).ID;
-                    _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioInputDeviceId, input);
+                    _globalSettings.AudioInputDeviceId = input;
                 }
             }
 
             if (AudioOutput.SelectedAudioOutput.Value == null)
             {
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId, "default");
+                _globalSettings.AudioOutputDeviceId = "default";
             }
             else
             {
                 var output = (MMDevice)AudioOutput.SelectedAudioOutput.Value;
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId, output.ID);
+                _globalSettings.AudioOutputDeviceId = output.ID;
             }
 
             //check if we have optional output
             if (AudioOutput.SelectedMicAudioOutput.Value != null)
             {
                 var micOutput = (MMDevice)AudioOutput.SelectedMicAudioOutput.Value;
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId, micOutput.ID);
+                _globalSettings.MicAudioOutputDeviceId = micOutput.ID;
             }
             else
             {
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId, "");
+                _globalSettings.MicAudioOutputDeviceId = "";
             }
 
             ShowMicPassthroughWarning();
@@ -1167,8 +1163,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void ShowMicPassthroughWarning()
         {
-            if (_globalSettings.GetClientSetting(GlobalSettingsKeys.MicAudioOutputDeviceId).RawValue
-                .Equals(_globalSettings.GetClientSetting(GlobalSettingsKeys.AudioOutputDeviceId).RawValue))
+            if (_globalSettings.MicAudioOutputDeviceId.Equals(_globalSettings.AudioOutputDeviceId))
             {
                 MessageBox.Show(Properties.Resources.MsgBoxMicPassthruText, Properties.Resources.MsgBoxMicPassthru, MessageBoxButton.OK,
                     MessageBoxImage.Warning);
@@ -1195,7 +1190,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                         ClientState.IsConnected = true;
                         ClientState.IsVoipConnected = false;
 
-                        if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.PlayConnectionSounds))
+                        if (_globalSettings.PlayConnectionSounds)
                         {
                             try
                             {
@@ -1207,7 +1202,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                             }
                         }
 
-                        _globalSettings.SetClientSetting(GlobalSettingsKeys.LastServer, ServerIp.Text);
+                        _globalSettings.LastServer = ServerIp.Text;
 
                         _audioManager.StartEncoding(_guid, InputManager,
                             _resolvedIp, _port);
@@ -1251,9 +1246,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             _globalSettings.SetPositionSetting(GlobalSettingsKeys.ClientY, Top);
 
             if (!string.IsNullOrWhiteSpace(ClientState.LastSeenName) &&
-                _globalSettings.GetClientSetting(GlobalSettingsKeys.LastSeenName).StringValue != ClientState.LastSeenName)
+                _globalSettings.LastSeenName != ClientState.LastSeenName)
             {
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.LastSeenName, ClientState.LastSeenName);
+                _globalSettings.LastSeenName = ClientState.LastSeenName;
             }
 
             //save window position
@@ -1279,7 +1274,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         protected override void OnStateChanged(EventArgs e)
         {
-            if (WindowState == WindowState.Minimized && _globalSettings.GetClientSettingBool(GlobalSettingsKeys.MinimiseToTray))
+            if (WindowState == WindowState.Minimized && _globalSettings.MinimiseToTray)
             {
                 Hide();
             }
@@ -1355,8 +1350,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 _audioManager.SpeakerBoost = convertedValue;
             }
 
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.SpeakerBoost,
-                SpeakerBoost.Value.ToString(CultureInfo.InvariantCulture));
+            _globalSettings.SpeakerBoost = (float)SpeakerBoost.Value;
 
 
             if ((SpeakerBoostLabel != null) && (SpeakerBoost != null))
@@ -1413,7 +1407,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
 
                         _radioOverlayWindow.ShowInTaskbar =
-                            !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
+                            !_globalSettings.RadioOverlayTaskbarHide;
                         _radioOverlayWindow.Show();
                     }
                     else
@@ -1439,7 +1433,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
                 _awacsRadioOverlay = new AwacsRadioOverlayWindow.RadioOverlayWindow();
                 _awacsRadioOverlay.ShowInTaskbar =
-                    !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
+                    !_globalSettings.RadioOverlayTaskbarHide;
                 _awacsRadioOverlay.Show();
             }
             else
@@ -1455,7 +1449,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
             Logger.Info($"Received AutoConnect DCS-SRS @ {connection}");
 
-            var enabled = _globalSettings.GetClientSetting(GlobalSettingsKeys.AutoConnect).BoolValue;
+            var enabled = _globalSettings.AutoConnect;
 
             if (!enabled)
             {
@@ -1559,10 +1553,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             else
             {
                 // Show auto connect prompt if client is not connected yet and setting has been enabled, otherwise automatically connect
-                bool showPrompt = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnectPrompt);
+                bool showPrompt = _globalSettings.AutoConnectPrompt;
 
                 bool connectToServer = !showPrompt;
-                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnectPrompt))
+                if (_globalSettings.AutoConnectPrompt)
                 {
                     WindowHelper.BringProcessToFront(Process.GetCurrentProcess());
 
@@ -1585,7 +1579,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         private async void HandleAutoConnectMismatch(string currentConnection, string advertisedConnection)
         {
             // Show auto connect mismatch prompt if setting has been enabled (default), otherwise automatically switch server
-            bool showPrompt = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.AutoConnectMismatchPrompt);
+            bool showPrompt = _globalSettings.AutoConnectMismatchPrompt;
 
             Logger.Info($"Current SRS connection {currentConnection} does not match advertised server {advertisedConnection}, {(showPrompt ? "displaying mismatch prompt" : "automatically switching server")}");
 
@@ -1655,31 +1649,31 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void AutoConnectToggle_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AutoConnect, (bool)AutoConnectEnabledToggle.IsChecked);
+            _globalSettings.AutoConnect = AutoConnectEnabledToggle.IsChecked.GetValueOrDefault();
         }
 
         private void AutoConnectPromptToggle_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AutoConnectPrompt, (bool)AutoConnectPromptToggle.IsChecked);
+            _globalSettings.AutoConnectPrompt = AutoConnectPromptToggle.IsChecked.GetValueOrDefault();
         }
 
         private void AutoConnectMismatchPromptToggle_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AutoConnectMismatchPrompt, (bool)AutoConnectMismatchPromptToggle.IsChecked);
+            _globalSettings.AutoConnectMismatchPrompt = AutoConnectMismatchPromptToggle.IsChecked.GetValueOrDefault();
         }
 
         private void RadioOverlayTaskbarItem_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.RadioOverlayTaskbarHide, (bool)RadioOverlayTaskbarItem.IsChecked);
+            _globalSettings.RadioOverlayTaskbarHide = RadioOverlayTaskbarItem.IsChecked.GetValueOrDefault();
 
             if (_radioOverlayWindow != null)
-                _radioOverlayWindow.ShowInTaskbar = !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
-            else if (_awacsRadioOverlay != null) _awacsRadioOverlay.ShowInTaskbar = !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide);
+                _radioOverlayWindow.ShowInTaskbar = !_globalSettings.RadioOverlayTaskbarHide;
+            else if (_awacsRadioOverlay != null) _awacsRadioOverlay.ShowInTaskbar = !_globalSettings.RadioOverlayTaskbarHide;
         }
 
         private void DCSRefocus_OnClick_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.RefocusDCS, (bool)RefocusDCS.IsChecked);
+            _globalSettings.RefocusDCS = RefocusDCS.IsChecked.GetValueOrDefault();
         }
 
         private void ExpandInputDevices_OnClick_Click(object sender, RoutedEventArgs e)
@@ -1689,7 +1683,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 Properties.Resources.MsgBoxRestart, MessageBoxButton.OK,
                 MessageBoxImage.Warning);
 
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.ExpandControls, (bool)ExpandInputDevices.IsChecked);
+            _globalSettings.ExpandControls = ExpandInputDevices.IsChecked.GetValueOrDefault();
         }
 
         private void AllowXInputController_OnClick_Click(object sender, RoutedEventArgs e)
@@ -1699,7 +1693,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
                 Properties.Resources.MsgBoxRestart, MessageBoxButton.OK,
                 MessageBoxImage.Warning);
 
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AllowXInputController, (bool)AllowXInputController.IsChecked);
+            _globalSettings.AllowXInputController = AllowXInputController.IsChecked.GetValueOrDefault();
         }
 
         private void LaunchAddressTab(object sender, RoutedEventArgs e)
@@ -1709,12 +1703,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void MicAGC_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AGC, (bool)MicAGC.IsChecked);
+            _globalSettings.AGC = MicAGC.IsChecked.GetValueOrDefault();
         }
 
         private void MicDenoise_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.Denoise, (bool)MicDenoise.IsChecked);
+            _globalSettings.Denoise = MicDenoise.IsChecked.GetValueOrDefault();
         }
 
         private void RadioSoundEffects_OnClick(object sender, RoutedEventArgs e)
@@ -1762,12 +1756,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void MinimiseToTray_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.MinimiseToTray, (bool)MinimiseToTray.IsChecked);
+            _globalSettings.MinimiseToTray = MinimiseToTray.IsChecked.GetValueOrDefault();
         }
 
         private void StartMinimised_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.StartMinimised, (bool)StartMinimised.IsChecked);
+            _globalSettings.StartMinimised = StartMinimised.IsChecked.GetValueOrDefault();
         }
 
         private void AllowDCSPTT_OnClick(object sender, RoutedEventArgs e)
@@ -1787,12 +1781,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void CheckForBetaUpdates_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.CheckForBetaUpdates, (bool)CheckForBetaUpdates.IsChecked);
+            _globalSettings.CheckForBetaUpdates = CheckForBetaUpdates.IsChecked.GetValueOrDefault();
         }
 
         private void PlayConnectionSounds_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.PlayConnectionSounds, (bool)PlayConnectionSounds.IsChecked);
+            _globalSettings.PlayConnectionSounds = PlayConnectionSounds.IsChecked.GetValueOrDefault();
         }
 
         private void ConnectExternalAWACSMode_OnClick(object sender, RoutedEventArgs e)
@@ -1867,7 +1861,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void RequireAdminToggle_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.RequireAdmin, (bool)RequireAdminToggle.IsChecked);
+            _globalSettings.RequireAdmin = RequireAdminToggle.IsChecked.GetValueOrDefault();
             MessageBox.Show(this,
                 Properties.Resources.MsgBoxAdminText,
                 Properties.Resources.MsgBoxAdmin, MessageBoxButton.OK, MessageBoxImage.Warning);
@@ -1953,7 +1947,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void UpdatePresetsFolderLabel()
         {
-            var presetsFolder = _globalSettings.GetClientSetting(GlobalSettingsKeys.LastPresetsFolder).RawValue;
+            var presetsFolder = _globalSettings.LastPresetsFolder;
             if (!string.IsNullOrWhiteSpace(presetsFolder))
             {
                 PresetsFolderLabel.Content = Path.GetFileName(presetsFolder);
@@ -1968,7 +1962,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void AutoSelectInputProfile_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AutoSelectSettingsProfile, ((bool)AutoSelectInputProfile.IsChecked).ToString());
+            _globalSettings.AutoSelectSettingsProfile = AutoSelectInputProfile.IsChecked.GetValueOrDefault();
         }
 
         private void CopyProfile(object sender, RoutedEventArgs e)
@@ -1989,7 +1983,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void VAICOMTXInhibit_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.VAICOMTXInhibitEnabled, ((bool)VAICOMTXInhibitEnabled.IsChecked).ToString());
+            _globalSettings.VAICOMTXInhibitEnabled = VAICOMTXInhibitEnabled.IsChecked.GetValueOrDefault();
         }
 
         private void AlwaysAllowTransponderOverlay_OnClick(object sender, RoutedEventArgs e)
@@ -2031,7 +2025,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void ShowTransmitterName_OnClick_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.ShowTransmitterName, ((bool)ShowTransmitterName.IsChecked).ToString());
+            _globalSettings.ShowTransmitterName = ShowTransmitterName.IsChecked.GetValueOrDefault();
         }
 
         private void PushToTalkReleaseDelay_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
@@ -2091,12 +2085,12 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void AllowTransmissionsRecord_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.AllowRecording, (bool)AllowTransmissionsRecord.IsChecked);
+            _globalSettings.AllowRecording = AllowTransmissionsRecord.IsChecked.GetValueOrDefault();
         }
 
         private void RecordTransmissions_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.RecordAudio, (bool)RecordTransmissions.IsChecked);
+            _globalSettings.RecordAudio = RecordTransmissions.IsChecked.GetValueOrDefault();
             RecordTransmissions_IsEnabled();
         }
 
@@ -2116,40 +2110,40 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
 
         private void SingleFileMixdown_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.SingleFileMixdown, (bool)SingleFileMixdown.IsChecked);
+            _globalSettings.SingleFileMixdown = SingleFileMixdown.IsChecked.GetValueOrDefault();
         }
 
         private void RecordingQuality_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.RecordingQuality, $"V{(int)e.NewValue}");
+            _globalSettings.RecordingQuality = $"V{(int)e.NewValue}";
         }
 
         private void DisallowedAudioTone_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.DisallowedAudioTone, (bool)DisallowedAudioTone.IsChecked);
+            _globalSettings.DisallowedAudioTone = DisallowedAudioTone.IsChecked.GetValueOrDefault();
         }
 
         private void VoxEnabled_OnClick(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.VOX, (bool)VOXEnabled.IsChecked);
+            _globalSettings.VOX = VOXEnabled.IsChecked.GetValueOrDefault();
         }
 
         private void VOXMode_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if(VOXMode.IsEnabled)
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXMode, (int)e.NewValue);
+                _globalSettings.VOXMode = (int)e.NewValue;
         }
 
         private void VOXMinimumTime_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (VOXMinimimumTXTime.IsEnabled)
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXMinimumTime, (int)e.NewValue);
+                _globalSettings.VOXMinimumTime = (int)e.NewValue;
         }
 
         private void VOXMinimumRMS_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (VOXMinimumRMS.IsEnabled)
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXMinimumDB, (double)e.NewValue);
+                _globalSettings.VOXMinimumDB = e.NewValue;
         }
 
         private void AmbientCockpitEffectToggle_OnClick(object sender, RoutedEventArgs e)
@@ -2173,14 +2167,14 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             selectPresetsFolder.SelectedPath = PresetsFolderLabel.ToolTip.ToString();
             if (selectPresetsFolder.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                _globalSettings.SetClientSetting(GlobalSettingsKeys.LastPresetsFolder, selectPresetsFolder.SelectedPath);
+                _globalSettings.LastPresetsFolder = selectPresetsFolder.SelectedPath;
                 UpdatePresetsFolderLabel();
             }
         }
 
         private void PresetsFolderResetButton_Click(object sender, RoutedEventArgs e)
         {
-            _globalSettings.SetClientSetting(GlobalSettingsKeys.LastPresetsFolder, string.Empty);
+            _globalSettings.LastPresetsFolder = string.Empty;
             UpdatePresetsFolderLabel();
         }
     }

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlay.xaml.cs
@@ -205,7 +205,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
 
         private void FocusDCS()
         {
-            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RefocusDCS))
+            if (_globalSettings.RefocusDCS)
             {
                 var overlayWindow = new WindowInteropHelper(this).Handle;
 
@@ -251,7 +251,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
         {
             // Minimising a window without a taskbar icon leads to the window's menu bar still showing up in the bottom of screen
             // Since controls are unusable, but a very small portion of the always-on-top window still showing, we're closing it instead, similar to toggling the overlay
-            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.RadioOverlayTaskbarHide))
+            if (_globalSettings.RadioOverlayTaskbarHide)
             {
                 Close();
             }


### PR DESCRIPTION
Facades the get and set methods behind property getters/setters.

This may be easier to review one commit at a time or using Split View.

The bulk of additions are located in `DCS-SR-Client/Settings/GlobalSettingsStore.cs`.