### PR TITLE
Always create passthrough provider

### DIFF
--- a/DCS-SR-Client/Audio/Managers/AudioManager.cs
+++ b/DCS-SR-Client/Audio/Managers/AudioManager.cs
@@ -168,7 +168,6 @@ public class AudioManager : IHandle<SRClientUpdateMessage>
         {
             micOutput = (MMDevice)_audioOutputSingleton.SelectedMicAudioOutput.Value;
 
-            _passThroughAudioProvider = new ClientAudioProvider(true);
             _micWaveOut = new SRSWasapiOut(micOutput, AudioClientShareMode.Shared, true, 40, windowsN);
 
             _micWaveOutBuffer =
@@ -197,6 +196,9 @@ public class AudioManager : IHandle<SRClientUpdateMessage>
 
             _micWaveOut.Play();
         }
+
+
+        _passThroughAudioProvider = new ClientAudioProvider(true);
     }
 
     public void InitEncodersSpeex()


### PR DESCRIPTION
before 2.2, this member was always initialized: https://github.com/ciribob/DCS-SimpleRadioStandalone/blob/5c3150eeead7cf4660f4d7d609d3b30a0ec1b50a/DCS-SR-Client/Audio/Managers/AudioManager.cs#L202