### PR TITLE
Remove only dependency to MVVM Binding.

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -321,7 +321,6 @@
         <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.37" />
-        <PackageReference Include="MvvmEventBinding" Version="1.0.0" />
         <PackageReference Include="NAudio.Wasapi" Version="2.1.0" />
         <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
         <PackageReference Include="Sentry" Version="5.7.0" />

--- a/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsView.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsView.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:mvvmEventBinding="clr-namespace:MvvmEventBinding;assembly=MvvmEventBinding"
+    xmlns:Behaviors="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:presetChannels="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.RadioOverlayWindow.PresetChannels"
     xmlns:p="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Client.Properties"
     d:DataContext="{d:DesignInstance presetChannels:PresetChannelsViewModel,
@@ -19,9 +19,14 @@
                   Width="135"
                   HorizontalAlignment="Center"
                   VerticalAlignment="Top"
-                  DropDownClosed="{mvvmEventBinding:EventBinding DropDownClosedCommand}"
                   ItemsSource="{Binding Path=PresetChannels}"
-                  SelectedItem="{Binding Path=SelectedPresetChannel}" />
+                  SelectedItem="{Binding Path=SelectedPresetChannel}">
+            <Behaviors:Interaction.Triggers>
+                <Behaviors:EventTrigger EventName="DropDownClosed" SourceObject="{Binding ElementName=FrequencyDropDown}">
+                    <Behaviors:InvokeCommandAction Command="{Binding DropDownClosedCommand}" />
+                </Behaviors:EventTrigger>
+            </Behaviors:Interaction.Triggers>
+        </ComboBox>
 
         <StackPanel HorizontalAlignment="Center"
                     Background="#444"

--- a/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsViewModel.cs
+++ b/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsViewModel.cs
@@ -42,7 +42,7 @@ public class PresetChannelsViewModel : INotifyPropertyChanged, IHandle<ProfileCh
         EventBus.Instance.SubscribeOnUIThread(this);
     }
 
-    public DelegateCommand DropDownClosedCommand { get; set; }
+    public ICommand DropDownClosedCommand { get; }
 
     public DelegateCommand PresetCreateCommand { get; set; }
 
@@ -86,7 +86,7 @@ public class PresetChannelsViewModel : INotifyPropertyChanged, IHandle<ProfileCh
 
     public event PropertyChangedEventHandler PropertyChanged;
 
-    private void DropDownClosed(object args)
+    private void DropDownClosed()
     {
         if (SelectedPresetChannel != null
             && SelectedPresetChannel.Value is double


### PR DESCRIPTION
Going forward, the [MVVM Community Toolkit](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/) would be the way to go

However... Looks like we don't really need it atm, so canned the dependency without introducing a new one.

No more 4.6 warnings 🙌 