### PR TITLE
Logging through dcs.log

### DIFF
--- a/Scripts/DCS-SRS-AutoConnectGameGUI.lua
+++ b/Scripts/DCS-SRS-AutoConnectGameGUI.lua
@@ -51,21 +51,22 @@ local JSON = loadfile("Scripts\\JSON.lua")()
 SRSAuto.JSON = JSON
 
 local socket = require("socket")
+local log = require('log')
 -- local DcsWeb = require('DcsWeb')
 
 require("url") -- defines socket.url, which socket.http looks for
-http = require("http") -- socket.http
+local http = require("http") -- socket.http
 
 SRSAuto.UDPSendSocket = socket.udp()
 SRSAuto.UDPSendSocket:settimeout(0)
 
-SRSAuto.logFile = io.open(lfs.writedir()..[[Logs\DCS-SRS-AutoConnect.log]], "w")
-
 function SRSAuto.log(str)
-    if SRSAuto.logFile then
-        SRSAuto.logFile:write(str.."\n")
-        SRSAuto.logFile:flush()
-    end
+    log.write('SRS-AutoConnectGameGUI', log.INFO, str)
+end
+
+
+function SRSAuto.error(str)
+    log.write('SRS-AutoConnectGameGUI', log.INFO, str)
 end
 
 function SRSAuto.sendAutoConnectMessage(id)
@@ -205,7 +206,7 @@ SRSAuto.srsNudge = function()
     end)
 
     if not _status then
-        SRSAuto.log('ERROR: ' .. _result)
+        SRSAuto.error(_result)
     end
 
 
@@ -217,16 +218,16 @@ SRSAuto.sendMessage = function(msg, showTime, gid)
         local str = "trigger.action.outTextForGroup(" .. gid .. ",'" .. msg .. "'," .. showTime .. ",true); return true;"
         local _status, _error = net.dostring_in('server', str)
         if not _status and _error then
-            SRSAuto.log("Error! " .. _error)
+            SRSAuto.error(_error)
         end
     else
         local str = "trigger.action.outText('" .. msg .. "'," .. showTime .. ",true); return true;"
         local _status, _error = net.dostring_in('server', str)
         if not _status and _error then
-            SRSAuto.log("Error! " .. _error)
+            SRSAuto.error(_error)
         end
     end
 end
 
 DCS.setUserCallbacks(SRSAuto)
-net.log("Loaded - DCS-SRS-AutoConnect 2.2.0.4")
+SRSAuto.log("Loaded - DCS-SRS-AutoConnect 2.2.0.4")

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-OverlayGameGUI.lua
@@ -3,7 +3,7 @@
 -- Otherwise the Overlay will not work
 
 
-net.log("Loading - DCS-SRS Overlay GameGUI - Ciribob: 2.2.0.4 ")
+log.write('SRS-OverlayGameGUI', log.INFO, "Loading - DCS-SRS Overlay GameGUI - Ciribob: 2.2.0.4 ")
 
 local base = _G
 
@@ -33,6 +33,7 @@ local Gui               = require('dxgui')
 local DialogLoader      = require('DialogLoader')
 local Static            = require('Static')
 local Tools             = require('tools')
+local log               = require('log')
 
 local _modes = {     
     hidden = "hidden",
@@ -57,8 +58,7 @@ local HEIGHT = 200
 local _lastReceived = 0
 
 local srsOverlay = { 
-    connection = nil,
-    logFile = io.open(lfs.writedir()..[[Logs\DCS-SRS-InGameRadio.log]], "w")
+    connection = nil
 }
 
 
@@ -216,10 +216,15 @@ function srsOverlay.log(str)
         return
     end
 
-    if srsOverlay.logFile then
-        srsOverlay.logFile:write("["..os.date("%H:%M:%S").."] "..str.."\r\n")
-        srsOverlay.logFile:flush()
+    log.write('SRS-OverlayGameGUI', log.INFO, str)
+end
+
+function srsOverlay.error(str)
+     if not str then 
+        return
     end
+
+    log.write('SRS-OverlayGameGUI', log.ERROR, str)
 end
 
 
@@ -777,7 +782,7 @@ function srsOverlay.onSimulationFrame()
         end)
 
         if not _status then
-            srsOverlay.log("Error: ".._result)
+            srsOverlay.error(_result)
         end
         
     else

--- a/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRSGameGUI.lua
@@ -2,18 +2,23 @@
 -- Make sure you COPY this file to the same location as the Export.lua as well! 
 -- Otherwise the Radio Might not work
 
-net.log("Loading - DCS-SRS GameGUI - Ciribob: 2.2.0.4")
+log.write('SRS-GameGUI', log.INFO, "Loading - DCS-SRS GameGUI - Ciribob: 2.2.0.4")
+
+local base = _G
+
+local require = base.require
+local log = require('log')
 local SRS = {}
 
 SRS.CLIENT_ACCEPT_AUTO_CONNECT = true --- Set to false if you want to disable AUTO CONNECT
 
 SRS.dbg = {}
-SRS.logFile = io.open(lfs.writedir()..[[Logs\DCS-SRS-GameGUI.log]], "w")
 function SRS.log(str)
-    if SRS.logFile then
-        SRS.logFile:write(str.."\n")
-        SRS.logFile:flush()
-    end
+	log.write('SRS-GameGUI', log.INFO, str)
+end
+
+function SRS.error(str)
+	log.write('SRS-GameGUI', log.ERROR, str)
 end
 
 package.path  = package.path..";.\\LuaSocket\\?.lua;"
@@ -31,7 +36,7 @@ pcall(function()
 end)
 
 if not srs then
-	SRS.log("Couldnt load SRS.dll")
+	SRS.error("Couldnt load SRS.dll")
 end
 
 local JSON = loadfile("Scripts\\JSON.lua")()
@@ -340,7 +345,7 @@ SRS.onChatMessage = function(msg, from)
 			host = SRS.getHostFromMessage(msg)
 		end
 		if host == nil then 
-			SRS.log("Error getting host from message: " .. msg)
+			SRS.error("Error getting host from message: " .. msg)
 			return
 		end
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -23,12 +23,12 @@ SR.lastKnownSlot = ''
 SR.MIDS_FREQ = 1030.0 * 1000000 -- Start at UHF 300
 SR.MIDS_FREQ_SEPARATION = 1.0 * 100000 -- 0.1 MHZ between MIDS channels
 
-SR.logFile = io.open(lfs.writedir() .. [[Logs\DCS-SimpleRadioStandalone.log]], "w")
 function SR.log(str)
-    if SR.logFile then
-        SR.logFile:write(str .. "\n")
-        SR.logFile:flush()
-    end
+    log.write('SRS-export', log.INFO, str)
+end
+
+function SR.error(str)
+    log.write('SRS-export', log.ERROR, str)
 end
 
 package.path = package.path .. ";.\\LuaSocket\\?.lua;"
@@ -133,7 +133,7 @@ function SR.ModsPuginsRecursiveSearch(modsPath)
    
     -- Check that Mod folder actually exists, if not then do nothing
     if mode == nil or mode ~= "directory" then
-        SR.log("Error: SR.RecursiveSearch(): modsPath is not a directory or is null: '" .. modsPath)
+        SR.error("SR.RecursiveSearch(): modsPath is not a directory or is null: '" .. modsPath)
         return
     end
 
@@ -150,7 +150,7 @@ function SR.ModsPuginsRecursiveSearch(modsPath)
             local status, error = pcall(function () loadfile(modAutoloadPath)().register(SR) end)
             
             if error then
-                SR.log("Failed loading SRS Mod plugin due to an error in '"..modAutoloadPath.."'")
+                SR.error("Failed loading SRS Mod plugin due to an error in '"..modAutoloadPath.."'")
             else
                 SR.log("Loaded SRS Mod plugin '"..modAutoloadPath.."'")
             end
@@ -2278,24 +2278,24 @@ function SR.exportRadioCH47F(_data)
     _data.radios[1].modulation = 2 --Special intercom modulation
 
     _data.radios[2].name = "ARC-201 FM1" -- ARC 201
-    _data.radios[2].freq = SR.getRadioFrequency(49)
-    _data.radios[2].modulation = SR.getRadioModulation(49)
+    _data.radios[2].freq = SR.getRadioFrequency(51)
+    _data.radios[2].modulation = SR.getRadioModulation(51)
 
     _data.radios[2].encKey = 1
     _data.radios[2].encMode = 3 -- Cockpit Toggle + Gui Enc key setting
 
 
     _data.radios[3].name = "ARC-164 UHF" -- ARC_164
-    _data.radios[3].freq = SR.getRadioFrequency(47)
-    _data.radios[3].modulation = SR.getRadioModulation(47)
+    _data.radios[3].freq = SR.getRadioFrequency(49)
+    _data.radios[3].modulation = SR.getRadioModulation(49)
 
     _data.radios[3].encKey = 1
     _data.radios[3].encMode = 3 -- Cockpit Toggle + Gui Enc key setting
 
 
     _data.radios[4].name = "ARC-186 VHF" -- ARC_186
-    _data.radios[4].freq = SR.getRadioFrequency(48)
-    _data.radios[4].modulation = SR.getRadioModulation(48)
+    _data.radios[4].freq = SR.getRadioFrequency(50)
+    _data.radios[4].modulation = SR.getRadioModulation(50)
 
     _data.radios[4].encKey = 1
     _data.radios[4].encMode = 3 -- Cockpit Toggle + Gui Enc key setting
@@ -2312,8 +2312,8 @@ function SR.exportRadioCH47F(_data)
 
 
     _data.radios[5].name = "ARC-220 HF" -- ARC_220
-    _data.radios[5].freq = SR.getRadioFrequency(50)
-    _data.radios[5].modulation = SR.getRadioModulation(50)
+    _data.radios[5].freq = SR.getRadioFrequency(52)
+    _data.radios[5].modulation = SR.getRadioModulation(52)
 
     _data.radios[5].encMode = 0
 
@@ -7471,7 +7471,7 @@ LuaExportActivityNextEvent = function(tCurrent)
         local _status, _result = pcall(SR.exporter)
 
         if not _status then
-            SR.log('ERROR: ' ..  SR.debugDump(_result))
+            SR.error(SR.debugDump(_result))
         end
     end
 
@@ -7486,12 +7486,12 @@ LuaExportActivityNextEvent = function(tCurrent)
                 tNext = _result
             end
         else
-            SR.log('ERROR Calling other LuaExportActivityNextEvent from another script: ' .. SR.debugDump(_result))
+            SR.error('Calling other LuaExportActivityNextEvent from another script: ' .. SR.debugDump(_result))
         end
     end
 
     if terrain == nil then
-        SR.log("Terrain Export is not working")
+        SR.error("Terrain Export is not working")
         --SR.log("EXPORT CHECK "..tostring(terrain.isVisible(1,100,1,1,100,1)))
         --SR.log("EXPORT CHECK "..tostring(terrain.isVisible(1,1,1,1,-100,-100)))
     end
@@ -7508,20 +7508,20 @@ LuaExportBeforeNextFrame = function()
     local _status, _result = pcall(SR.readLOSSocket)
 
     if not _status then
-        SR.log('ERROR LuaExportBeforeNextFrame readLOSSocket SRS: ' .. SR.debugDump(_result))
+        SR.error('LuaExportBeforeNextFrame readLOSSocket SRS: ' .. SR.debugDump(_result))
     end
 
     _status, _result = pcall(SR.readSeatSocket)
 
     if not _status then
-        SR.log('ERROR LuaExportBeforeNextFrame readSeatSocket SRS: ' .. SR.debugDump(_result))
+        SR.error('LuaExportBeforeNextFrame readSeatSocket SRS: ' .. SR.debugDump(_result))
     end
 
     -- call original
     if _prevLuaExportBeforeNextFrame then
         _status, _result = pcall(_prevLuaExportBeforeNextFrame)
         if not _status then
-            SR.log('ERROR Calling other LuaExportBeforeNextFrame from another script: ' .. SR.debugDump(_result))
+            SR.error('Calling other LuaExportBeforeNextFrame from another script: ' .. SR.debugDump(_result))
         end
     end
 end


### PR DESCRIPTION
Migrates all the custom log files into dcs.log.
Makes it easier to find issue, see timings wrt other scripts, etc.

Sample:

```log
2025-06-20 03:59:21.402 INFO    SRS-GameGUI (Main): Loading - DCS-SRS GameGUI - Ciribob: 2.2.0.4
2025-06-20 03:59:21.402 INFO    SRS-GameGUI (Main): Loaded SRS.dll
2025-06-20 04:04:32.294 INFO    TACVIEW.EXPORT.LUA (Main): Tacview 1.9.5.109 C++ flight data recorder successfully loaded.
2025-06-20 04:04:32.304 INFO    SRS-export (Main): Loaded Terrain - SimpleRadio Standalone!
```

All the logs are under different categories, and they share the common `SRS-` prefix to easily grep them in logs.

Moreover, if need be, there is a way to still push them in individual logs via autoexec.cfg output configuration.