### PR TITLE
AutoUpdater `-wait` flag to wait after install completion

### DIFF
--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -177,10 +177,16 @@ public partial class MainWindow : Window
                     if (path.Length > 0)
                     {
                         var latestVersion = new Version(release.TagName.Replace("v", ""));
-                        var serverVersion = Assembly.LoadFile(Path.Combine(path, "SR-Server.exe")).GetName()
-                            .Version;
+                        var serverExe = Path.Combine(path, "SR-Server.exe");
+                        var useThisVersion = true;
+                        if (Path.Exists(serverExe))
+                        {
+                            var serverVersion = Assembly.LoadFile(serverExe).GetName().Version;
+                            useThisVersion = serverVersion < latestVersion;
+                        }
+                        
 
-                        if (serverVersion < latestVersion) return new Uri(releaseAsset.BrowserDownloadUrl);
+                        if (useThisVersion) return new Uri(releaseAsset.BrowserDownloadUrl);
 
                         //no update
                         return null;

--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -243,7 +243,7 @@ public partial class MainWindow : Window
     private bool WaitInstaller()
     {
         foreach (var arg in Environment.GetCommandLineArgs())
-            if arg.Trim().Equals("-wait"))
+            if (arg.Trim().Equals("-wait"))
                 return true;
 
         return false;

--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -240,6 +240,15 @@ public partial class MainWindow : Window
         return false;
     }
 
+    private bool WaitInstaller()
+    {
+        foreach (var arg in Environment.GetCommandLineArgs())
+            if arg.Trim().Equals("-wait"))
+                return true;
+
+        return false;
+    }
+
     public void ShowError()
     {
         MessageBox.Show(
@@ -347,9 +356,13 @@ public partial class MainWindow : Window
 
             procInfo.FileName = Path.Combine(Path.Combine(_directory, "extract"), "installer.exe");
             procInfo.UseShellExecute = false;
-            Process.Start(procInfo);
+            var installerProcess = Process.Start(procInfo);
 
-            installerProcess?.WaitForExit();
+            if (WaitInstaller() && installerProcess != null)
+            {
+                installerProcess.WaitForExit();
+            }
+            
 
 
             //Process.Start(changelogURL);

--- a/AutoUpdater/MainWindow.xaml.cs
+++ b/AutoUpdater/MainWindow.xaml.cs
@@ -343,6 +343,8 @@ public partial class MainWindow : Window
             procInfo.UseShellExecute = false;
             Process.Start(procInfo);
 
+            installerProcess?.WaitForExit();
+
 
             //Process.Start(changelogURL);
         }


### PR DESCRIPTION
From [SRS discord request](https://discord.com/channels/298054423656005632/598576342921117707/1386436975279603805) by @karel26


Added a `-wait` flag on the AutoUpdater, which will make it hold until after the installer itself has run.
Note that the limitation is you need to run the AutoUpdater out of the target installation path tree.

Hope that helps!

(fully non-GUI installer/updater is a whole other can of worms :) )