### PR TITLE
Fix Overlay's setting MIDS incorrectly

### DIFF
--- a/DCS-SR-Client/Settings/RadioChannels/FilePresetChannelsStore.cs
+++ b/DCS-SR-Client/Settings/RadioChannels/FilePresetChannelsStore.cs
@@ -136,11 +136,11 @@ public partial class FilePresetChannelsStore : IPresetChannelsStore
                             midsChannel = int.Parse(trimmed, CultureInfo.InvariantCulture);
                         }
 
-                        if (midsChannel > 0 && midsChannel < 126)
+                        if (midsChannel > 0 && midsChannel < 127)
                             channels.Add(new PresetChannel
                             {
                                 Text = name,
-                                Value = midsChannel * MHz + MidsOffsetMHz,
+                                Value = midsChannel * MHz / 10 + MidsOffsetMHz,
                                 MidsChannel = midsChannel
                             });
                     }

--- a/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsViewModel.cs
+++ b/DCS-SR-Client/UI/ClientWindow/RadioOverlayWindow/PresetChannels/PresetChannelsViewModel.cs
@@ -145,11 +145,11 @@ public class PresetChannelsViewModel : INotifyPropertyChanged, IHandle<ProfileCh
                 //frequency is calculated off the channel for mids
                 var midsChannel = (int)channel.Frequency;
 
-                if (midsChannel is > 0 and < 126)
+                if (midsChannel is > 0 and < 127)
                 {
                     presetChannelServerList.Add( new PresetChannel()
                     {
-                        Value = (double) midsChannel * FilePresetChannelsStore.MHz + FilePresetChannelsStore.MidsOffsetMHz,
+                        Value = (double) midsChannel * (FilePresetChannelsStore.MHz/10) + FilePresetChannelsStore.MidsOffsetMHz,
                         Text = channel.Name,
                         MidsChannel = midsChannel
                     });
@@ -215,13 +215,13 @@ public class PresetChannelsViewModel : INotifyPropertyChanged, IHandle<ProfileCh
         {
             if (PresetChannels.Count == 0)
             {
-                for (var chn = 1; chn < 126; chn++)
+                for (var chn = 1; chn < 127; chn++)
                     PresetChannels.Add(new PresetChannel
                     {
                         MidsChannel = chn,
                         Channel = chn,
                         Text = "MIDS " + chn,
-                        Value = (double) (chn * FilePresetChannelsStore.MHz + FilePresetChannelsStore.MidsOffsetMHz)
+                        Value = (double) (chn * (FilePresetChannelsStore.MHz/10) + FilePresetChannelsStore.MidsOffsetMHz)
                     });
             }
         }


### PR DESCRIPTION
A simple fix to make the Freq values be set correctly.
The Presets were off by a factor of 10, but are correct for other situations.

```
# Client 2.2:
EAM: 01: 1031000000.0
F18: 01: 1030100000.0

EAM: 10: 1040000000.0
F18: 10: 1031000000.0

EAM: 30: 1060000000.0
F18: 30: 1033000000.0

# Client 2.1:
EAM: 01: 1030100000.0
F18: 01: 1030100000.0

EAM: 10: 1031000000.0
F18: 10: 1031000000.0

EAM: 30: 1033000000.0
F18: 30: 1033000000.0

With fix:
EAM: 01: 1030100000.0
EAM: 10: 1031000000.0
EAM: 30: 1033000000.0
```

Verified that this will work with auto-generator and manually created preset lists.
Discussed in this Discord Thread: https://discord.com/channels/298054423656005632/1390397049291149473