### PR TITLE
Fix up compressor attack/release time scale

### DIFF
--- a/Common/Audio/Models/RadioModel.cs
+++ b/Common/Audio/Models/RadioModel.cs
@@ -85,9 +85,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Audio.Models
             {
                 return new SimpleCompressorEffect(source)
                 {
-                    Attack = Attack,
+                    Attack = Attack * 1000,
                     MakeUpGain = MakeUp,
-                    Release = Release,
+                    Release = Release * 1000,
                     Threshold = Threshold,
                     Ratio = Ratio,
                     Enabled = true,

--- a/DCS-SR-Client/RadioModels/HOWTO.md
+++ b/DCS-SR-Client/RadioModels/HOWTO.md
@@ -59,7 +59,8 @@ If no q factor are specified, it's a first order pass.
 ```
 
 gain and threshold expressed in dB.
-Translating from DCS' presets, ratio = 1 / slope.
+Translating from DCS' presets, ratio = 1 / slope, or maybe 1 / (1 - slope).
+attack and release time are expressed in seconds.
 
 ### Saturation
 ```json


### PR DESCRIPTION
For NAudio they are expressed in milliseconds, whereas the values lifted from DCS are in seconds.