### PR TITLE
Update UH60L.lua for 'DAP' variant of UH60L v2 mod

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/UH60L.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/UH60L.lua
@@ -174,6 +174,7 @@ end
 local result = {
     register = function(SR)
         SR.exporters["UH-60L"] = exportRadioUH60L
+        SR.exporters["UH-60L_DAP"] = exportRadioUH60L --ANDR0ID Added
         SR.exporters["MH-60R"] = exportRadioUH60L
     end,
 }


### PR DESCRIPTION
Adds support for the UH-60L DAP following release of version 2 of the mod. 

Add: SR.exporters["UH-60L_DAP"] = SR.exportRadioUH60L to exporters list. 

*Updated pull request to correct file*