### PR TITLE
Fix persistent UnitID and Type checks

### DIFF
--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/A10C.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/A10C.lua
@@ -3,7 +3,7 @@ function exportRadioA10C(_data, SR)
     _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = false, desc = "Using cockpit PTT (HOTAS Mic Switch) requires use of VoIP bindings." }
 
     -- Check if player is in a new aircraft
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         -- New aircraft; Reset volumes to 100%
         local _device = GetDevice(0)
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/A10C2.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/A10C2.lua
@@ -12,7 +12,7 @@ function exportRadioA10C2(_data, SR)
     _data.capabilities = { dcsPtt = true, dcsIFF = true, dcsRadioSwitch = true, intercomHotMic = false, desc = "Using cockpit PTT (HOTAS Mic Switch) requires use of VoIP bindings." }
 
     -- Check if player is in a new aircraft
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         -- New aircraft; Reset volumes to 100%
         local _device = GetDevice(0)
 

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/AH64.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/AH64.lua
@@ -14,7 +14,7 @@ function exportRadioAH64D(_data, SR)
     }
     
     -- Check if player is in a new aircraft
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         -- New aircraft; SENS volume is at 0
             pcall(function()
                  -- source https://github.com/DCSFlightpanels/dcs-bios/blob/master/Scripts/DCS-BIOS/lib/AH-64D.lua

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/AV8BNA.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/AV8BNA.lua
@@ -36,7 +36,7 @@ function exportRadioAV8BNA(_data, SR)
 
     --SR.log("UFC Scratch:\n"..SR.JSON:encode(SR.getListIndicatorValue(5)).."\n\n")
 
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         _av8.radio1.guard = 0
         _av8.radio2.guard = 0
     end

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/CH47F.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/CH47F.lua
@@ -5,7 +5,7 @@ _ch47.radio3 = {guard=0,enc=false}
 function exportRadioCH47F(_data, SR)
 
     -- RESET
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         _ch47.radio1 = {enc=false}
         _ch47.radio2 = {guard=0,enc=false}
         _ch47.radio3 = {guard=0,enc=false}

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/FA18C.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/FA18C.lua
@@ -63,7 +63,7 @@ function exportRadioFA18C(_data, SR)
     -- }
     --_data.radios[3].secFreq = 243.0 * 1000000
     -- reset state on aircraft switch
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         _fa18.radio1.guard = 0
         _fa18.radio1.channel = nil
         _fa18.radio2.guard = 0

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/JF17.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/JF17.lua
@@ -4,7 +4,7 @@ function exportRadioJF17(_data, SR)
     _data.capabilities = { dcsPtt = false, dcsIFF = true, dcsRadioSwitch = false, intercomHotMic = false, desc = "" }
 
     -- reset state on aircraft switch
-    if _lastUnitId ~= _data.unitId or not _jf17 then
+    if SR.LastKnownUnitId ~= _data.unitId or not _jf17 then
         _jf17 = {
             radios = {
                 [2] = {

--- a/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/M2000C.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SRS-Modules/M2000C.lua
@@ -84,7 +84,7 @@ function exportRadioM2000C(_data, SR)
 
 
     -- reset state on aircraft switch
-    if _lastUnitId ~= _data.unitId then
+    if SR.LastKnownUnitId ~= _data.unitId then
         _mirageEncStatus = false
         _previousEncState = 0
     end

--- a/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
+++ b/Scripts/DCS-SRS/Scripts/DCS-SimpleRadioStandalone.lua
@@ -61,6 +61,9 @@ SR.lastKnownPos = { x = 0, y = 0, z = 0 }
 SR.lastKnownSeat = 0
 SR.lastKnownSlot = ''
 
+SR.LastKnownUnitId = "" -- used for a10c volume
+SR.LastKnownUnitType = ""    -- used for F/A-18C ENT button
+
 SR.MIDS_FREQ = 1030.0 * 1000000 -- Start at UHF 300
 SR.MIDS_FREQ_SEPARATION = 1.0 * 100000 -- 0.1 MHZ between MIDS channels
 
@@ -118,8 +121,6 @@ end
 local _prevLuaExportActivityNextEvent = LuaExportActivityNextEvent
 local _prevLuaExportBeforeNextFrame = LuaExportBeforeNextFrame
 
-local _lastUnitId = "" -- used for a10c volume
-local _lastUnitType = ""    -- used for F/A-18C ENT button
 local _tNextSRS = 0
 
 SR.exporters = {}   -- exporter table. Initialized at the end
@@ -368,8 +369,8 @@ function SR.exporter()
             _update.ambient = {vol = 0.2, abType = 'jet' }
         end
 
-        _lastUnitId = _update.unitId
-        _lastUnitType = _data.Name
+        SR.LastKnownUnitId = _update.unitId
+        SR.LastKnownUnitType = _data.Name
     else
         -- There may be a unit but we're purposely ignoring it if you're in a special slot
         
@@ -416,8 +417,8 @@ function SR.exporter()
             SR.lastKnownPos = _point
         end
 
-        _lastUnitId = ""
-        _lastUnitType = ""
+        SR.LastKnownUnitId = ""
+        SR.LastKnownUnitType = ""
     end
 
     _update.seat = SR.lastKnownSeat


### PR DESCRIPTION
The glass cockpit planes store a state and use the last UnitID/UnitType to persist that state. When `DCS-SimpleRadioStandalone.lua` was broken up, the Logs didn't show that that UnitID check was failing, the dial based aircraft kept working with out issue.