### PR TITLE
Only trace failed json deserialization on network messages.

### DIFF
--- a/Common/Network/Server/SRSClientSession.cs
+++ b/Common/Network/Server/SRSClientSession.cs
@@ -116,7 +116,13 @@ public class SRSClientSession : TcpSession
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, $"Unable to process JSON: \n {message}");
+                // Can be extremely noisy, use only for debugging!
+                // We conditionally check the trace to avoid building a string with a potentially really long message.
+                if (Logger.IsTraceEnabled)
+                {
+                    Logger.Trace(ex, $"Unable to process JSON: \n {message}");
+                }
+                
             }
 
 


### PR DESCRIPTION
Some servers can be subject to various bot probing, leading to a lot of log spamming.

Downgraded the error to a trace, as to give at least a way to diagnose them without needing an exe re-release.