### PR TITLE
fix: renamed realRadioTx to realRadioRx

### DIFF
--- a/ServerCommandLine/Program.cs
+++ b/ServerCommandLine/Program.cs
@@ -253,7 +253,7 @@ public class Options
         Required = false)]
     public bool? RealRadioTX { get; set; }
 
-    [Option("realRadioTx",
+    [Option("realRadioRx",
         HelpText = "Enables receiving radio interference from other transmissions. Default is false",
         Required = false)]
     public bool? RealRadioRX { get; set; }


### PR DESCRIPTION
Name was wrong for RealRadioRx Option, was using the same name as Tx and causing duplicate match errors from the Options provider.
