### PR TITLE
feat: add transponder power toggle binding Feat #628

### DIFF
--- a/Common/Settings/GlobalSettingsStore.cs
+++ b/Common/Settings/GlobalSettingsStore.cs
@@ -224,7 +224,10 @@ public enum InputBinding
     ModifierIntercomPTT = 236,
 
     AwacsOverlayToggle = 137,
-    ModifierAwacsOverlayToggle = 237
+    ModifierAwacsOverlayToggle = 237,
+
+    TransponderPowerToggle = 138,
+    ModifierTransponderPowerToggle = 238
 }
 
 public class GlobalSettingsStore

--- a/DCS-SR-Client/Singletons/InputDeviceManager.cs
+++ b/DCS-SR-Client/Singletons/InputDeviceManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -643,6 +643,9 @@ public class InputDeviceManager : IDisposable
                                         break;
                                     case InputBinding.TransponderIDENT:
                                         TransponderHelper.ToggleIdent();
+                                        break;
+                                    case InputBinding.TransponderPowerToggle:
+                                        TransponderHelper.TogglePower();
                                         break;
                                     case InputBinding.RadioVolumeUp:
                                         RadioHelper.RadioVolumeUp(dcsPlayerRadioInfo.selected);

--- a/DCS-SR-Client/UI/ClientWindow/InputSettingsControl/InputSettings.xaml
+++ b/DCS-SR-Client/UI/ClientWindow/InputSettingsControl/InputSettings.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.InputSettingsControl.InputSettings"
+<UserControl x:Class="Ciribob.DCS.SimpleRadio.Standalone.Client.UI.ClientWindow.InputSettingsControl.InputSettings"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -165,6 +165,10 @@
             <inputSettingsControl:InputBindingControl x:Name="TransponderIDENT"
                                                       ControlInputBinding="TransponderIDENT"
                                                       InputName="Transponder IDENT" />
+
+            <inputSettingsControl:InputBindingControl x:Name="TransponderPowerToggle"
+                                                      ControlInputBinding="TransponderPowerToggle"
+                                                      InputName="Transponder Power Toggle" />
 
             <inputSettingsControl:InputBindingControl x:Name="RadioVolumeUp"
                                                       ControlInputBinding="RadioVolumeUp"


### PR DESCRIPTION
Problem
There is a desktop input binding for Transponder IDENT but no binding to turn the transponder itself on or off. In VR or during FENCE checks this means users either have to use chat commands or manipulate cockpit controls directly to toggle the transponder, which is awkward when they already have other SRS actions bound to their HOTAS.
Changes
Added a new InputBinding pair TransponderPowerToggle / ModifierTransponderPowerToggle to the global input enum.
Wired TransponderPowerToggle into InputDeviceManager so that it calls the existing TransponderHelper.TogglePower() helper, which flips the transponder between OFF and NORMAL.
Exposed the new binding in the Input Settings UI as “Transponder Power Toggle” so it can be mapped to any key or button alongside the existing “Transponder IDENT” binding.
Testing
In the client input settings, bound “Transponder Power Toggle” to a joystick button and confirmed that pressing it toggles transponder power on and off (from NORMAL to OFF and back) without affecting the existing IDENT binding or other radio controls.