### PR TITLE
Fix incorrect “window not visible” warning on high DPI setups #312

### DIFF
--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -187,6 +187,12 @@ public partial class MainWindow : MetroWindow
         bool awacsWindowVisible = awacsWindowX >= virtualLeft && awacsWindowX <= virtualRight &&
                                   awacsWindowY >= virtualTop && awacsWindowY <= virtualBottom;
 
+        // Use DPI-independent default positions based on virtual screen origin (addresses gcask review)
+        var defaultMainX = (int)(virtualLeft + 50);
+        var defaultMainY = (int)(virtualTop + 50);
+        var defaultOverlayX = (int)(virtualLeft + 100);
+        var defaultOverlayY = (int)(virtualTop + 100);
+
         if (!mainWindowVisible)
         {
             MessageBox.Show(this,
@@ -198,11 +204,11 @@ public partial class MainWindow : MetroWindow
             Logger.Warn(
                 $"Main client window outside visible area of monitors, resetting position ({mainWindowX},{mainWindowY}) to defaults");
 
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.ClientX, 200);
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.ClientY, 200);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.ClientX, defaultMainX);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.ClientY, defaultMainY);
 
-            Left = 200;
-            Top = 200;
+            Left = defaultMainX;
+            Top = defaultMainY;
         }
 
         if (!radioWindowVisible)
@@ -218,8 +224,8 @@ public partial class MainWindow : MetroWindow
 
             EventBus.Instance.PublishOnUIThreadAsync(new CloseRadioOverlayMessage());
 
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.RadioX, 300);
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.RadioY, 300);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.RadioX, defaultOverlayX);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.RadioY, defaultOverlayY);
         }
 
         if (!awacsWindowVisible)
@@ -233,8 +239,8 @@ public partial class MainWindow : MetroWindow
             Logger.Warn(
                 $"AWACS overlay window outside visible area of monitors, resetting position ({awacsWindowX},{awacsWindowY}) to defaults");
 
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.AwacsX, 300);
-            _globalSettings.SetPositionSetting(GlobalSettingsKeys.AwacsY, 300);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.AwacsX, defaultOverlayX);
+            _globalSettings.SetPositionSetting(GlobalSettingsKeys.AwacsY, defaultOverlayY);
         }
     }
 

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -157,10 +157,6 @@ public partial class MainWindow : MetroWindow
             return;
         }
 
-        var mainWindowVisible = false;
-        var radioWindowVisible = false;
-        var awacsWindowVisible = false;
-
         var mainWindowX = (int)_globalSettings.GetPositionSetting(GlobalSettingsKeys.ClientX).DoubleValue;
         var mainWindowY = (int)_globalSettings.GetPositionSetting(GlobalSettingsKeys.ClientY).DoubleValue;
         var radioWindowX = (int)_globalSettings.GetPositionSetting(GlobalSettingsKeys.RadioX).DoubleValue;
@@ -172,32 +168,24 @@ public partial class MainWindow : MetroWindow
         Logger.Info($"Checking window visibility for radio overlay {{X={radioWindowX},Y={radioWindowY}}}");
         Logger.Info($"Checking window visibility for AWACS overlay {{X={awacsWindowX},Y={awacsWindowY}}}");
 
-        foreach (var screen in Screen.AllScreens)
-        {
-            Logger.Info(
-                $"Checking {(screen.Primary ? "primary " : "")}screen {screen.DeviceName} with bounds {screen.Bounds} for window visibility");
+        // Use WPF's virtual screen bounds so that the check runs in the same
+        // DPI-independent coordinate space as the stored window positions.
+        var virtualLeft = SystemParameters.VirtualScreenLeft;
+        var virtualTop = SystemParameters.VirtualScreenTop;
+        var virtualRight = virtualLeft + SystemParameters.VirtualScreenWidth;
+        var virtualBottom = virtualTop + SystemParameters.VirtualScreenHeight;
 
-            if (screen.Bounds.Contains(mainWindowX, mainWindowY))
-            {
-                Logger.Info(
-                    $"Main client window {{X={mainWindowX},Y={mainWindowY}}} is visible on {(screen.Primary ? "primary " : "")}screen {screen.DeviceName} with bounds {screen.Bounds}");
-                mainWindowVisible = true;
-            }
+        Logger.Info(
+            $"VirtualScreen bounds for visibility check: Left={virtualLeft}, Top={virtualTop}, Right={virtualRight}, Bottom={virtualBottom}");
 
-            if (screen.Bounds.Contains(radioWindowX, radioWindowY))
-            {
-                Logger.Info(
-                    $"Radio overlay {{X={radioWindowX},Y={radioWindowY}}} is visible on {(screen.Primary ? "primary " : "")}screen {screen.DeviceName} with bounds {screen.Bounds}");
-                radioWindowVisible = true;
-            }
+        bool mainWindowVisible = mainWindowX >= virtualLeft && mainWindowX <= virtualRight &&
+                                 mainWindowY >= virtualTop && mainWindowY <= virtualBottom;
 
-            if (screen.Bounds.Contains(awacsWindowX, awacsWindowY))
-            {
-                Logger.Info(
-                    $"AWACS overlay {{X={awacsWindowX},Y={awacsWindowY}}} is visible on {(screen.Primary ? "primary " : "")}screen {screen.DeviceName} with bounds {screen.Bounds}");
-                awacsWindowVisible = true;
-            }
-        }
+        bool radioWindowVisible = radioWindowX >= virtualLeft && radioWindowX <= virtualRight &&
+                                  radioWindowY >= virtualTop && radioWindowY <= virtualBottom;
+
+        bool awacsWindowVisible = awacsWindowX >= virtualLeft && awacsWindowX <= virtualRight &&
+                                  awacsWindowY >= virtualTop && awacsWindowY <= virtualBottom;
 
         if (!mainWindowVisible)
         {

--- a/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
+++ b/DCS-SR-Client/UI/ClientWindow/MainWindow.xaml.cs
@@ -187,7 +187,7 @@ public partial class MainWindow : MetroWindow
         bool awacsWindowVisible = awacsWindowX >= virtualLeft && awacsWindowX <= virtualRight &&
                                   awacsWindowY >= virtualTop && awacsWindowY <= virtualBottom;
 
-        // Use DPI-independent default positions based on virtual screen origin (addresses gcask review)
+        // Use DPI-independent default positions based on virtual screen origin
         var defaultMainX = (int)(virtualLeft + 50);
         var defaultMainY = (int)(virtualTop + 50);
         var defaultOverlayX = (int)(virtualLeft + 100);


### PR DESCRIPTION
**Problem**

On mixed DPI multi‑monitor setups (for example a 4K main display at 150% and 1080p side displays at 100 percent), SRS sometimes shows the “client window is no longer visible” warning on startup and resets the window position even though the window was visible on a secondary monitor. This happened because the visibility check compared saved window positions in WPF logical coordinates against Screen.Bounds in device pixels, so valid positions could be treated as off screen when DPI scaling was applied.

**Fix**

Updated the window visibility check in MainWindow.xaml.cs to use WPF’s SystemParameters.VirtualScreenLeft/Top/Width/Height as the reference rectangle. These values are in the same DPI independent coordinate space as the stored window positions, so the visibility test no longer mixes logical and device pixels. If a saved position lies within the virtual screen bounds it is considered visible; otherwise SRS resets it to a safe default as before. The existing DisableWindowVisibilityCheck flag still works as a manual override.

**Testing**
Verified on a single 4K monitor at 100 percent and on a 4K main monitor at 150 percent with 1080p side monitors at 100 percent that moving the SRS client to different screens, closing, and reopening no longer triggers false “not visible” messages or unwanted position resets.