### PR TITLE
Reload bans from banned.txt when players reconnect #967

### DIFF
--- a/Common/Network/Server/SRSClientSession.cs
+++ b/Common/Network/Server/SRSClientSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
@@ -53,6 +53,15 @@ public class SRSClientSession : TcpSession
     protected override void OnConnected()
     {
         var clientIp = (IPEndPoint)Socket.RemoteEndPoint;
+
+        try
+        {
+            ((ServerSync)Server).ReloadBanListFromFile();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to reload banned.txt on client connect");
+        }
 
         EventBus.Instance.PublishOnBackgroundThreadAsync(new SRSClientStatus
         {

--- a/Common/Network/Server/ServerState.cs
+++ b/Common/Network/Server/ServerState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -87,7 +87,7 @@ public class ServerState : IHandle<StartServerMessage>, IHandle<StopServerMessag
     }
 
 
-    private static string GetCurrentDirectory()
+    internal static string GetCurrentDirectory()
     {
         //To get the location the assembly normally resides on disk or the install directory
         var currentPath = AppContext.BaseDirectory;

--- a/Common/Network/Server/ServerSync.cs
+++ b/Common/Network/Server/ServerSync.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -47,6 +47,34 @@ public class ServerSync : TcpServer, IHandle<ServerSettingsChangedMessage>
         {
             _natHandler = new NatHandler(_serverSettings.GetServerPort());
             _natHandler.OpenNAT();
+        }
+    }
+
+    internal void ReloadBanListFromFile()
+    {
+        try
+        {
+            _bannedIps.Clear();
+
+            var path = Path.Combine(ServerState.GetCurrentDirectory(), "banned.txt");
+            if (!File.Exists(path))
+            {
+                Logger.Info($"'{path}' was not found or you don't have permission to read the file");
+                return;
+            }
+
+            foreach (var line in File.ReadAllLines(path))
+            {
+                if (IPAddress.TryParse(line.Trim(), out var ip))
+                {
+                    Logger.Info($"Loaded Banned IP: {line}");
+                    _bannedIps.Add(ip);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Unable to read banned.txt");
         }
     }
 


### PR DESCRIPTION
**Reload bans from banned.txt when players reconnect https://github.com/ciribob/DCS-SimpleRadioStandalone/issues/967**

**Problem**
Banning a player through the HTTP API correctly writes their IP into banned.txt and prevents them from reconnecting. However, if the IP is later removed from banned.txt (manually or by a management script), the player stays banned until the SRS server is fully restarted. The server only loaded banned.txt once at startup and never refreshed the in memory ban list used for connection checks.

**Changes**
On server start, the existing logic still loads banned.txt into an in memory HashSet of banned IPs. A new helper method in the TCP server (ServerSync) can reload the ban list from banned.txt on demand by clearing and repopulating that HashSet. Each time a new TCP client session is established, the session now asks the server to reload banned.txt just before checking whether the connecting IP is banned. If the IP has been removed from banned.txt since the last connection, it will no longer be present in the in memory ban list and the player is allowed to connect without restarting the server.

**Testing**
Banned a player through the existing HTTP API and confirmed that their IP was written to banned.txt and that they could not reconnect. Removed the same IP from banned.txt and tried to reconnect; the player was now able to join the server without restarting the SRS server process. Existing behavior for banned IPs that are still present in banned.txt is unchanged.