### PR TITLE
Treat server-pushed global frequencies as display-only on receiver

### DIFF
--- a/Common/Network/Voice/GlobalFrequencyPolicy.cs
+++ b/Common/Network/Voice/GlobalFrequencyPolicy.cs
@@ -1,0 +1,21 @@
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Voice;
+
+// SyncedServerSettings.GlobalFrequencies is populated from the server-pushed
+// GLOBAL_LOBBY_FREQUENCIES setting and is delivered without signing, PKI, or
+// any per-client opt-out (see SyncedServerSettings.Decode and the
+// SYNC / UPDATE / RADIO_UPDATE / SERVER_SETTINGS handlers in
+// TCPClientHandler). A malicious or compromised server can therefore name an
+// arbitrary frequency as "global" at any moment. Treating that list as
+// authoritative on the receiver let the server (1) strip the per-packet
+// encryption byte before the strict-encryption gate evaluated it and (2)
+// bypass the LOS / in-range / blocked-radio realism gates per-frequency.
+//
+// The policy enforced here is: the client treats GlobalFrequencies as a
+// display-only hint. The per-packet encryption byte and the realism gates
+// must always be evaluated against the sender's intended values.
+public static class GlobalFrequencyPolicy
+{
+    public static bool ShouldStripReceiverEncryption() => false;
+
+    public static bool ShouldBypassRealismGates() => false;
+}

--- a/DCS-SR-Client/Audio/Managers/UDPClientAudioProcessor.cs
+++ b/DCS-SR-Client/Audio/Managers/UDPClientAudioProcessor.cs
@@ -14,6 +14,7 @@ using Ciribob.DCS.SimpleRadio.Standalone.Common.Models;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Models.Player;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Client;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Voice;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings.Input;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings.Setting;
@@ -541,11 +542,10 @@ public class UDPClientAudioProcessor : IDisposable
                                         RadioReceivingState state = null;
                                         bool decryptable;
 
-                                        //Check if Global
+                                        //Check if Global (display-only hint — see GlobalFrequencyPolicy)
                                         var globalFrequency = globalFrequencies.Contains(udpVoicePacket.Frequencies[i]);
 
-                                        if (globalFrequency)
-                                            //remove encryption for global
+                                        if (globalFrequency && GlobalFrequencyPolicy.ShouldStripReceiverEncryption())
                                             udpVoicePacket.Encryptions[i] = 0;
 
                                         var radio = _clientStateSingleton.DcsPlayerRadioInfo.CanHearTransmission(
@@ -567,7 +567,7 @@ public class UDPClientAudioProcessor : IDisposable
                                                     || radio.modulation ==
                                                     Modulation
                                                         .MIDS // IGNORE LOS and Distance for MIDS - we assume a Link16 Network is in place
-                                                    || globalFrequency
+                                                    || (globalFrequency && GlobalFrequencyPolicy.ShouldBypassRealismGates())
                                                     || (
                                                         HasLineOfSight(udpVoicePacket, out losLoss)
                                                         && InRange(udpVoicePacket.Guid, udpVoicePacket.Frequencies[i],

--- a/DCS-SR-CommonTests/Network/Voice/GlobalFrequencyPolicyTests.cs
+++ b/DCS-SR-CommonTests/Network/Voice/GlobalFrequencyPolicyTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Models;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Models.Player;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Voice;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings.Setting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Common.Tests.Network.Voice;
+
+// Regression tests for the server-pushed GLOBAL_LOBBY_FREQUENCIES trust
+// downgrade in UDPClientAudioProcessor.UdpAudioDecode. Before this fix the
+// receiver rewrote udpVoicePacket.Encryptions[i] to 0 and bypassed the
+// LOS / in-range / blocked-radio realism gates whenever a frequency appeared
+// in SyncedServerSettings.GlobalFrequencies, allowing a malicious or
+// compromised server to silently strip per-packet encryption and bypass
+// realism gates by naming arbitrary frequencies "global" at any time.
+[TestClass]
+public class GlobalFrequencyPolicyTests
+{
+    [TestMethod]
+    public void GlobalFrequenciesAreDisplayOnly_DoNotStripReceiverEncryption()
+    {
+        Assert.IsFalse(GlobalFrequencyPolicy.ShouldStripReceiverEncryption(),
+            "GLOBAL_LOBBY_FREQUENCIES is server-pushed and unauthenticated. " +
+            "The receiver must never rewrite the per-packet encryption byte.");
+    }
+
+    [TestMethod]
+    public void GlobalFrequenciesAreDisplayOnly_DoNotBypassRealismGates()
+    {
+        Assert.IsFalse(GlobalFrequencyPolicy.ShouldBypassRealismGates(),
+            "GLOBAL_LOBBY_FREQUENCIES is server-pushed and unauthenticated. " +
+            "The receiver must never bypass LOS / in-range / blocked-radio gates " +
+            "for a server-named frequency.");
+    }
+
+    [TestMethod]
+    public void ServerPushedGlobalFrequencyDoesNotMakeEncryptedTrafficDecryptableOnCleartextReceiver()
+    {
+        // Simulate the receiver-side decision UDPClientAudioProcessor.UdpAudioDecode
+        // performs after SyncedServerSettings.Decode has applied an attacker-pushed
+        // GLOBAL_LOBBY_FREQUENCIES delta. Even though 243 MHz now appears in
+        // SyncedServerSettings.GlobalFrequencies, the patched receiver must keep
+        // the sender's encryption byte intact and let CanHearTransmission refuse.
+
+        var serverSettings = new SyncedServerSettings();
+        serverSettings.Decode(new Dictionary<string, string>
+        {
+            { ServerSettingsKeys.GLOBAL_LOBBY_FREQUENCIES.ToString(), "243.0" },
+            { ServerSettingsKeys.STRICT_RADIO_ENCRYPTION.ToString(), "true" },
+        });
+        CollectionAssert.Contains(serverSettings.GlobalFrequencies, 243e6);
+
+        var senderEncryptionKey = (byte)0xAB;
+        const double frequency = 243e6;
+        var radioInfo = new PlayerRadioInfoBase { unitId = 1 };
+        radioInfo.radios[1] = new RadioBase
+        {
+            freq = frequency,
+            modulation = Modulation.AM,
+            enc = false,
+            encKey = 0,
+        };
+
+        var packetEncryption = senderEncryptionKey;
+        var globalFrequency = serverSettings.GlobalFrequencies.Contains(frequency);
+        if (globalFrequency && GlobalFrequencyPolicy.ShouldStripReceiverEncryption())
+            packetEncryption = 0;
+
+        var radio = radioInfo.CanHearTransmission(
+            frequency,
+            Modulation.AM,
+            packetEncryption,
+            strictEncryption: serverSettings.GetSettingAsBool(ServerSettingsKeys.STRICT_RADIO_ENCRYPTION),
+            sendingUnitId: 2,
+            blockedRadios: new List<int>(),
+            out _,
+            out var decryptable);
+
+        Assert.IsNotNull(radio, "Receiver should still see the matching radio.");
+        Assert.AreEqual(senderEncryptionKey, packetEncryption,
+            "Receiver must not rewrite the per-packet encryption byte for a server-named global frequency.");
+        Assert.IsFalse(decryptable,
+            "A cleartext receiver must NOT treat encrypted traffic as decryptable " +
+            "just because the server named the frequency global.");
+    }
+
+    [TestMethod]
+    public void ServerPushedGlobalFrequencyDoesNotBypassBlockedRadioRealismGate()
+    {
+        // Simulate the LOS / in-range / blocked-radio realism gate evaluated in
+        // UDPClientAudioProcessor.UdpAudioDecode. With hasLineOfSight=false,
+        // inRange=false, and the receiving radio explicitly in the local
+        // blockedRadios set, the gate must be false even when 243 MHz appears
+        // in the server-pushed GlobalFrequencies list.
+
+        var serverSettings = new SyncedServerSettings();
+        serverSettings.Decode(new Dictionary<string, string>
+        {
+            { ServerSettingsKeys.GLOBAL_LOBBY_FREQUENCIES.ToString(), "243.0" },
+        });
+
+        const double frequency = 243e6;
+        const bool hasLineOfSight = false;
+        const bool inRange = false;
+        var receivedOn = 1;
+        var blockedRadios = new List<int> { receivedOn };
+        var radioModulation = Modulation.AM;
+        var globalFrequency = serverSettings.GlobalFrequencies.Contains(frequency);
+
+        var realismGate =
+            radioModulation == Modulation.INTERCOM
+            || radioModulation == Modulation.MIDS
+            || (globalFrequency && GlobalFrequencyPolicy.ShouldBypassRealismGates())
+            || (hasLineOfSight && inRange && !blockedRadios.Contains(receivedOn));
+
+        Assert.IsFalse(realismGate,
+            "The realism gate must remain closed when LOS/range fail and the " +
+            "radio is locally blocked, regardless of GLOBAL_LOBBY_FREQUENCIES.");
+    }
+}

--- a/DCS-SRS-Mobile/Utility/UDPClientAudioProcessor.cs
+++ b/DCS-SRS-Mobile/Utility/UDPClientAudioProcessor.cs
@@ -11,6 +11,7 @@ using Ciribob.DCS.SimpleRadio.Standalone.Common.Models;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Models.Player;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Client;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Common.Network.Voice;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings.Input;
 using Ciribob.DCS.SimpleRadio.Standalone.Common.Settings.Setting;
@@ -520,11 +521,10 @@ public class UDPClientAudioProcessor : IDisposable, IHandle<PTTState>
                                     RadioReceivingState state = null;
                                     bool decryptable;
 
-                                    //Check if Global
+                                    //Check if Global (display-only hint — see GlobalFrequencyPolicy)
                                     var globalFrequency = globalFrequencies.Contains(udpVoicePacket.Frequencies[i]);
 
-                                    if (globalFrequency)
-                                        //remove encryption for global
+                                    if (globalFrequency && GlobalFrequencyPolicy.ShouldStripReceiverEncryption())
                                         udpVoicePacket.Encryptions[i] = 0;
 
                                     var radio = _clientStateSingleton.DcsPlayerRadioInfo.CanHearTransmission(
@@ -546,7 +546,7 @@ public class UDPClientAudioProcessor : IDisposable, IHandle<PTTState>
                                                 || radio.modulation ==
                                                 Modulation
                                                     .MIDS // IGNORE LOS and Distance for MIDS - we assume a Link16 Network is in place
-                                                || globalFrequency
+                                                || (globalFrequency && GlobalFrequencyPolicy.ShouldBypassRealismGates())
                                                 || (
                                                     HasLineOfSight(udpVoicePacket, out losLoss)
                                                     && InRange(udpVoicePacket.Guid, udpVoicePacket.Frequencies[i],


### PR DESCRIPTION
## Summary

`UDPClientAudioProcessor.UdpAudioDecode` (both `DCS-SR-Client` and `DCS-SRS-Mobile`) treated `SyncedServerSettings.GlobalFrequencies` as authoritative on the receiver. That list is populated from the unauthenticated server-pushed `GLOBAL_LOBBY_FREQUENCIES` setting (see `SyncedServerSettings.Decode` and the `SYNC` / `UPDATE` / `RADIO_UPDATE` / `SERVER_SETTINGS` handlers in `TCPClientHandler`), so a malicious or compromised server could, at any time, name an arbitrary frequency "global" and cause every receiver in the lobby to:

1. Rewrite `udpVoicePacket.Encryptions[i] = 0` before the strict-encryption gate evaluated it — making encrypted traffic from that frequency play in cleartext on receivers that had `STRICT_RADIO_ENCRYPTION` configured.
2. Skip the LOS / in-range / blocked-radio realism gates per-frequency.

This change introduces `Common/Network/Voice/GlobalFrequencyPolicy.cs` with both decisions hard-wired to `false` and routes both the desktop client and the mobile client receivers through it, so the global-frequency list remains a display-only hint and the per-packet encryption byte and realism gates are always evaluated against the sender's intended values.

## Patch surface

- `Common/Network/Voice/GlobalFrequencyPolicy.cs` — new policy module with rationale comment.
- `DCS-SR-Client/Audio/Managers/UDPClientAudioProcessor.cs` — gate encryption strip + realism bypass on the policy.
- `DCS-SRS-Mobile/Utility/UDPClientAudioProcessor.cs` — same change for mobile.
- `DCS-SR-CommonTests/Network/Voice/GlobalFrequencyPolicyTests.cs` — regression coverage.

## Variant analysis

Searched for `globalFrequenc` across the tree. The other producers/consumers are:

- `Common/Network/Server/UDPVoiceRouter.cs` — server-side forwarding; not a receiver trust-boundary problem.
- `DCS-SR-Client/Singletons/ClientStateSingleton.cs`, `DCS-SRS-Mobile/Singleton/ClientStateSingleton.cs` — list storage only; no trust decision.

The only two receiver-side decision sites are the two `UDPClientAudioProcessor.UdpAudioDecode` blocks patched here, and both go through `GlobalFrequencyPolicy`.

## Test plan

- [x] `dotnet test DCS-SR-CommonTests --filter "FullyQualifiedName~GlobalFrequencyPolicyTests" -p:EnableWindowsTargeting=true` — 4/4 pass.
- [ ] Manual end-to-end against a modified server that pushes `GLOBAL_LOBBY_FREQUENCIES=243.0` while a sender transmits encrypted on 243 MHz — verify the receiver does not decrypt and that LOS/range/blocked-radio gates still apply.